### PR TITLE
Prettify secrets.json file 

### DIFF
--- a/src/provisioning/Wippersnapper_FS.h
+++ b/src/provisioning/Wippersnapper_FS.h
@@ -23,12 +23,16 @@
 #include "Wippersnapper.h"
 
 #define FILE_TEMPLATE_AIRLIFT                                                  \
-  "{\"io_username\":\"YOUR_IO_USERNAME_HERE\",\"io_key\":\"YOUR_IO_KEY_"       \
-  "HERE\",\"network_type_wifi_airlift\":{\"network_ssid\":\"YOUR_WIFI_SSID_"   \
-  "HERE\",\"network_password\":\"YOUR_WIFI_PASS_HERE\"}}" ///< JSON string for
-                                                          ///< airlift-specific
-                                                          ///< configuration
-                                                          ///< file
+  "{\n\t\"io_username\":\"YOUR_IO_USERNAME_HERE\",\n\t\"io_key\":\"YOUR_IO_"   \
+  "KEY_"                                                                       \
+  "HERE\",\n\t\"network_type_wifi_airlift\":{\n\t\t\"network_ssid\":\"YOUR_"   \
+  "WIFI_SSID_"                                                                 \
+  "HERE\",\n\t\t\"network_password\":\"YOUR_WIFI_PASS_HERE\"\n\t}\n}" ///< JSON
+                                                                      ///< string
+                                                                      ///< for
+///< airlift-specific
+///< configuration
+///< file
 
 // forward decl.
 class Wippersnapper;


### PR DESCRIPTION
Previously, the `secrets.json` file which gets written to the WIPPER filesystem was one line:
```
{"io_username":"YOUR_IO_USERNAME_HERE","io_key":"YOUR_IO_KEY_HERE","network_type_wifi_airlift":{"network_ssid":"YOUR_WIFI_SSID_HERE","network_password":"YOUR_WIFI_PASS_HERE"}}
```

This pull request updates it to be more readable by the user. The `secrets.json` file written to WIPPER FS now looks like: 
```
{
   "io_username":"YOUR_IO_USERNAME_HERE",
   "io_key":"YOUR_IO_KEY_HERE",
   "network_type_wifi_airlift":{
      "network_ssid":"YOUR_WIFI_SSID_HERE",
      "network_password":"YOUR_WIFI_PASS_HERE"
   }
}
```