### PR TITLE
Remove "beta" from library.properties "name" field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
-name=Adafruit WipperSnapper Beta
-version=1.0.0-beta.36
+name=Adafruit WipperSnapper
+version=1.0.0-beta.38
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -60,7 +60,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.37" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.38" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic


### PR DESCRIPTION
Will open issue within https://github.com/arduino/library-registry/issues to update the name of the repository/library once a new release is cut.