### PR TITLE
Update CI for ESP32, ESP8266

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,11 @@ jobs:
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
     - name: Rename build artifacts to reflect the platform name
       run: |
-            mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
-            mv examples/*/build/*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.elf
-            mv examples/*/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.map
-            mv examples/*/build/*/Wippersnapper_demo.ino.bootloader.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin
-            mv examples/*/build/*/Wippersnapper_demo.ino.partitions.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin
+            mv examples/Wippersnapper_demo/build/esp32.esp32.*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
+            mv examples/Wippersnapper_demo/build/esp32.esp32.*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.elf
+            mv examples/Wippersnapper_demo/build/esp32.esp32.*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.map
+            mv examples/Wippersnapper_demo/build/esp32.esp32.*/Wippersnapper_demo.ino.bootloader.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin
+            mv examples/Wippersnapper_demo/build/esp32.esp32.*/Wippersnapper_demo.ino.partitions.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin
     - name: Zip build artifacts
       run : |
             zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,13 +107,20 @@ jobs:
     - name: Rename build artifacts to reflect the platform name
       run: |
             mv examples/Wippersnapper_demo/build/esp32.esp32.*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
-    - name: upload build artifacts
+            mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
+            mv examples/*/build/*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.elf
+            mv examples/*/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.map
+            mv examples/*/build/*/Wippersnapper_demo.ino.bootloader.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin
+            mv examples/*/build/*/Wippersnapper_demo.ino.partitions.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin
+    - name: Zip build artifacts
+      run : |
+            zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*
+    - name: upload build artifacts zip
       uses: actions/upload-artifact@v2
       with:
         name: build-files
         path: |
-            wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
-
+            wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip
 
   build-samd:
     name: Build WipperSnapper SAMD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,13 @@ jobs:
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
     - name: Rename build artifacts to reflect the platform name
       run: |
-            mv examples/Wippersnapper_demo/build/esp32.esp32.*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
+            mv examples/Wippersnapper_demo/build/esp32.esp32.*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
     - name: upload build artifacts
       uses: actions/upload-artifact@v2
       with:
         name: build-files
         path: |
-            wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
+            wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
 
 
   build-samd:
@@ -188,7 +188,6 @@ jobs:
     - name: build platforms
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
 
-  # NOTE: This does NOT release artifacts, it only builds
   build-esp8266:
     name: Build WipperSnapper ESP8266
     runs-on: ubuntu-latest
@@ -223,13 +222,13 @@ jobs:
             ls examples/*
     - name: Rename build artifacts to reflect the platform name
       run: |
-            mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
+            mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
     - name: upload build artifacts
       uses: actions/upload-artifact@v2
       with:
         name: build-files
         path: |
-            wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
+            wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
 
 
   clang_and_doxy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,6 @@ jobs:
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
     - name: Rename build artifacts to reflect the platform name
       run: |
-            mv examples/Wippersnapper_demo/build/esp32.esp32.*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
             mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
             mv examples/*/build/*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.elf
             mv examples/*/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.map

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           files: |
                   wippersnapper.*.uf2
                   wippersnapper.*.bin
+                  wippersnapper.*.zip
 
   build-esp32s2:
     name: Build WipperSnapper ESP32-S2
@@ -223,12 +224,17 @@ jobs:
     - name: Rename build artifacts to reflect the platform name
       run: |
             mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
-    - name: upload build artifacts
+            mv examples/*/build/*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.elf
+            mv examples/*/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.map
+    - name: Zip build artifacts
+      run : |
+            zip -r examples/*/build/*/wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip examples/*/build/*/Wippersnapper_demo/*
+    - name: upload build artifacts zip
       uses: actions/upload-artifact@v2
       with:
         name: build-files
         path: |
-            wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
+            examples/*/build/*/wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip
 
 
   clang_and_doxy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,13 +228,13 @@ jobs:
             mv examples/*/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.map
     - name: Zip build artifacts
       run : |
-            zip -r examples/*/build/*/wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip examples/*/build/*/Wippersnapper_demo/*
+            zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*
     - name: upload build artifacts zip
       uses: actions/upload-artifact@v2
       with:
         name: build-files
         path: |
-            examples/*/build/*/wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip
+            wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip
 
 
   clang_and_doxy:


### PR DESCRIPTION
* Appends `littlefs` string to ESP32, ESP8266 build artifacts
* Renames and zips all build artifacts (incl. map file, bootloader, partitions, etc.) for ESP32, ESP8266 platforms
* Uploads ZIP files for ESP32, ESP8266 platforms instead of .bin application file.

Example of build artifacts from run can be found on https://github.com/brentru/Adafruit_Wippersnapper_Arduino/actions/runs/1900909781 (and this PR's triggered action as well)


@lorennorman  FYI ^