### PR TITLE
Improve network reliability in beta.18->beta.20

### DIFF
--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -1201,9 +1201,7 @@ void Wippersnapper::runNetFSM() {
   while (fsmNetwork != FSM_NET_CONNECTED) {
     switch (fsmNetwork) {
     case FSM_NET_CHECK_MQTT:
-      WS_DEBUG_PRINTLN("FSM_NET_CHECK_MQTT");
-
-      // have we connected prior?
+      // WS_DEBUG_PRINTLN("FSM_NET_CHECK_MQTT");
       if (WS._mqtt->connected()) {
         fsmNetwork = FSM_NET_CONNECTED;
         return;
@@ -1211,47 +1209,42 @@ void Wippersnapper::runNetFSM() {
       fsmNetwork = FSM_NET_CHECK_NETWORK;
       break;
     case FSM_NET_CHECK_NETWORK:
-      WS_DEBUG_PRINTLN("FSM_NET_CHECK_NETWORK");
+      // WS_DEBUG_PRINTLN("FSM_NET_CHECK_NETWORK");
       if (networkStatus() == WS_NET_CONNECTED) {
-        WS_DEBUG_PRINTLN("Connected to WiFi");
+        // WS_DEBUG_PRINTLN("Connected to WiFi");
         fsmNetwork = FSM_NET_ESTABLISH_MQTT;
         break;
       }
       fsmNetwork = FSM_NET_ESTABLISH_NETWORK;
       break;
     case FSM_NET_ESTABLISH_NETWORK:
-      WS_DEBUG_PRINTLN("FSM_NET_ESTABLISH_NETWORK");
+      // WS_DEBUG_PRINTLN("FSM_NET_ESTABLISH_NETWORK");
       // Attempt to connect to wireless network
       maxAttempts = 5;
-      while (maxAttempts >= 0) {
+      while (maxAttempts > 0) {
         setStatusLEDColor(LED_NET_CONNECT);
         WS.feedWDT();
         // attempt to connect
         WS_DEBUG_PRINTLN("Attempting to connect to WiFi...");
         _connect();
+        delay(5000);
         // did we connect?
         if (networkStatus() == WS_NET_CONNECTED)
           break;
         setStatusLEDColor(BLACK);
-        delay(5000); // delay 5s before re-connecting
         maxAttempts--;
       }
       // Validate connection
-      WS_DEBUG_PRINT("Done trying to establish, are we connected? ");
-      WS_DEBUG_PRINTLN(networkStatus());
-      if (networkStatus() == WS_NET_CONNECTED) {
-        fsmNetwork = FSM_NET_CHECK_NETWORK;
-        break;
-      } else { // unrecoverable error, hang forever
-        errorWriteHang("ERROR: Unable to connect to Wireless Network");
-      }
+      if (networkStatus() != WS_NET_CONNECTED)
+        haltError("ERROR: Unable to connect to WiFi, rebooting soon...");
+      fsmNetwork = FSM_NET_CHECK_NETWORK;
       break;
     case FSM_NET_ESTABLISH_MQTT:
       WS_DEBUG_PRINTLN("FSM_NET_ESTABLISH_MQTT");
       WS._mqtt->setKeepAliveInterval(WS_KEEPALIVE_INTERVAL);
       // Attempt to connect
-      maxAttempts = 10;
-      while (maxAttempts >= 0) {
+      maxAttempts = 5;
+      while (maxAttempts > 0) {
         setStatusLEDColor(LED_IO_CONNECT);
         int8_t mqttRC = WS._mqtt->connect();
         if (mqttRC == WS_MQTT_CONNECTED) {
@@ -1259,18 +1252,16 @@ void Wippersnapper::runNetFSM() {
           break;
         }
         setStatusLEDColor(BLACK);
-        WS_DEBUG_PRINTLN("Unable to connect to Adafruit IO MQTT, retrying in 5 seconds...");
+        WS_DEBUG_PRINTLN(
+            "Unable to connect to Adafruit IO MQTT, retrying in 5 seconds...");
         delay(5000);
         maxAttempts--;
       }
-      if (fsmNetwork == FSM_NET_CHECK_MQTT) {
-        break;
-      } else { // unrecoverable error, hang forever
-        errorWriteHang("ERROR: Unable to connect to Adafruit.IO MQTT, resetting...");
-      }
+      if (fsmNetwork != FSM_NET_CHECK_MQTT)
+        haltError(
+            "ERROR: Unable to connect to Adafruit.IO MQTT, rebooting soon...");
       break;
     default:
-      // don't feed wdt
       break;
     }
   }

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -63,7 +63,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.20" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.21" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -119,9 +119,6 @@ public:
   */
   /********************************************************/
   ws_status_t networkStatus() {
-    delay(100);
-    WS_DEBUG_PRINT("networkStatus: ");
-    WS_DEBUG_PRINTLN(WiFi.status());
     switch (WiFi.status()) {
     case WL_CONNECTED:
       return WS_NET_CONNECTED;

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -119,6 +119,9 @@ public:
   */
   /********************************************************/
   ws_status_t networkStatus() {
+    delay(100);
+    WS_DEBUG_PRINT("networkStatus: ");
+    WS_DEBUG_PRINTLN(WiFi.status());
     switch (WiFi.status()) {
     case WL_CONNECTED:
       return WS_NET_CONNECTED;
@@ -216,14 +219,8 @@ protected:
       _disconnect();
       delay(100);
       WiFi.begin(_ssid, _pass);
-      _status = WS_NET_DISCONNECTED;
       delay(100);
-    }
-
-    // wait for a connection to be established
-    long startRetry = millis();
-    while (WiFi.status() != WL_CONNECTED && millis() - startRetry < 10000) {
-      // do nothing, busy loop during the timeout
+      _status = WS_NET_DISCONNECTED;
     }
   }
 


### PR DESCRIPTION
Improvements to network FSM (`runNetFSM`):
* Unrecoverable errors with WiFi and MQTT network connectivity failures cause the device to reset completely, instead of hanging forever.
* Implement a WiFi reconnect delay from the application code to avoid rapid-connection attempts.
* Queries the adapter's status from the application, instead of relying on a control flow within the interface itself.

Addresses https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/199

***

**Test**: A wippersnapper device is connected and running. The wireless network goes offline
during runtime and comes back later to simulate an intermittent connectivity problem.
**Hardware Tested**: Adafruit QT Py ESP32-S2

**Beta.20 Behavior**
```
MQTT ping packet:
[0xC0], [0x00],
Client sendPacket returned: 2
Read data: [0xD0],
Packet Type: [0xD0],
Read data: [0x00],
Packet Length: 0
*** Rapid attempt to reconnect, too many attempts in succession ***
Connecting to: io.adafruit.com
Connect result: 0
Connecting to: io.adafruit.com
Connect result: 0
Connecting to: io.adafruit.com
Connect result: 0
Connecting to: io.adafruit.com
Connect result: 0
Connecting to: io.adafruit.com
Connect result: 0
Connecting to: io.adafruit.com
Connect result: 0
Connecting to: io.adafruit.com
Connect result: 0
Connecting to: io.adafruit.com
Connect result: 0
Connecting to: io.adafruit.com
Connect result: 0
Connecting to: io.adafruit.com
Connect result: 0
Connecting to: io.adafruit.com
Connect result: 0
ERROR: Unable to connect to Adafruit.IO
*** Device never reboots, stalls and blinks ***
```

**Beta.21 Behavior**
```
Read data: [0x00], [0x0B],
Publish QOS1+ reply: @ [0x40], [0x02], [0x00], [0x0B],
PUBLISHED!
*** DISCONNECTED NETWORK ***
Packet Length: 0
networkStatus: 6
Attempting to connect to WiFi...
networkStatus: 1
Attempting to connect to WiFi...
networkStatus: 1
Attempting to connect to WiFi...
networkStatus: 1
Attempting to connect to WiFi...
networkStatus: 1
Attempting to connect to WiFi...
networkStatus: 1
Attempting to connect to WiFi...
networkStatus: 1
networkStatus: 1
ERROR [WDT RESET]: ERROR: Unable to connect to WiFi, rebooting soon...
*** RECONNECTED NETWORK ***
*** DEVICE REBOOTED ***
Attempting to connect to WiFi...
networkStatus: 3
networkStatus: 3
networkStatus: 3
FSM_NET_ESTABLISH_MQTT
Connecting to: io.adafruit.com
Connect result: 1
MQTT connect packet:
....
```

***

**Test**: A WipperSnapper device can not connect to an offline wireless network.
**Hardware Tested**: Adafruit QT Py ESP32-S2

**beta.20**
```
15:47:59.340 -> ERROR: Unable to connect to Wireless Network
*** HANGS ***
```

**beta.21**
```
ERROR: Unable to connect to Wireless Network
Attempting to connect to WiFi...
Attempting to connect to WiFi...
Attempting to connect to WiFi...
Attempting to connect to WiFi...
Attempting to connect to WiFi...
ERROR [WDT RESET]: ERROR: Unable to connect to WiFi, rebooting soon...
*** REBOOT ***
```

