### PR TITLE
Fix and merge binaries for ESP32 Web Tool

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -396,7 +396,7 @@ jobs:
 
   clang_and_doxy:
     runs-on: ubuntu-latest
-    needs: [build-samd, build-esp32, build-esp32c3, build-esp32sx, build-esp8266, build-samd-non-fs]
+    needs: [build-samd, build-esp32-4M, build-esp32-8M, build-esp32c3, build-esp32sx, build-esp8266, build-samd-non-fs]
     steps:
     - uses: actions/setup-python@v1
       with:

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -60,13 +60,13 @@ jobs:
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
 
-  build-esp32:
-    name: Build WipperSnapper ESP32
+  build-esp32-4M:
+    name: Build WipperSnapper ESP32 4M
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        arduino-platform: ["feather_esp32", "feather_esp32_v2", "qtpy_esp32"]
+        arduino-platform: ["feather_esp32"]
     steps:
     - uses: actions/setup-python@v1
       with:
@@ -109,6 +109,85 @@ jobs:
     - name: boot_app0 file from esp32 source bsp
       if: steps.check_files.outputs.files_exists == 'false'
       run: mv /home/runner/Arduino/hardware/espressif/esp32/tools/partitions/boot_app0.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin
+
+    - name: Create combined binary using Esptool merge_bin
+      run: |
+          python3 -m esptool --chip esp32 merge_bin --flash_mode dio --flash_freq 80m --flash_size 4MB \
+            -o wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.combined.bin \
+            0x1000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
+            0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \
+            0xe000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin \
+            0x10000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
+
+    - name: Zip build artifacts
+      run: |
+            zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*
+    - name: upload build artifacts zip
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-files
+        path: |
+            wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip
+
+
+  build-esp32-8M:
+    name: Build WipperSnapper ESP32 8M
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arduino-platform: ["feather_esp32_v2", "qtpy_esp32"]
+    steps:
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v2
+    - name: Get WipperSnapper version
+      run: |
+        git fetch --prune --unshallow --tags
+        git describe --dirty --tags
+        echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+    - uses: actions/checkout@v2
+      with:
+         repository: adafruit/ci-arduino
+         path: ci
+    - name: Install CI-Arduino
+      run: bash ci/actions_install.sh
+    - name: Install extra Arduino libraries
+      run: |
+        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
+    - name: build ESP32 platforms
+      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
+    - name: Rename build artifacts to reflect the platform name
+      run: |
+            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
+            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.elf
+            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.map
+            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.bootloader.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin
+            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.partitions.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin
+
+    - name: Check boot_app0 file existence (esp32 built from core, not-source)
+      id: check_files
+      uses: andstor/file-existence-action@v1
+      with:
+        files: "/home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin"
+
+    - name: boot_app0 file from arduino-cli core
+      if: steps.check_files.outputs.files_exists == 'true'
+      run: mv /home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin
+
+    - name: boot_app0 file from esp32 source bsp
+      if: steps.check_files.outputs.files_exists == 'false'
+      run: mv /home/runner/Arduino/hardware/espressif/esp32/tools/partitions/boot_app0.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin
+
+    - name: Create combined binary using Esptool merge_bin
+      run: |
+          python3 -m esptool --chip esp32 merge_bin --flash_mode dio --flash_freq 80m --flash_size 8MB \
+            -o wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.combined.bin \
+            0x1000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
+            0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \
+            0xe000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin \
+            0x10000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
 
     - name: Zip build artifacts
       run: |

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -86,6 +86,9 @@ jobs:
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
+    - name: Install Dependencies
+      run: |
+        pip3 install esptool
     - name: build ESP32 platforms
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
     - name: Rename build artifacts to reflect the platform name
@@ -156,6 +159,9 @@ jobs:
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
+    - name: Install Dependencies
+      run: |
+        pip3 install esptool
     - name: build ESP32 platforms
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
     - name: Rename build artifacts to reflect the platform name

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.39
+version=1.0.0-beta.40
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -60,7 +60,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.39" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.40" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic


### PR DESCRIPTION
ESP Web Tools do not work while uploading binaries at offsets after the Arduino-ESP32 BSP v2.0.4 release. @makermelissa  and I believe its due to web tools not patching the binary with flash size/freq, while esptool.py does.

This PR provides a patch that:
* Creates combined binaries for ESP32-4M, ESP32-8M with Esptool's `merge_bin` cmd to be uploaded at 0x0. WipperSnapper_Boards definitions for these boards will be updated with the new `structure` and offset.

Subsequent PR(s) will reduce the number of actions steps, and map the flash frequency and flash size to the appropriate esp32 board.