### PR TITLE
Fix IO_URL not set for LittleFS

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arduino-platform: ["feather_esp32", "feather_esp32_v2_daily"]
+        arduino-platform: ["feather_esp32", "feather_esp32_v2"]
     steps:
     - uses: actions/setup-python@v1
       with:

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -111,6 +111,9 @@ void WipperSnapper_LittleFS::parseSecrets() {
   // set password
   WS._network_pass = network_type_wifi_native_network_password;
 
+  // Optionally set the Adafruit.io URL
+  WS._mqttBrokerURL = doc["io_url"];
+
   // close the file
   secretsFile.close();
 

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -112,7 +112,7 @@ void WipperSnapper_LittleFS::parseSecrets() {
   WS._network_pass = network_type_wifi_native_network_password;
 
   // Optionally set the Adafruit.io URL
-  WS._mqttBrokerURL = doc["io_url"];
+  WS._mqttBrokerURL = _doc["io_url"];
 
   // close the file
   secretsFile.close();


### PR DESCRIPTION
Fixes `io_url` never getting set for platforms using LittleFS.

Addresses
https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/236