### PR TITLE
Fix fsm issue with Beta.4

### DIFF
--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -974,7 +974,9 @@ void Wippersnapper::enableWDT(int timeoutMS) {
 */
 /*******************************************************/
 void Wippersnapper::processPackets() {
-  runNetFSM();
+  // TODO: This causes issues when calling `virtual _connect()`
+  // from WS object, removed for now
+  // runNetFSM();
   feedWDT();
   // Process all incoming packets from Wippersnapper MQTT Broker
   WS._mqtt->processPackets(10);
@@ -996,7 +998,9 @@ void Wippersnapper::processPackets() {
 /*******************************************************/
 void Wippersnapper::publish(const char *topic, uint8_t *payload, uint16_t bLen,
                             uint8_t qos) {
-  runNetFSM();
+  // TODO: This causes issues when calling `virtual _connect()`
+  // from WS object, removed for now
+  // runNetFSM();
   feedWDT();
   WS._mqtt->publish(topic, payload, bLen, qos);
 }

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -64,7 +64,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.4" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.5" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic


### PR DESCRIPTION
Bumps to beta 5 and fixes a regression in beta 4 causing the following output
```
1:40:25.246 -> Registering Board...
11:40:25.246 -> registerBoard()
11:40:25.246 -> Encoding registration message...Encoded!
11:40:35.359 -> Publishing registration message...Published!
11:40:35.359 -> Publishing registration message...ERROR: Please define a network interface!
11:40:35.359 -> ERROR: Please define a network interface!
11:40:35.359 -> ERROR: Please define a network interface!
11:40:35.359 -> ERROR: Please define a network interface!
```