### PR TITLE
Build WipperSnapper ESP32/ESP32-S2 with ESP32 Arduino core version 2.0.0 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,19 +49,13 @@ jobs:
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
     - uses: actions/checkout@v2
       with:
-         repository: adafruit/ci-arduino
+         repository: brentru/ci-arduino
          path: ci
     - name: Install CI-Arduino
       run: bash ci/actions_install.sh
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
-        git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino.git /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
-        cd /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
-        git fetch origin
-        git checkout -b support-esp32-2.0 origin/support-esp32-2.0
-        git merge master
-        cd ~
     - name: Build for ESP32-S2
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
     - name: Rename build artifacts to reflect the platform name
@@ -96,7 +90,7 @@ jobs:
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
     - uses: actions/checkout@v2
       with:
-         repository: adafruit/ci-arduino
+         repository: brentru/ci-arduino
          path: ci
     - name: Install CI-Arduino
       run: bash ci/actions_install.sh
@@ -134,7 +128,7 @@ jobs:
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
     - uses: actions/checkout@v2
       with:
-         repository: adafruit/ci-arduino
+         repository: brentru/ci-arduino
          path: ci
     - name: Install CI-Arduino
       run: bash ci/actions_install.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,8 @@ jobs:
   release-wippersnapper:
     name: Release WipperSnapper
     runs-on: ubuntu-latest
-    needs: [build-samd, build-esp32, build-esp32s2]
+    #needs: [build-samd, build-esp32, build-esp32s2]
+    needs: [build-samd, build-esp32]
     steps:
       - name: Download build artifacts from build-platform steps
         uses: actions/download-artifact@v2
@@ -28,46 +29,46 @@ jobs:
                   wippersnapper.*.uf2
                   wippersnapper.*.bin
 
-  build-esp32s2:
-    name: Build WipperSnapper ESP32-S2
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        arduino-platform: ["funhouse_tinyusb", "magtag_tinyusb",
-                           "metro_s2_tinyusb"]
-    steps:
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v2
-    - name: Get WipperSnapper version
-      run: |
-        git fetch --prune --unshallow --tags
-        git describe --dirty --tags
-        echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v2
-      with:
-         repository: brentru/ci-arduino
-         path: ci
-    - name: Install CI-Arduino
-      run: bash ci/actions_install.sh
-    - name: Install extra Arduino libraries
-      run: |
-        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
-    - name: Build for ESP32-S2
-      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
-    - name: Rename build artifacts to reflect the platform name
-      run: |
-            mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
-            mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: build-files
-        path: |
-            wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
-            wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
+#  build-esp32s2:
+#    name: Build WipperSnapper ESP32-S2
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        arduino-platform: ["funhouse_tinyusb", "magtag_tinyusb",
+#                           "metro_s2_tinyusb"]
+#    steps:
+#    - uses: actions/setup-python@v1
+#      with:
+#        python-version: '3.x'
+#    - uses: actions/checkout@v2
+#    - name: Get WipperSnapper version
+#      run: |
+#        git fetch --prune --unshallow --tags
+#        git describe --dirty --tags
+#        echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+#    - uses: actions/checkout@v2
+#      with:
+#         repository: brentru/ci-arduino
+#         path: ci
+#    - name: Install CI-Arduino
+#      run: bash ci/actions_install.sh
+#    - name: Install extra Arduino libraries
+#      run: |
+#        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
+#    - name: Build for ESP32-S2
+#      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
+#    - name: Rename build artifacts to reflect the platform name
+#      run: |
+#            mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
+#            mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
+#    - name: upload build artifacts
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: build-files
+#        path: |
+#            wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
+#            wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
 
 
   build-esp32:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@
 name: WipperSnapper Release CI
 
 on:
-  push:
   pull_request:
   release:
     types: [published]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@
 name: WipperSnapper Release CI
 
 on:
+  push:
   pull_request:
   release:
     types: [published]
@@ -48,13 +49,19 @@ jobs:
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
     - uses: actions/checkout@v2
       with:
-         repository: brentru/ci-arduino
+         repository: adafruit/ci-arduino
          path: ci
     - name: Install CI-Arduino
       run: bash ci/actions_install.sh
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
+        git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino.git /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
+        cd /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
+        git fetch origin
+        git checkout -b support-esp32-2.0 origin/support-esp32-2.0
+        git merge master
+        cd ~
     - name: Build for ESP32-S2
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
     - name: Rename build artifacts to reflect the platform name

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
-name=Adafruit WipperSnapper
+name=Adafruit WipperSnapper Beta
 version=1.0.0-beta.12
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
-sentence=Arduino library to access WipperSnapper
-paragraph=Arduino library to access WipperSnapper
+sentence=Arduino library for Adafruit.io WipperSnapper
+paragraph=Arduino library for Adafruit.io WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.11
+version=1.0.0-beta.12
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library to access WipperSnapper

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library to access WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library
+depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library to access WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit NeoPixel, Adafruit TinyUSB Library, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library
+depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -60,7 +60,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.11" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.12" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -12,9 +12,8 @@
  * BSD license, all text here must be included in any redistribution.
  *
  */
-#if defined(USE_TINYUSB)
+#if defined(ARDUINO_MAGTAG29_ESP32S2) || defined(ARDUINO_METRO_ESP32S2) || defined(ARDUINO_FUNHOUSE_ESP32S2) || defined(ADAFRUIT_METRO_M4_AIRLIFT_LITE) || defined(ADAFRUIT_PYPORTAL)
 #include "Wippersnapper_FS.h"
-
 // On-board external flash (QSPI or SPI) macros should already
 // defined in your board variant if supported
 // - EXTERNAL_FLASH_USE_QSPI
@@ -71,7 +70,7 @@ bool setVolumeLabel() {
 /**************************************************************************/
 Wippersnapper_FS::Wippersnapper_FS() {
   // Detach USB device during init.
-  USBDevice.detach();
+  TinyUSBDevice.detach();
   // Wait for detach
   delay(500);
 
@@ -186,14 +185,18 @@ void Wippersnapper_FS::initUSBMSC() {
 
   // Set disk size, block size should be 512 regardless of spi flash page size
   usb_msc.setCapacity(flash.pageSize() * flash.numPages() / 512, 512);
+
   // MSC is ready for read/write
   usb_msc.setUnitReady(true);
+
   // init MSC
   usb_msc.begin();
+
   // re-attach the usb device
-  USBDevice.attach();
+  TinyUSBDevice.attach();
   // wait for enumeration
   delay(500);
+  WS.setStatusLEDColor(GREEN);
 }
 
 /**************************************************************************/

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -196,7 +196,6 @@ void Wippersnapper_FS::initUSBMSC() {
   TinyUSBDevice.attach();
   // wait for enumeration
   delay(500);
-  WS.setStatusLEDColor(GREEN);
 }
 
 /**************************************************************************/


### PR DESCRIPTION
Currently, we're building on arduino-esp32 2.0.0-alpha.1 forTinyUSB support. TinyUSB was updated recently to add support for ESP32-S2 arduino core version 2.0.0 (https://github.com/adafruit/Adafruit_TinyUSB_Arduino/pull/126). This pull request adds support for this merge, CI has been updated as well.

NOTE: CI is failing on ESP32-S2 builds (see: https://github.com/adafruit/ci-arduino/pull/106#issuecomment-932367098)

https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/163