### PR TITLE
Refactor I2C_Driver Initialization

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -202,18 +202,17 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
   uint16_t i2cAddress = (uint16_t)msgDeviceInitReq->i2c_device_address;
   if (strcmp("aht20", msgDeviceInitReq->i2c_device_name) == 0) {
     _ahtx0 = new WipperSnapper_I2C_Driver_AHTX0(this->_i2c, i2cAddress);
-    if (!_ahtx0->isInitialized()) {
+    if (!_ahtx0->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize AHTX0 chip!");
       _busStatusResponse =
           wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
       return false;
     }
-    WS_DEBUG_PRINTLN("AHTX0 Initialized Successfully!");
     _ahtx0->configureDriver(msgDeviceInitReq);
     drivers.push_back(_ahtx0);
   } else if (strcmp("bme280", msgDeviceInitReq->i2c_device_name) == 0) {
     _bme280 = new WipperSnapper_I2C_Driver_BME280(this->_i2c, i2cAddress);
-    if (!_bme280->isInitialized()) {
+    if (!_bme280->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize BME280!");
       _busStatusResponse =
           wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
@@ -224,7 +223,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     WS_DEBUG_PRINTLN("BME280 Initialized Successfully!");
   } else if (strcmp("dps310", msgDeviceInitReq->i2c_device_name) == 0) {
     _dps310 = new WipperSnapper_I2C_Driver_DPS310(this->_i2c, i2cAddress);
-    if (!_dps310->isInitialized()) {
+    if (!_dps310->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize DPS310!");
       _busStatusResponse =
           wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
@@ -235,7 +234,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     WS_DEBUG_PRINTLN("DPS310 Initialized Successfully!");
   } else if (strcmp("scd30", msgDeviceInitReq->i2c_device_name) == 0) {
     _scd30 = new WipperSnapper_I2C_Driver_SCD30(this->_i2c, i2cAddress);
-    if (!_scd30->isInitialized()) {
+    if (!_scd30->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize SCD30!");
       _busStatusResponse =
           wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
@@ -246,7 +245,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     WS_DEBUG_PRINTLN("SCD30 Initialized Successfully!");
   } else if (strcmp("mcp9808", msgDeviceInitReq->i2c_device_name) == 0) {
     _mcp9808 = new WipperSnapper_I2C_Driver_MCP9808(this->_i2c, i2cAddress);
-    if (!_mcp9808->isInitialized()) {
+    if (!_mcp9808->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize MCP9808!");
       _busStatusResponse =
           wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -17,6 +17,7 @@
 #define WipperSnapper_I2C_Driver_H
 
 #include <Adafruit_Sensor.h>
+#include <Arduino.h>
 
 /**************************************************************************/
 /*!
@@ -28,13 +29,16 @@ class WipperSnapper_I2C_Driver {
 public:
   /*******************************************************************************/
   /*!
-      @brief    Constructor for an I2C sensor.
+      @brief    Instanciates an I2C sensor.
+      @param    i2c
+                The I2C hardware interface, default is Wire.
       @param    sensorAddress
-                7-bit device address.
+                The I2C sensor's unique address.
   */
   /*******************************************************************************/
-  WipperSnapper_I2C_Driver(TwoWire *, uint16_t sensorAddress) {
-    _sensorAddress = sensorAddress;
+  WipperSnapper_I2C_Driver(TwoWire *i2c, uint16_t sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress;
   }
 
   /*******************************************************************************/
@@ -43,6 +47,14 @@ public:
   */
   /*******************************************************************************/
   ~WipperSnapper_I2C_Driver() { _sensorAddress = 0; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the I2C sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() { return false; }
 
   /*******************************************************************************/
   /*!
@@ -94,23 +106,6 @@ public:
       ++propertyIdx;
     }
   }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Gets the initialization status of an I2C driver.
-      @returns  True if I2C device is initialized successfully, False otherwise.
-  */
-  /*******************************************************************************/
-  bool isInitialized() { return _isInitialized; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Sets the I2C device's address.
-      @param    i2cAddress
-                The I2C device's unique address.
-  */
-  /*******************************************************************************/
-  void setI2CAddress(uint16_t i2cAddress) { _sensorAddress = i2cAddress; }
 
   /*******************************************************************************/
   /*!
@@ -673,9 +668,8 @@ public:
   }
 
 protected:
-  bool _isInitialized = false; ///< True if the I2C device was initialized
-                               ///< successfully, False otherwise.
-  uint16_t _sensorAddress;     ///< The I2C device's unique I2C address.
+  TwoWire *_i2c;           ///< Pointer to the I2C driver's Wire object
+  uint16_t _sensorAddress; ///< The I2C driver's unique I2C address.
   long _tempSensorPeriod =
       0L; ///< The time period between reading the temperature sensor's value.
   long _tempSensorPeriodPrv =

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_AHTX0.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_AHTX0.h
@@ -31,17 +31,16 @@ public:
   /*******************************************************************************/
   /*!
       @brief    Constructor for an AHTX0 sensor.
-      @param    _i2c
+      @param    i2c
                 The I2C interface.
       @param    sensorAddress
-                The 7-bit I2C address of the AHTX0 sensor.
+                7-bit device address.
   */
   /*******************************************************************************/
-  WipperSnapper_I2C_Driver_AHTX0(TwoWire *_i2c, uint16_t sensorAddress)
-      : WipperSnapper_I2C_Driver(_i2c, sensorAddress) {
-    setI2CAddress(sensorAddress);
-    _aht = new Adafruit_AHTX0();
-    _isInitialized = _aht->begin(_i2c);
+  WipperSnapper_I2C_Driver_AHTX0(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
   }
 
   /*******************************************************************************/
@@ -50,6 +49,19 @@ public:
   */
   /*******************************************************************************/
   ~WipperSnapper_I2C_Driver_AHTX0() { delete _aht; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the AHTX0 sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _aht = new Adafruit_AHTX0();
+    bool isInit = _aht->begin(_i2c, (int32_t)_sensorAddress);
+    return isInit;
+  }
 
   /*******************************************************************************/
   /*!

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
@@ -33,17 +33,16 @@ public:
   /*******************************************************************************/
   /*!
       @brief    Constructor for an BME280 sensor.
-      @param    _i2c
+      @param    i2c
                 The I2C interface.
       @param    sensorAddress
-                The 7-bit I2C address of the BME280 sensor.
+                7-bit device address.
   */
   /*******************************************************************************/
-  WipperSnapper_I2C_Driver_BME280(TwoWire *_i2c, uint16_t sensorAddress)
-      : WipperSnapper_I2C_Driver(_i2c, sensorAddress) {
-    setI2CAddress(sensorAddress);
-    _bme = new Adafruit_BME280();
-    _isInitialized = _bme->begin(sensorAddress, _i2c);
+  WipperSnapper_I2C_Driver_BME280(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
   }
 
   /*******************************************************************************/
@@ -52,6 +51,18 @@ public:
   */
   /*******************************************************************************/
   ~WipperSnapper_I2C_Driver_BME280() { delete _bme; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the BME280 sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _bme = new Adafruit_BME280();
+    bool isInit = _bme->begin(_sensorAddress, _i2c);
+    return isInit;
+  }
 
   /*******************************************************************************/
   /*!

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_DPS310.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_DPS310.h
@@ -31,17 +31,16 @@ public:
   /*******************************************************************************/
   /*!
       @brief    Constructor for a DPS310 sensor.
-      @param    _i2c
+      @param    i2c
                 The I2C interface.
       @param    sensorAddress
-                The 7-bit I2C address of the sensor.
+                7-bit device address.
   */
   /*******************************************************************************/
-  WipperSnapper_I2C_Driver_DPS310(TwoWire *_i2c, uint16_t sensorAddress)
-      : WipperSnapper_I2C_Driver(_i2c, sensorAddress) {
-    setI2CAddress(sensorAddress);
-    _dps310 = new Adafruit_DPS310();
-    _isInitialized = _dps310->begin_I2C((uint8_t)_sensorAddress, _i2c);
+  WipperSnapper_I2C_Driver_DPS310(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
   }
 
   /*******************************************************************************/
@@ -50,6 +49,18 @@ public:
   */
   /*******************************************************************************/
   ~WipperSnapper_I2C_Driver_DPS310() { delete _dps310; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the DPS310 sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _dps310 = new Adafruit_DPS310();
+    bool isInit = _dps310->begin_I2C((uint8_t)_sensorAddress, _i2c);
+    return isInit;
+  }
 
   /*******************************************************************************/
   /*!

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MCP9808.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MCP9808.h
@@ -28,18 +28,16 @@ public:
   /*******************************************************************************/
   /*!
       @brief    Constructor for a MCP9808 sensor.
-      @param    _i2c
+      @param    i2c
                 The I2C interface.
       @param    sensorAddress
-                The 7-bit I2C address of the sensor.
+                7-bit device address.
   */
   /*******************************************************************************/
-  WipperSnapper_I2C_Driver_MCP9808(TwoWire *_i2c, uint16_t sensorAddress)
-      : WipperSnapper_I2C_Driver(_i2c, sensorAddress) {
-    // Called when a MCP9808 component is created
-    setI2CAddress(sensorAddress); // sets the driver's I2C address
-    _mcp9808 = new Adafruit_MCP9808();
-    _isInitialized = _mcp9808->begin();
+  WipperSnapper_I2C_Driver_MCP9808(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
   }
 
   /*******************************************************************************/
@@ -50,6 +48,18 @@ public:
   ~WipperSnapper_I2C_Driver_MCP9808() {
     // Called when a MCP9808 component is deleted.
     delete _mcp9808;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the MCP9808 sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _mcp9808 = new Adafruit_MCP9808();
+    bool isInit = _mcp9808->begin((uint8_t)_sensorAddress, _i2c);
+    return isInit;
   }
 
   /*******************************************************************************/

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD30.h
@@ -30,17 +30,16 @@ public:
   /*******************************************************************************/
   /*!
       @brief    Constructor for a SCD30 sensor.
-      @param    _i2c
+      @param    i2c
                 The I2C interface.
       @param    sensorAddress
-                The 7-bit I2C address of the sensor.
+                7-bit device address.
   */
   /*******************************************************************************/
-  WipperSnapper_I2C_Driver_SCD30(TwoWire *_i2c, uint16_t sensorAddress)
-      : WipperSnapper_I2C_Driver(_i2c, sensorAddress) {
-    setI2CAddress(sensorAddress);
-    _scd30 = new Adafruit_SCD30();
-    _isInitialized = _scd30->begin((uint8_t)_sensorAddress, _i2c);
+  WipperSnapper_I2C_Driver_SCD30(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
   }
 
   /*******************************************************************************/
@@ -49,6 +48,18 @@ public:
   */
   /*******************************************************************************/
   ~WipperSnapper_I2C_Driver_SCD30() { delete _scd30; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the SCD30 sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _scd30 = new Adafruit_SCD30();
+    bool isInit = _scd30->begin((uint8_t)_sensorAddress, _i2c);
+    return isInit;
+  }
 
   /*******************************************************************************/
   /*!


### PR DESCRIPTION
- Switch all drivers' initialization to match standard Adafruit library initialization procedure where `new` sensor driver allocates/initializes the driver base class and `begin` initializes the sensor and begins I2C.  
  - Previously, this was completed by the constructor for each driver which is great in Python but does not follow the C++ convention we use across Adafruit_Sensor libraries.
  - The guide for adding an i2c sensor will minimally need to be updated once this is merged.
- `begin()` must be implemented on all driver sub-classes

