### PR TITLE
Better signaling for network connection

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper Beta
-version=1.0.0-beta.12
+version=1.0.0-beta.13
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino library for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -915,7 +915,7 @@ void Wippersnapper::runNetFSM() {
     case FSM_NET_ESTABLISH_NETWORK:
       // WS_DEBUG_PRINTLN("FSM_NET_ESTABLISH_NETWORK");
       // Attempt to connect to wireless network
-      maxAttempts = 2;
+      maxAttempts = 5;
       while (maxAttempts >= 0) {
         setStatusLEDColor(LED_NET_CONNECT);
         WS.feedWDT();
@@ -925,10 +925,9 @@ void Wippersnapper::runNetFSM() {
         if (networkStatus() == WS_NET_CONNECTED)
           break;
         setStatusLEDColor(BLACK);
-        delay(500);
         maxAttempts--;
       }
-      // Validate connection OK
+      // Validate connection
       if (networkStatus() == WS_NET_CONNECTED) {
         fsmNetwork = FSM_NET_CHECK_NETWORK;
         break;
@@ -949,7 +948,7 @@ void Wippersnapper::runNetFSM() {
           break;
         }
         setStatusLEDColor(BLACK);
-        delay(500;)
+        delay(500);
       }
       if (fsmNetwork == FSM_NET_CHECK_MQTT) {
         break;

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -868,7 +868,7 @@ void Wippersnapper::errorWriteHang(String error) {
   // Print error
   WS_DEBUG_PRINTLN(error);
 #ifdef USE_TINYUSB
-  _fileSystem->writeErrorToBootOut("errorName");
+  _fileSystem->writeErrorToBootOut(error.c_str());
 #endif
   // Signal and hang forever
   while (1) {

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -939,7 +939,7 @@ void Wippersnapper::runNetFSM() {
       // WS_DEBUG_PRINTLN("FSM_NET_ESTABLISH_MQTT");
       WS._mqtt->setKeepAliveInterval(WS_KEEPALIVE_INTERVAL);
       // Attempt to connect
-      maxAttempts = 2;
+      maxAttempts = 10;
       while (maxAttempts >= 0) {
         setStatusLEDColor(LED_IO_CONNECT);
         mqttRC = WS._mqtt->connect(WS._username, WS._key);
@@ -948,7 +948,8 @@ void Wippersnapper::runNetFSM() {
           break;
         }
         setStatusLEDColor(BLACK);
-        delay(500);
+        delay(1000);
+        maxAttempts--;
       }
       if (fsmNetwork == FSM_NET_CHECK_MQTT) {
         break;

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -225,6 +225,7 @@ public:
 
   // Errors
   void haltError(String error);
+  void errorWriteHang(String error);
 
   // MQTT topic callbacks //
   // Decodes a signal message

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -60,7 +60,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.12" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.13" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -181,14 +181,14 @@ protected:
       delay(100);
       WiFi.begin(_ssid, _pass);
       _status = WS_NET_DISCONNECTED;
-      delay(1000);
+      delay(100);
     }
 
-/*     // wait for a connection to be established
+    // wait for a connection to be established
     long startRetry = millis();
     while (WiFi.status() != WL_CONNECTED && millis() - startRetry < 10000) {
       // do nothing, busy loop during the timeout
-    } */
+    }
 }
 
   /**************************************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -181,15 +181,15 @@ protected:
       delay(100);
       WiFi.begin(_ssid, _pass);
       _status = WS_NET_DISCONNECTED;
-      delay(100);
+      delay(1000);
     }
 
-    // wait for a connection to be established
+/*     // wait for a connection to be established
     long startRetry = millis();
     while (WiFi.status() != WL_CONNECTED && millis() - startRetry < 10000) {
       // do nothing, busy loop during the timeout
-    }
-  }
+    } */
+}
 
   /**************************************************************************/
   /*!


### PR DESCRIPTION
WipperSnapper currently hangs and resets after an unsuccessful WiFi network or MQTT connection. It's difficult for the user to understand what's occurring if they aren't paying close attention to the LEDs.

This pull request:
* Adds a maximum amount of connection attempts to the network connection and mqtt connection states
  * If the maximum attempts are exceeded, the hardware will blink red indefinitely and write the error to both the serial output and the whippersnapper boot output text file.

Addresses https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/165