### PR TITLE
Write hardware info to debug output and boot file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper Beta
-version=1.0.0-beta.29
+version=1.0.0-beta.30
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -87,6 +87,8 @@ void Wippersnapper::provision() {
 #endif
 
   set_ssid_pass();
+  // Get MAC address from network interface
+  getMacAddr();
 }
 
 /**************************************************************************/
@@ -122,7 +124,7 @@ void Wippersnapper::_disconnect() {
               MAC address.
 */
 /****************************************************************************/
-void Wippersnapper::setUID() {
+void Wippersnapper::getMacAddr() {
   WS_DEBUG_PRINTLN("ERROR: Please define a network interface!");
 }
 
@@ -1063,15 +1065,16 @@ bool Wippersnapper::buildWSTopics() {
   if (WS._username == NULL || WS._key == NULL || WS._network_ssid == NULL ||
       WS._network_pass == NULL)
     return false;
+  
+  // TODO: Validate that we've filled the MAC address
 
-  // Get UID from the network iface
-  setUID();
+  // UID Manipulation, TODO refactor?
   // Move the top 3 bytes from the UID
   for (int i = 5; i > 2; i--) {
-    WS._uid[6 - 1 - i] = WS._uid[i];
+    WS._macAddr[6 - 1 - i] = WS._macAddr[i];
   }
-  snprintf(WS.sUID, sizeof(WS.sUID), "%02d%02d%02d", WS._uid[0], WS._uid[1],
-           WS._uid[2]);
+  snprintf(WS.sUID, sizeof(WS.sUID), "%02d%02d%02d", WS._macAddr[0], WS._macAddr[1],
+           WS._macAddr[2]);
 
   // Get board ID from _Boards.h
   WS._boardId = BOARD_ID;
@@ -1519,6 +1522,20 @@ bool validateAppCreds() {
 */
 /**************************************************************************/
 void Wippersnapper::connect() {
+  WS_DEBUG_PRINTLN("Adafruit.io WipperSnapper");
+  
+  // Print all identifiers to the debug log
+  WS_DEBUG_PRINTLN("-------Device Information-------");
+  WS_DEBUG_PRINT("Firmware Version: "); WS_DEBUG_PRINTLN(WS_VERSION);
+  WS_DEBUG_PRINT("Board ID: "); WS_DEBUG_PRINTLN(BOARD_ID);
+  WS_DEBUG_PRINT("Adafruit IO User: "); WS_DEBUG_PRINTLN(WS._username);
+  WS_DEBUG_PRINT("WiFi Network: "); WS_DEBUG_PRINTLN(WS._network_ssid);
+
+  char sMAC[18] = {0};
+  sprintf(sMAC, "%02X:%02X:%02X:%02X:%02X:%02X", WS._macAddr[0], WS._macAddr[1], WS._macAddr[2], WS._macAddr[3], WS._macAddr[4], WS._macAddr[5]);
+  WS_DEBUG_PRINT("MAC Address: "); WS_DEBUG_PRINTLN(sMAC);
+  WS_DEBUG_PRINTLN("-------------------------------");
+
   // enable WDT
   WS.enableWDT(WS_WDT_TIMEOUT);
 

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -1065,7 +1065,7 @@ bool Wippersnapper::buildWSTopics() {
   if (WS._username == NULL || WS._key == NULL || WS._network_ssid == NULL ||
       WS._network_pass == NULL)
     return false;
-  
+
   // TODO: Validate that we've filled the MAC address
 
   // UID Manipulation, TODO refactor?
@@ -1073,8 +1073,8 @@ bool Wippersnapper::buildWSTopics() {
   for (int i = 5; i > 2; i--) {
     WS._macAddr[6 - 1 - i] = WS._macAddr[i];
   }
-  snprintf(WS.sUID, sizeof(WS.sUID), "%02d%02d%02d", WS._macAddr[0], WS._macAddr[1],
-           WS._macAddr[2]);
+  snprintf(WS.sUID, sizeof(WS.sUID), "%02d%02d%02d", WS._macAddr[0],
+           WS._macAddr[1], WS._macAddr[2]);
 
   // Get board ID from _Boards.h
   WS._boardId = BOARD_ID;
@@ -1523,17 +1523,27 @@ bool validateAppCreds() {
 /**************************************************************************/
 void Wippersnapper::connect() {
   WS_DEBUG_PRINTLN("Adafruit.io WipperSnapper");
-  
+
   // Print all identifiers to the debug log
   WS_DEBUG_PRINTLN("-------Device Information-------");
-  WS_DEBUG_PRINT("Firmware Version: "); WS_DEBUG_PRINTLN(WS_VERSION);
-  WS_DEBUG_PRINT("Board ID: "); WS_DEBUG_PRINTLN(BOARD_ID);
-  WS_DEBUG_PRINT("Adafruit IO User: "); WS_DEBUG_PRINTLN(WS._username);
-  WS_DEBUG_PRINT("WiFi Network: "); WS_DEBUG_PRINTLN(WS._network_ssid);
+
+  WS_DEBUG_PRINT("Firmware Version: ");
+  WS_DEBUG_PRINTLN(WS_VERSION);
+
+  WS_DEBUG_PRINT("Board ID: ");
+  WS_DEBUG_PRINTLN(BOARD_ID);
+
+  WS_DEBUG_PRINT("Adafruit IO User: ");
+  WS_DEBUG_PRINTLN(WS._username);
+
+  WS_DEBUG_PRINT("WiFi Network: ");
+  WS_DEBUG_PRINTLN(WS._network_ssid);
 
   char sMAC[18] = {0};
-  sprintf(sMAC, "%02X:%02X:%02X:%02X:%02X:%02X", WS._macAddr[0], WS._macAddr[1], WS._macAddr[2], WS._macAddr[3], WS._macAddr[4], WS._macAddr[5]);
-  WS_DEBUG_PRINT("MAC Address: "); WS_DEBUG_PRINTLN(sMAC);
+  sprintf(sMAC, "%02X:%02X:%02X:%02X:%02X:%02X", WS._macAddr[0], WS._macAddr[1],
+          WS._macAddr[2], WS._macAddr[3], WS._macAddr[4], WS._macAddr[5]);
+  WS_DEBUG_PRINT("MAC Address: ");
+  WS_DEBUG_PRINTLN(sMAC);
   WS_DEBUG_PRINTLN("-------------------------------");
 
   // enable WDT

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -62,7 +62,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.29" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.30" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -274,7 +274,7 @@ public:
   WipperSnapper_LittleFS
       *_littleFS; ///< Instance of LittleFS Filesystem (non-native USB)
 
-  uint8_t _macAddr[6];      /*!< Unique network iface identifier */
+  uint8_t _macAddr[6];  /*!< Unique network iface identifier */
   char sUID[13];        /*!< Unique network iface identifier */
   const char *_boardId; /*!< Adafruit IO+ board string */
   Adafruit_MQTT *_mqtt; /*!< Reference to Adafruit_MQTT, _mqtt. */

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -197,7 +197,7 @@ public:
   void connect();
   void disconnect();
 
-  virtual void setUID();
+  virtual void getMacAddr();
   virtual void setupMQTTClient(const char *clientID);
 
   virtual ws_status_t networkStatus();
@@ -274,7 +274,7 @@ public:
   WipperSnapper_LittleFS
       *_littleFS; ///< Instance of LittleFS Filesystem (non-native USB)
 
-  uint8_t _uid[6];      /*!< Unique network iface identifier */
+  uint8_t _macAddr[6];      /*!< Unique network iface identifier */
   char sUID[13];        /*!< Unique network iface identifier */
   const char *_boardId; /*!< Adafruit IO+ board string */
   Adafruit_MQTT *_mqtt; /*!< Reference to Adafruit_MQTT, _mqtt. */

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -149,6 +149,7 @@ public:
   */
   /********************************************************/
   void getMacAddr() {
+    uint8_t mac[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     WiFi.macAddress(mac);
     memcpy(WS._macAddr, mac, sizeof(mac));
   }
@@ -201,8 +202,6 @@ protected:
   const char *_pass;          /*!< Network password. */
   const char *_mqttBrokerURL; /*!< MQTT broker URL. */
   String _fv;                 /*!< nina-fw firmware version. */
-  uint8_t mac[6] = {0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00}; /*!< ESP32 interface's MAC address. */
   int _ssPin = -1;                     /*!< SPI S.S. pin. */
   int _ackPin = -1;                    /*!< SPI ACK pin. */
   int _rstPin = -1;                    /*!< SPI RST pin. */

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -148,9 +148,9 @@ public:
   @note   For the ESP32, the UID is the MAC address.
   */
   /********************************************************/
-  void setUID() {
+  void getMacAddr() {
     WiFi.macAddress(mac);
-    memcpy(WS._uid, mac, sizeof(mac));
+    memcpy(WS._macAddr, mac, sizeof(mac));
   }
 
   /********************************************************/

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -198,15 +198,15 @@ public:
   const char *connectionType() { return "AIRLIFT"; }
 
 protected:
-  const char *_ssid;          /*!< Network SSID. */
-  const char *_pass;          /*!< Network password. */
-  const char *_mqttBrokerURL; /*!< MQTT broker URL. */
-  String _fv;                 /*!< nina-fw firmware version. */
-  int _ssPin = -1;                     /*!< SPI S.S. pin. */
-  int _ackPin = -1;                    /*!< SPI ACK pin. */
-  int _rstPin = -1;                    /*!< SPI RST pin. */
-  int _gpio0Pin = -1;                  /*!< SPI GPIO0 pin, unused. */
-  WiFiSSLClient *_mqtt_client;         /*!< Instance of a secure WiFi client. */
+  const char *_ssid;           /*!< Network SSID. */
+  const char *_pass;           /*!< Network password. */
+  const char *_mqttBrokerURL;  /*!< MQTT broker URL. */
+  String _fv;                  /*!< nina-fw firmware version. */
+  int _ssPin = -1;             /*!< SPI S.S. pin. */
+  int _ackPin = -1;            /*!< SPI ACK pin. */
+  int _rstPin = -1;            /*!< SPI RST pin. */
+  int _gpio0Pin = -1;          /*!< SPI GPIO0 pin, unused. */
+  WiFiSSLClient *_mqtt_client; /*!< Instance of a secure WiFi client. */
   SPIClass *_wifi; /*!< Instance of the SPI bus used by the AirLift. */
 
   /**************************************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -85,9 +85,10 @@ public:
   @note   On ESP32, the UID is the MAC address.
   */
   /********************************************************/
-  void setUID() {
+  void getMacAddr() {
+    uint8_t mac[6] = {0};
     WiFi.macAddress(mac);
-    memcpy(WS._uid, mac, sizeof(mac));
+    memcpy(WS._macAddr, mac, sizeof(mac));
   }
 
   /********************************************************/
@@ -141,7 +142,6 @@ protected:
   const char *_ssid;
   const char *_pass;
   const char *_mqttBrokerURL;
-  uint8_t mac[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
   WiFiClientSecure *_mqtt_client;
 
   // io.adafruit.us

--- a/src/network_interfaces/Wippersnapper_ESP8266.h
+++ b/src/network_interfaces/Wippersnapper_ESP8266.h
@@ -103,9 +103,9 @@ public:
   @note   For the ESP8266, the UID is the MAC address.
   */
   /********************************************************/
-  void setUID() {
+  void getMacAddr() {
     WiFi.macAddress(mac);
-    memcpy(WS._uid, mac, sizeof(mac));
+    memcpy(WS._macAddr, mac, sizeof(mac));
   }
 
   /*******************************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP8266.h
+++ b/src/network_interfaces/Wippersnapper_ESP8266.h
@@ -104,6 +104,7 @@ public:
   */
   /********************************************************/
   void getMacAddr() {
+    uint8_t mac[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     WiFi.macAddress(mac);
     memcpy(WS._macAddr, mac, sizeof(mac));
   }
@@ -155,7 +156,6 @@ protected:
   const char *_ssid = NULL;
   const char *_pass = NULL;
   const char *_mqttBrokerURL = NULL;
-  uint8_t mac[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
   WiFiClientSecure *_wifi_client;
 
   /**************************************************************************/

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -140,10 +140,10 @@ public:
   @note   For the ESP32, the UID is the MAC address.
   */
   /********************************************************/
-  void setUID() {
+  void getMacAddr() {
     uint8_t mac[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     WiFi.macAddress(mac);
-    memcpy(WS._uid, mac, sizeof(mac));
+    memcpy(WS._macAddr, mac, sizeof(mac));
   }
 
   /********************************************************/

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -315,7 +315,7 @@ void Wippersnapper_FS::createConfigFileSkel() {
   secretsFile.flush();
   secretsFile.close();
   writeToBootOut(
-      "* Please edit the secrets.json file. Then, reset your board.");
+      "* Please edit the secrets.json file. Then, reset your board.\n");
 }
 
 /**************************************************************************/
@@ -338,7 +338,7 @@ void Wippersnapper_FS::parseSecrets() {
     WS_DEBUG_PRINT("ERROR: deserializeJson() failed with code ");
     WS_DEBUG_PRINTLN(err.c_str());
 
-    writeToBootOut("ERROR: deserializeJson() failed with code");
+    writeToBootOut("ERROR: deserializeJson() failed with code\n");
     writeToBootOut(err.c_str());
     fsHalt();
   }
@@ -348,7 +348,7 @@ void Wippersnapper_FS::parseSecrets() {
   // error check against default values [ArduinoJSON, 3.3.3]
   if (io_username == nullptr) {
     WS_DEBUG_PRINTLN("ERROR: invalid io_username value in secrets.json!");
-    writeToBootOut("ERROR: invalid io_username value in secrets.json!");
+    writeToBootOut("ERROR: invalid io_username value in secrets.json!\n");
     while (1) {
       WS.statusLEDBlink(WS_LED_STATUS_FS_WRITE);
       yield();
@@ -360,20 +360,21 @@ void Wippersnapper_FS::parseSecrets() {
     writeToBootOut(
         "* ERROR: Default username found in secrets.json, please edit "
         "the secrets.json file and reset the board for the changes to take "
-        "effect");
+        "effect\n");
     fsHalt();
   }
   WS._username = io_username;
 
   writeToBootOut("Adafruit.io Username: ");
   writeToBootOut(WS._username);
+  writeToBootOut("\n");
 
   // Get io key
   const char *io_key = doc["io_key"];
   // error check against default values [ArduinoJSON, 3.3.3]
   if (io_key == nullptr) {
     WS_DEBUG_PRINTLN("ERROR: invalid io_key value in secrets.json!");
-    writeToBootOut("ERROR: invalid io_key value in secrets.json!");
+    writeToBootOut("ERROR: invalid io_key value in secrets.json!\n");
     fsHalt();
   }
   WS._key = io_key;
@@ -399,14 +400,14 @@ void Wippersnapper_FS::parseSecrets() {
           "secrets.json!");
       writeToBootOut(
           "ERROR: invalid network_type_wifi_airlift_network_password value in "
-          "secrets.json!");
+          "secrets.json!\n");
       fsHalt();
     }
     // check if SSID is from template (not entered)
     if (doc["network_type_wifi_airlift"]["network_password"] ==
         "YOUR_WIFI_SSID_HERE") {
       writeToBootOut("Default SSID found in secrets.json, please edit "
-                     "the secrets.json file and reset the board");
+                     "the secrets.json file and reset the board\n");
       fsHalt();
     }
 
@@ -435,14 +436,14 @@ void Wippersnapper_FS::parseSecrets() {
           "secrets.json!");
       writeToBootOut(
           "ERROR: invalid network_type_wifi_native_network_password value in "
-          "secrets.json!");
+          "secrets.json!\n");
       fsHalt();
     }
     // check if SSID is from template (not entered)
     if (doc["network_type_wifi_native"]["network_password"] ==
         "YOUR_WIFI_SSID_HERE") {
       writeToBootOut("Default SSID found in secrets.json, please edit "
-                     "the secrets.json file and reset the board");
+                     "the secrets.json file and reset the board\n");
       fsHalt();
     }
 
@@ -457,12 +458,13 @@ void Wippersnapper_FS::parseSecrets() {
     WS_DEBUG_PRINTLN(
         "ERROR: Network interface not detected in secrets.json file.");
     writeToBootOut(
-        "ERROR: Network interface not detected in secrets.json file.");
+        "ERROR: Network interface not detected in secrets.json file.\n");
     fsHalt();
   }
 
   writeToBootOut("WiFi Network: ");
   writeToBootOut(WS._network_ssid);
+  writeToBootOut("\n");
 
   // Optional, Set the IO URL
   WS._mqttBrokerURL = doc["io_url"];
@@ -485,7 +487,7 @@ void Wippersnapper_FS::writeToBootOut(PGM_P str) {
   // Append error output to FS
   File bootFile = wipperFatFs.open("/wipper_boot_out.txt", FILE_WRITE);
   if (bootFile) {
-    bootFile.println(str);
+    bootFile.print(str);
     bootFile.flush();
     bootFile.close();
   } else {

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -261,9 +261,6 @@ bool Wippersnapper_FS::createBootFile() {
     bootFile.print("Board ID: ");
     bootFile.println(BOARD_ID);
 
-    bootFile.print("Firmware Version: ");
-    bootFile.println(WS_VERSION);
-
     sprintf(sMAC, "%02X:%02X:%02X:%02X:%02X:%02X", WS._macAddr[0],
             WS._macAddr[1], WS._macAddr[2], WS._macAddr[3], WS._macAddr[4],
             WS._macAddr[5]);

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -249,9 +249,24 @@ void Wippersnapper_FS::eraseBootFile() {
 /**************************************************************************/
 bool Wippersnapper_FS::createBootFile() {
   bool is_success = false;
+  char sMAC[18] = {0};
+
   File bootFile = wipperFatFs.open("/wipper_boot_out.txt", FILE_WRITE);
   if (bootFile) {
+    bootFile.println("Adafruit.io WipperSnapper");
+
+    bootFile.print("Firmware Version: ");
     bootFile.println(WS_VERSION);
+
+    bootFile.print("Board ID: ");
+    bootFile.println(BOARD_ID);
+
+    bootFile.print("Firmware Version: ");
+    bootFile.println(WS_VERSION);
+
+    sprintf(sMAC, "%02X:%02X:%02X:%02X:%02X:%02X", WS._macAddr[0], WS._macAddr[1], WS._macAddr[2], WS._macAddr[3], WS._macAddr[4], WS._macAddr[5]);
+    bootFile.print("MAC Address: "); bootFile.println(sMAC);
+
     bootFile.flush();
     bootFile.close();
     is_success = true;

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -102,8 +102,8 @@ Wippersnapper_FS::Wippersnapper_FS() {
 */
 /************************************************************/
 Wippersnapper_FS::~Wippersnapper_FS() {
-  //io_username = NULL;
-  //io_key = NULL;
+  // io_username = NULL;
+  // io_key = NULL;
 }
 
 /**************************************************************************/
@@ -264,8 +264,11 @@ bool Wippersnapper_FS::createBootFile() {
     bootFile.print("Firmware Version: ");
     bootFile.println(WS_VERSION);
 
-    sprintf(sMAC, "%02X:%02X:%02X:%02X:%02X:%02X", WS._macAddr[0], WS._macAddr[1], WS._macAddr[2], WS._macAddr[3], WS._macAddr[4], WS._macAddr[5]);
-    bootFile.print("MAC Address: "); bootFile.println(sMAC);
+    sprintf(sMAC, "%02X:%02X:%02X:%02X:%02X:%02X", WS._macAddr[0],
+            WS._macAddr[1], WS._macAddr[2], WS._macAddr[3], WS._macAddr[4],
+            WS._macAddr[5]);
+    bootFile.print("MAC Address: ");
+    bootFile.println(sMAC);
 
     bootFile.flush();
     bootFile.close();
@@ -314,7 +317,7 @@ void Wippersnapper_FS::createConfigFileSkel() {
       "HERE\",\n\t\t\"network_password\":\"YOUR_WIFI_PASS_HERE\"\n\t}\n}");
   secretsFile.flush();
   secretsFile.close();
-  writeErrorToBootOut(
+  writeToBootOut(
       "* Please edit the secrets.json file. Then, reset your board.");
 }
 
@@ -338,17 +341,17 @@ void Wippersnapper_FS::parseSecrets() {
     WS_DEBUG_PRINT("ERROR: deserializeJson() failed with code ");
     WS_DEBUG_PRINTLN(err.c_str());
 
-    writeErrorToBootOut("ERROR: deserializeJson() failed with code");
-    writeErrorToBootOut(err.c_str());
+    writeToBootOut("ERROR: deserializeJson() failed with code");
+    writeToBootOut(err.c_str());
     fsHalt();
   }
 
   // Get io username
-  const char * io_username = doc["io_username"];
+  const char *io_username = doc["io_username"];
   // error check against default values [ArduinoJSON, 3.3.3]
   if (io_username == nullptr) {
     WS_DEBUG_PRINTLN("ERROR: invalid io_username value in secrets.json!");
-    writeErrorToBootOut("ERROR: invalid io_username value in secrets.json!");
+    writeToBootOut("ERROR: invalid io_username value in secrets.json!");
     while (1) {
       WS.statusLEDBlink(WS_LED_STATUS_FS_WRITE);
       yield();
@@ -357,7 +360,7 @@ void Wippersnapper_FS::parseSecrets() {
 
   // check if username is from templated json
   if (doc["io_username"] == "YOUR_IO_USERNAME_HERE") {
-    writeErrorToBootOut(
+    writeToBootOut(
         "* ERROR: Default username found in secrets.json, please edit "
         "the secrets.json file and reset the board for the changes to take "
         "effect");
@@ -365,12 +368,15 @@ void Wippersnapper_FS::parseSecrets() {
   }
   WS._username = io_username;
 
+  writeToBootOut("Adafruit.io Username: ");
+  writeToBootOut(WS._username);
+
   // Get io key
   const char *io_key = doc["io_key"];
   // error check against default values [ArduinoJSON, 3.3.3]
   if (io_key == nullptr) {
     WS_DEBUG_PRINTLN("ERROR: invalid io_key value in secrets.json!");
-    writeErrorToBootOut("ERROR: invalid io_key value in secrets.json!");
+    writeToBootOut("ERROR: invalid io_key value in secrets.json!");
     fsHalt();
   }
   WS._key = io_key;
@@ -394,7 +400,7 @@ void Wippersnapper_FS::parseSecrets() {
       WS_DEBUG_PRINTLN(
           "ERROR: invalid network_type_wifi_airlift_network_password value in "
           "secrets.json!");
-      writeErrorToBootOut(
+      writeToBootOut(
           "ERROR: invalid network_type_wifi_airlift_network_password value in "
           "secrets.json!");
       fsHalt();
@@ -402,8 +408,8 @@ void Wippersnapper_FS::parseSecrets() {
     // check if SSID is from template (not entered)
     if (doc["network_type_wifi_airlift"]["network_password"] ==
         "YOUR_WIFI_SSID_HERE") {
-      writeErrorToBootOut("Default SSID found in secrets.json, please edit "
-                          "the secrets.json file and reset the board");
+      writeToBootOut("Default SSID found in secrets.json, please edit "
+                     "the secrets.json file and reset the board");
       fsHalt();
     }
 
@@ -430,7 +436,7 @@ void Wippersnapper_FS::parseSecrets() {
       WS_DEBUG_PRINTLN(
           "ERROR: invalid network_type_wifi_native_network_password value in "
           "secrets.json!");
-      writeErrorToBootOut(
+      writeToBootOut(
           "ERROR: invalid network_type_wifi_native_network_password value in "
           "secrets.json!");
       fsHalt();
@@ -438,8 +444,8 @@ void Wippersnapper_FS::parseSecrets() {
     // check if SSID is from template (not entered)
     if (doc["network_type_wifi_native"]["network_password"] ==
         "YOUR_WIFI_SSID_HERE") {
-      writeErrorToBootOut("Default SSID found in secrets.json, please edit "
-                          "the secrets.json file and reset the board");
+      writeToBootOut("Default SSID found in secrets.json, please edit "
+                     "the secrets.json file and reset the board");
       fsHalt();
     }
 
@@ -453,10 +459,13 @@ void Wippersnapper_FS::parseSecrets() {
   if (!setNetwork) {
     WS_DEBUG_PRINTLN(
         "ERROR: Network interface not detected in secrets.json file.");
-    writeErrorToBootOut(
+    writeToBootOut(
         "ERROR: Network interface not detected in secrets.json file.");
     fsHalt();
   }
+
+  writeToBootOut("WiFi Network: ");
+  writeToBootOut(WS._network_ssid);
 
   // Optional, Set the IO URL
   WS._mqttBrokerURL = doc["io_url"];
@@ -475,7 +484,7 @@ void Wippersnapper_FS::parseSecrets() {
                 PROGMEM string.
 */
 /**************************************************************************/
-void Wippersnapper_FS::writeErrorToBootOut(PGM_P str) {
+void Wippersnapper_FS::writeToBootOut(PGM_P str) {
   // Append error output to FS
   File bootFile = wipperFatFs.open("/wipper_boot_out.txt", FILE_WRITE);
   if (bootFile) {

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -15,14 +15,13 @@
 #ifndef WIPPERSNAPPER_FS_H
 #define WIPPERSNAPPER_FS_H
 
-// using f_mkfs() for formatting
-#include "fatfs/diskio.h"
-#include "fatfs/ff.h"
-
+#include "ArduinoJson.h"
 #include "Adafruit_SPIFlash.h"
 #include "Adafruit_TinyUSB.h"
-#include "ArduinoJson.h"
 #include "SdFat.h"
+// using f_mkfs() for formatting
+#include "fatfs/ff.h"
+#include "fatfs/diskio.h"
 
 
 #include "Wippersnapper.h"

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -15,13 +15,15 @@
 #ifndef WIPPERSNAPPER_FS_H
 #define WIPPERSNAPPER_FS_H
 
+// using f_mkfs() for formatting
+#include "fatfs/diskio.h"
+#include "fatfs/ff.h"
+
 #include "Adafruit_SPIFlash.h"
 #include "Adafruit_TinyUSB.h"
 #include "ArduinoJson.h"
 #include "SdFat.h"
-// using f_mkfs() for formatting
-#include "fatfs/diskio.h"
-#include "fatfs/ff.h"
+
 
 #include "Wippersnapper.h"
 

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -15,13 +15,13 @@
 #ifndef WIPPERSNAPPER_FS_H
 #define WIPPERSNAPPER_FS_H
 
-#include "ArduinoJson.h"
 #include "Adafruit_SPIFlash.h"
 #include "Adafruit_TinyUSB.h"
+#include "ArduinoJson.h"
 #include "SdFat.h"
 // using f_mkfs() for formatting
-#include "fatfs/ff.h"
 #include "fatfs/diskio.h"
+#include "fatfs/ff.h"
 
 #include "Wippersnapper.h"
 
@@ -53,7 +53,7 @@ public:
   bool configFileExists();
   void createConfigFileSkel();
   bool createBootFile();
-  void writeErrorToBootOut(PGM_P str);
+  void writeToBootOut(PGM_P str);
   void fsHalt();
 
   void parseSecrets();


### PR DESCRIPTION
This pull request:
* Enhances debug output: Hardware identifiers are written to the serial debug terminal and `wipper_boot_out.txt` (if the platform supports TinyUSB)
* Refactoring to differentiate between the device's UID (for WipperSnapper) and the device's MAC address.


Example output from Serial Terminal (Tested: Adafruit ESP32 Feather v2):
```
...
14:05:02.085 -> entry 0x400805e4
14:05:02.886 -> Adafruit.io WipperSnapper
14:05:02.886 -> -------Device Information-------
14:05:02.886 -> Firmware Version: 1.0.0-beta.30
14:05:02.886 -> Board ID: feather-esp32-v2-daily
14:05:02.886 -> Adafruit IO User: SNIP
14:05:02.886 -> WiFi Network: SNIP
14:05:02.886 -> MAC Address: 4C:75:25:E3:62:34
14:05:02.886 -> -------------------------------
14:05:02.886 -> Subscribing to MQTT topics...
...
```

Example Output from `wipper_boot_out.txt` (Tested: Adafruit ESP32-S2 Feather):
```
Adafruit.io WipperSnapper
Firmware Version: 1.0.0-beta.30
Board ID: adafruit-feather-esp32s2
MAC Address: 7C:DF:A1:94:8A:2C
Adafruit.io Username: SNIP
WiFi Network: SNIP
```


Addresses:
https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/241
https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/238