### PR TITLE
Fix ESP32 Connection Issue on Beta 19

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper Beta
-version=1.0.0-beta.19
+version=1.0.0-beta.20
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -83,8 +83,8 @@ void Wippersnapper::provision() {
   _nvs = new Wippersnapper_ESP32_nvs();
   _nvs->parseSecrets();
 #endif
-  // Set credentials
-  set_user_key();
+
+  // Set WiFi credentials within network interface
   set_ssid_pass();
 }
 
@@ -1194,8 +1194,6 @@ void Wippersnapper::errorWriteHang(String error) {
 /**************************************************************************/
 void Wippersnapper::runNetFSM() {
   WS.feedWDT();
-  // MQTT connack RC
-  int mqttRC;
   // Initial state
   fsm_net_t fsmNetwork;
   fsmNetwork = FSM_NET_CHECK_MQTT;
@@ -1250,7 +1248,7 @@ void Wippersnapper::runNetFSM() {
       maxAttempts = 10;
       while (maxAttempts >= 0) {
         setStatusLEDColor(LED_IO_CONNECT);
-        mqttRC = WS._mqtt->connect();
+        int8_t mqttRC = WS._mqtt->connect(WS._username, WS._key);
         if (mqttRC == WS_MQTT_CONNECTED) {
           fsmNetwork = FSM_NET_CHECK_MQTT;
           break;

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -1248,7 +1248,7 @@ void Wippersnapper::runNetFSM() {
       maxAttempts = 10;
       while (maxAttempts >= 0) {
         setStatusLEDColor(LED_IO_CONNECT);
-        int8_t mqttRC = WS._mqtt->connect(WS._username, WS._key);
+        int8_t mqttRC = WS._mqtt->connect();
         if (mqttRC == WS_MQTT_CONNECTED) {
           fsmNetwork = FSM_NET_CHECK_MQTT;
           break;

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -77,14 +77,10 @@ void Wippersnapper::provision() {
   // init. LED for status signaling
   statusLEDInit();
 #ifdef USE_TINYUSB
-  // init new filesystem
   _fileSystem = new Wippersnapper_FS();
-  // parse out secrets.json file
   _fileSystem->parseSecrets();
 #elif defined(USE_NVS)
-  // init esp32 nvs partition namespace
   _nvs = new Wippersnapper_ESP32_nvs();
-  // parse out secrets
   _nvs->parseSecrets();
 #endif
   // Set credentials
@@ -106,19 +102,6 @@ void Wippersnapper::set_user_key(const char *aio_username,
                                  const char *aio_key) {
   WS._username = aio_username;
   WS._key = aio_key;
-}
-
-/****************************************************************************/
-/*!
-    @brief    Configures the device's Adafruit IO credentials from the
-                secrets.json file.
-*/
-/****************************************************************************/
-void Wippersnapper::set_user_key() {
-#ifdef USE_TINYUSB
-  WS._username = _fileSystem->io_username;
-  WS._key = _fileSystem->io_key;
-#endif
 }
 
 /**************************************************************************/

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -84,15 +84,8 @@ void Wippersnapper::provision() {
 #elif defined(USE_NVS)
   // init esp32 nvs partition namespace
   _nvs = new Wippersnapper_ESP32_nvs();
-  // validate esp32 has been programmed with credentials
-  if (!_nvs->validateNVSConfig()) {
-    WS_DEBUG_PRINTLN(
-        "ERROR: NVS partition or credentials not found - was NVS flashed?");
-    while (1)
-      yield();
-  }
-  // pull values out of NVS configuration
-  _nvs->setNVSConfig();
+  // parse out secrets
+  _nvs->parseSecrets();
 #endif
   // Set credentials
   set_user_key();

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -187,7 +187,6 @@ public:
   bool lockStatusLED = false; ///< True if status LED is using the built-in LED
 
   void set_user_key(const char *aio_username, const char *aio_key);
-  void set_user_key();
   virtual void set_ssid_pass(const char *ssid, const char *ssidPassword);
   virtual void set_ssid_pass();
 

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -63,7 +63,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.19" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.20" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -100,6 +100,14 @@ public:
   */
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
+    WS_DEBUG_PRINT("BROKER URL: ");
+    WS_DEBUG_PRINT(WS._mqttBrokerURL);
+
+    WS_DEBUG_PRINT("USERNAME: ");
+    WS_DEBUG_PRINT(WS._username);
+    WS_DEBUG_PRINT("KEY: ");
+    WS_DEBUG_PRINT(WS._key);
+
     if (WS._mqttBrokerURL == nullptr) {
       WS._mqttBrokerURL = "io.adafruit.com";
       _mqtt_client->setCACert(_aio_root_ca_prod);

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -100,15 +100,8 @@ public:
   */
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
-    WS_DEBUG_PRINT("BROKER URL: ");
-    WS_DEBUG_PRINT(WS._mqttBrokerURL);
-
-    WS_DEBUG_PRINT("USERNAME: ");
-    WS_DEBUG_PRINT(WS._username);
-    WS_DEBUG_PRINT("KEY: ");
-    WS_DEBUG_PRINT(WS._key);
-
     if (WS._mqttBrokerURL == nullptr) {
+      WS_DEBUG_PRINTLN("IO ADAFRUIT TEST L114");
       WS._mqttBrokerURL = "io.adafruit.com";
       _mqtt_client->setCACert(_aio_root_ca_prod);
     } else {

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -101,7 +101,6 @@ public:
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
     if (WS._mqttBrokerURL == nullptr) {
-      WS_DEBUG_PRINTLN("IO ADAFRUIT TEST L114");
       WS._mqttBrokerURL = "io.adafruit.com";
       _mqtt_client->setCACert(_aio_root_ca_prod);
     } else {

--- a/src/provisioning/Wippersnapper_ESP32_nvs.cpp
+++ b/src/provisioning/Wippersnapper_ESP32_nvs.cpp
@@ -44,19 +44,25 @@ Wippersnapper_ESP32_nvs::~Wippersnapper_ESP32_nvs() { nvs.end(); }
 */
 /****************************************************************************/
 void Wippersnapper_ESP32_nvs::parseSecrets() {
-  // parsey
+  // Parse from
+  // https://github.com/adafruit/Adafruit_WebSerial_NVMGenerator/blob/main/wsPartitions.csv
   _ssid = nvs.getString("wsNetSSID", "");
   _ssidPass = nvs.getString("wsNetPass", "");
   _aioUser = nvs.getString("wsAIOUser", "");
   _aioPass = nvs.getString("wsAIOKey", "");
-  _aioURL = nvs.getString("wsAIOURL", "");
 
-  // Validate configuration was set within the partition
-  if (_ssid == "" || _ssidPass == "" || _aioUser == "" || _aioPass == "") {
+  // Validate getString() calls
+  if (_ssid.length() == 0 || _ssidPass.length() == 0 ||
+      _aioUser.length() == 0 || _aioPass.length() == 0) {
     WS.setStatusLEDColor(RED);
     while (1)
       ;
   }
+
+  // optional NVS staging url
+  _aioURL = nvs.getString("wsAIOURL", "");
+  if (_aioURL.length() == 0)
+    _aioURL = "io.adafruit.com";
 
   // Set global configuration strings
   WS._network_ssid = _ssid.c_str();

--- a/src/provisioning/Wippersnapper_ESP32_nvs.cpp
+++ b/src/provisioning/Wippersnapper_ESP32_nvs.cpp
@@ -22,8 +22,12 @@
 */
 /****************************************************************************/
 Wippersnapper_ESP32_nvs::Wippersnapper_ESP32_nvs() {
-  // init. nvs, read-only
-  nvs.begin("wsNamespace", false);
+  // Attempt to initialize NVS partition
+  if (!nvs.begin("wsNamespace", false)) {
+    WS.setStatusLEDColor(RED);
+    while (1)
+      ;
+  }
 }
 
 /****************************************************************************/
@@ -35,39 +39,31 @@ Wippersnapper_ESP32_nvs::~Wippersnapper_ESP32_nvs() { nvs.end(); }
 
 /****************************************************************************/
 /*!
-    @brief    Reads and validates credentials from nvs' "wsNamespace"
+    @brief    Reads, validates, and sets credentials from nvs' "wsNamespace"
                 namespace.
-    @returns  True if credentials were found, False otherwise.
 */
 /****************************************************************************/
-bool Wippersnapper_ESP32_nvs::validateNVSConfig() {
+void Wippersnapper_ESP32_nvs::parseSecrets() {
+  // parsey
   _ssid = nvs.getString("wsNetSSID", "");
   _ssidPass = nvs.getString("wsNetPass", "");
   _aioUser = nvs.getString("wsAIOUser", "");
   _aioPass = nvs.getString("wsAIOKey", "");
   _aioURL = nvs.getString("wsAIOURL", "");
 
-  // validate config properly set in partition
+  // Validate configuration was set within the partition
   if (_ssid == "" || _ssidPass == "" || _aioUser == "" || _aioPass == "") {
-    // TODO: Possibly LED blink/some external error handling around this
-    return false;
+    WS.setStatusLEDColor(RED);
+    while (1)
+      ;
   }
-  return true;
-}
 
-/****************************************************************************/
-/*!
-    @brief    Sets Wippersnapper configuration using nvs configuration
-    @returns  True if credentials set successfully, False otherwise.
-*/
-/****************************************************************************/
-bool Wippersnapper_ESP32_nvs::setNVSConfig() {
+  // Set global configuration strings
   WS._network_ssid = _ssid.c_str();
   WS._network_pass = _ssidPass.c_str();
   WS._username = _aioUser.c_str();
   WS._key = _aioPass.c_str();
   WS._mqttBrokerURL = _aioURL.c_str();
-  return true;
 }
 
 #endif // ARDUINO_ARCH_ESP32

--- a/src/provisioning/Wippersnapper_ESP32_nvs.cpp
+++ b/src/provisioning/Wippersnapper_ESP32_nvs.cpp
@@ -59,17 +59,12 @@ void Wippersnapper_ESP32_nvs::parseSecrets() {
       ;
   }
 
-  // optional NVS staging url
-  _aioURL = nvs.getString("wsAIOURL", "");
-  if (_aioURL.length() == 0)
-    _aioURL = "io.adafruit.com";
-
   // Set global configuration strings
   WS._network_ssid = _ssid.c_str();
   WS._network_pass = _ssidPass.c_str();
   WS._username = _aioUser.c_str();
   WS._key = _aioPass.c_str();
-  WS._mqttBrokerURL = _aioURL.c_str();
+  WS._mqttBrokerURL = nullptr;
 }
 
 #endif // ARDUINO_ARCH_ESP32

--- a/src/provisioning/Wippersnapper_ESP32_nvs.h
+++ b/src/provisioning/Wippersnapper_ESP32_nvs.h
@@ -29,9 +29,7 @@ class Wippersnapper_ESP32_nvs {
 public:
   Wippersnapper_ESP32_nvs();
   ~Wippersnapper_ESP32_nvs();
-
-  bool validateNVSConfig();
-  bool setNVSConfig();
+  void parseSecrets();
 
   Preferences nvs; ///< Provides access to ESP32's Non-Volatile Storage
 

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -340,6 +340,7 @@ void Wippersnapper_FS::parseSecrets() {
         "effect");
     fsHalt();
   }
+  WS._username = _fileSystem->io_username;
 
   // Get io key
   io_key = doc["io_key"];
@@ -349,6 +350,7 @@ void Wippersnapper_FS::parseSecrets() {
     writeErrorToBootOut("ERROR: invalid io_key value in secrets.json!");
     fsHalt();
   }
+  WS._key = _fileSystem->io_key;
 
   // next, we detect the network interface from the `secrets.json`
   WS_DEBUG_PRINTLN("Attempting to find network interface...");

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -340,7 +340,7 @@ void Wippersnapper_FS::parseSecrets() {
         "effect");
     fsHalt();
   }
-  WS._username = _fileSystem->io_username;
+  WS._username = io_username;
 
   // Get io key
   io_key = doc["io_key"];
@@ -350,7 +350,7 @@ void Wippersnapper_FS::parseSecrets() {
     writeErrorToBootOut("ERROR: invalid io_key value in secrets.json!");
     fsHalt();
   }
-  WS._key = _fileSystem->io_key;
+  WS._key = io_key;
 
   // next, we detect the network interface from the `secrets.json`
   WS_DEBUG_PRINTLN("Attempting to find network interface...");


### PR DESCRIPTION
* Addresses https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/198
* Error handling for potential NVS initialization failure
* Error handling for empty NVS partition
* Reduces the amount of NVS function calls from application code 
* `set_user_key()` is now performed within the filesystem code, instead of application code
* `mqttRC` return type changed to match Adafruit MQTT Library's connect() return type.