### PR TITLE
Update I2C Component for ESP32-S2 Feather RevB/RevC

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -36,9 +36,12 @@ WipperSnapper_Component_I2C::WipperSnapper_Component_I2C(
   WS_DEBUG_PRINTLN(msgInitRequest->i2c_frequency);
 
 #if defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
-  // Invert Feather ESP32-S2 pin power for I2C
-  pinMode(7, OUTPUT);
-  digitalWrite(7, LOW);
+  // turn on the I2C power by setting pin to opposite of 'rest state'
+  pinMode(PIN_I2C_POWER, INPUT);
+  delay(1);
+  bool polarity = digitalRead(PIN_I2C_POWER);
+  pinMode(PIN_I2C_POWER, OUTPUT);
+  digitalWrite(PIN_I2C_POWER, !polarity);
 #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2_TFT)
   // Power the AP2112 regulator
   // TODO: Remove when fixed by latest BSP release


### PR DESCRIPTION
```
As of March 28, 2022, the ESP32-S2 Feather board has revised the power circuitry for the NeoPixel and I2C QT port. Instead of a transistor we now have a totally new LDO regulator that can be enabled or disabled with a GPIO pin. Set GPIO 7 to be output and HIGH to turn on the NeoPixel and QT power.
```

This pull request updates the I2C Component to work properly with RevA/B/C ESP32-S2 Feather.

Tested successfully with:
* Adafruit ESP32-S2 Feather RevA (No Markings)
* Adafruit ESP32-S2 Feather RevC

Addresses:
https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/239