### PR TITLE
Fix "ERROR: Please define a network interface!" on WipperSnapper Registration

### DIFF
--- a/src/Wippersnapper_Registration.cpp
+++ b/src/Wippersnapper_Registration.cpp
@@ -138,7 +138,7 @@ void Wippersnapper_Registration::encodeRegMsg() {
 /************************************************************/
 void Wippersnapper_Registration::publishRegMsg() {
   // Run the network fsm
-  //WS.runNetFSM();
+  // WS.runNetFSM();
   // Publish
   WS.publish(WS._topic_description, _message_buffer, _message_len, 1);
   WS_DEBUG_PRINTLN("Published!")
@@ -156,7 +156,7 @@ void Wippersnapper_Registration::publishRegMsg() {
 bool Wippersnapper_Registration::pollRegMsg() {
   bool is_success = false;
   // Check network
-  //WS.runNetFSM();
+  // WS.runNetFSM();
 
   // poll for response from broker
   WS.feedWDT(); // let us drop out if we can't process


### PR DESCRIPTION
https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/pull/124 did not fully comment out the WipperSnapper object calling the FSM which caused the issue to occasionally re-emerge like in https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/126.

This pull request comments out the calls to `runNetFSM` from the WipperSnapper object, `WS` causing the virtual `_connect` function to not get executed.