### PR TITLE
Add driver for SCD40 CO2, Temperature, and Humidity Sensor

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -282,6 +282,17 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _tsl2591->configureDriver(msgDeviceInitReq);
     drivers.push_back(_tsl2591);
     WS_DEBUG_PRINTLN("TSL2591 Initialized Successfully!");
+  }  else if (strcmp("scd40", msgDeviceInitReq->i2c_device_name) == 0) {
+    _scd40 = new WipperSnapper_I2C_Driver_SCD40(this->_i2c, i2cAddress);
+    if (!_scd40->begin()) {
+      WS_DEBUG_PRINTLN("ERROR: Failed to initialize SCD40!");
+      _busStatusResponse =
+          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
+      return false;
+    }
+    _scd40->configureDriver(msgDeviceInitReq);
+    drivers.push_back(_scd40);
+    WS_DEBUG_PRINTLN("SCD40 Initialized Successfully!");
   } else {
     WS_DEBUG_PRINTLN("ERROR: I2C device type not found!")
     _busStatusResponse =

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -282,7 +282,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _tsl2591->configureDriver(msgDeviceInitReq);
     drivers.push_back(_tsl2591);
     WS_DEBUG_PRINTLN("TSL2591 Initialized Successfully!");
-  }  else if (strcmp("scd40", msgDeviceInitReq->i2c_device_name) == 0) {
+  } else if (strcmp("scd40", msgDeviceInitReq->i2c_device_name) == 0) {
     _scd40 = new WipperSnapper_I2C_Driver_SCD40(this->_i2c, i2cAddress);
     if (!_scd40->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize SCD40!");

--- a/src/components/i2c/WipperSnapper_I2C.h
+++ b/src/components/i2c/WipperSnapper_I2C.h
@@ -27,6 +27,7 @@
 #include "drivers/WipperSnapper_I2C_Driver_MCP9808.h"
 #include "drivers/WipperSnapper_I2C_Driver_SCD30.h"
 #include "drivers/WipperSnapper_I2C_Driver_TSL2591.h"
+#include "drivers/WipperSnapper_I2C_Driver_SCD40.h"
 
 #define I2C_TIMEOUT_MS 50 ///< Default I2C timeout, in milliseconds.
 
@@ -78,6 +79,7 @@ private:
   WipperSnapper_I2C_Driver_MCP9808 *_mcp9808 = nullptr;
   WipperSnapper_I2C_Driver_MCP9601 *_mcp9601 = nullptr;
   WipperSnapper_I2C_Driver_TSL2591 *_tsl2591 = nullptr;
+  WipperSnapper_I2C_Driver_SCD40 *_scd40 = nullptr;
 };
 extern Wippersnapper WS;
 

--- a/src/components/i2c/WipperSnapper_I2C.h
+++ b/src/components/i2c/WipperSnapper_I2C.h
@@ -26,8 +26,8 @@
 #include "drivers/WipperSnapper_I2C_Driver_MCP9601.h"
 #include "drivers/WipperSnapper_I2C_Driver_MCP9808.h"
 #include "drivers/WipperSnapper_I2C_Driver_SCD30.h"
-#include "drivers/WipperSnapper_I2C_Driver_TSL2591.h"
 #include "drivers/WipperSnapper_I2C_Driver_SCD40.h"
+#include "drivers/WipperSnapper_I2C_Driver_TSL2591.h"
 
 #define I2C_TIMEOUT_MS 50 ///< Default I2C timeout, in milliseconds.
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD40.h
@@ -8,7 +8,7 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Copyright (c) Brent Rubell 2021 for Adafruit Industries.
+ * Copyright (c) Marni Brewster 2022 for Adafruit Industries.
  *
  * MIT license, all text here must be included in any redistribution.
  *

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD40.h
@@ -81,14 +81,9 @@ public:
     float temperature;
     float humidity;
     uint16_t error;
-    bool isDataReady = false;
-    error = _scd->getDataReadyFlag(isDataReady);
-    if (_tempSensorPeriod != 0 && error || !isDataReady) {
-      return false;
-    }
 
     error = _scd->readMeasurement(co2, temperature, humidity);
-    if (error || co2 == 0) {
+    if (_tempSensorPeriod != 0 && error || co2 == 0) {
       return false;
     }
 
@@ -111,14 +106,9 @@ public:
     float temperature;
     float humidity;
     uint16_t error;
-    bool isDataReady = false;
-    error = _scd->getDataReadyFlag(isDataReady);
-    if (_humidSensorPeriod != 0 && error || !isDataReady) {
-      return false;
-    }
 
     error = _scd->readMeasurement(co2, temperature, humidity);
-    if (error || co2 == 0) {
+    if (_humidSensorPeriod != 0 && error || co2 == 0) {
       return false;
     }
 
@@ -141,15 +131,12 @@ public:
     float temperature;
     float humidity;
     uint16_t error;
-    bool isDataReady = false;
-    error = _scd->getDataReadyFlag(isDataReady);
-    if (_CO2SensorPeriod != 0 && error || !isDataReady) {
-      return false;
-    }
+
     error = _scd->readMeasurement(co2, temperature, humidity);
-    if (error || co2 == 0) {
+    if (_CO2SensorPeriod != 0 && error || co2 == 0) {
       return false;
     }
+
     // TODO: This is a TEMPORARY HACK, we need to add CO2 type to
     // adafruit_sensor
     co2Event->data[0] = co2;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD40.h
@@ -83,7 +83,7 @@ public:
     uint16_t error;
 
     error = _scd->readMeasurement(co2, temperature, humidity);
-    if (_tempSensorPeriod != 0 && error || co2 == 0) {
+    if ((_tempSensorPeriod != 0 && error) || co2 == 0) {
       return false;
     }
 
@@ -108,7 +108,7 @@ public:
     uint16_t error;
 
     error = _scd->readMeasurement(co2, temperature, humidity);
-    if (_humidSensorPeriod != 0 && error || co2 == 0) {
+    if ((_humidSensorPeriod != 0 && error) || co2 == 0) {
       return false;
     }
 
@@ -133,7 +133,7 @@ public:
     uint16_t error;
 
     error = _scd->readMeasurement(co2, temperature, humidity);
-    if (_CO2SensorPeriod != 0 && error || co2 == 0) {
+    if ((_CO2SensorPeriod != 0 && error) || co2 == 0) {
       return false;
     }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD40.h
@@ -1,0 +1,136 @@
+/*!
+ * @file WipperSnapper_I2C_Driver_SCD40.h
+ *
+ * Device driver for the SCD40 CO2, Temperature, and Humidity sensor.
+ * TEMPORARY HACK
+ *
+ * MIT license, all text here must be included in any redistribution.
+ *
+ */
+
+#ifndef WipperSnapper_I2C_Driver_SCD40_H
+#define WipperSnapper_I2C_Driver_SCD40_H
+
+#include "WipperSnapper_I2C_Driver.h"
+#include <SensirionI2CScd4x.h>
+#include <Wire.h>
+
+/**************************************************************************/
+/*!
+    @brief  Class that provides a driver interface for the SCD40 sensor.
+*/
+/**************************************************************************/
+class WipperSnapper_I2C_Driver_SCD40 : public WipperSnapper_I2C_Driver {
+
+public:
+  /*******************************************************************************/
+  /*!
+      @brief    Constructor for a SCD40 sensor.
+      @param    i2c
+                The I2C interface.
+      @param    sensorAddress
+                7-bit device address.
+  */
+  /*******************************************************************************/
+  WipperSnapper_I2C_Driver_SCD40(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the SCD40 sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _scd = new SensirionI2CScd4x();  
+    _scd->begin(*_i2c);
+    bool error = _scd->stopPeriodicMeasurement();
+    if (error) {
+      return false;
+    } 
+
+    bool error_1 = _scd->startPeriodicMeasurement();          
+    if (error_1) {
+      return false;
+    }
+      
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SCD40's current temperature.
+      @param    tempEvent
+                Pointer to an Adafruit_Sensor event.
+      @returns  True if the temperature was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+    // check if sensor is enabled and data is available      
+    _error = _scd->readMeasurement(_co2, _temperature, _humidity);
+    if (_tempSensorPeriod != 0 && _error)
+      return false;
+
+    tempEvent->temperature = _temperature;
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SCD40's current relative humidity reading.
+      @param    humidEvent
+                Pointer to an Adafruit_Sensor event.
+      @returns  True if the humidity was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventRelativeHumidity(sensors_event_t *humidEvent) {
+    // check if sensor is enabled and data is available   
+    if (_humidSensorPeriod != 0 && _error)
+      return false;
+    
+    if (_humidity) {
+      // This sensor library does not implement Adafruit_Sensor       
+      humidEvent->relative_humidity = _humidity;      
+    } else {
+      humidEvent->relative_humidity = 0;      
+    }
+    
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SCD40's current CO2 reading.
+      @param    co2Event
+                  Adafruit Sensor event for CO2
+      @returns  True if the sensor value was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventCO2(sensors_event_t *co2Event) {
+    // check if sensor is enabled and data is available   
+    if (_CO2SensorPeriod != 0 && _error)
+      return false;       
+    
+    if (_co2) {
+      co2Event->data[0] = _co2;
+    } else {
+      co2Event->data[0] = 0;
+    }
+    return true;
+  }
+
+protected:
+  SensirionI2CScd4x *_scd; ///< SCD40 driver object
+  uint16_t _co2;
+  float _temperature;
+  float _humidity;
+  uint16_t _error;
+};
+
+#endif // WipperSnapper_I2C_Driver_SCD40


### PR DESCRIPTION
This pull request adds support for using the SCD40 co2, temperature, and humidity sensor (https://www.adafruit.com/product/5187).
There is not an Adafruit library for this sensor, only a [Sensirion Arduino library](https://github.com/Sensirion/arduino-i2c-scd4x). This is already included in `library.properties`, but it does not implement `Arduino_Sensor`, so this PR likely needs some help. Also, I have never written C++ before, so I am likely botching things.
The output from doxygen that referenced my changes complained about defining variables, but I was unsure how to handle the way the Sensirion library makes one call to read (vs [the Adafruit python library that creates `scd.temperature`](https://github.com/adafruit/Adafruit_CircuitPython_SCD4X/blob/e4dba358a4e8a11c7e191c6ec8fdb143102ca91f/adafruit_scd4x.py#L122), for example).

With all of that being said, I was able to get this running locally:
![Screen Shot 2022-07-12 at 3 57 46 PM](https://user-images.githubusercontent.com/13192976/178596273-1249c860-25de-4076-9f7d-6ab5e05f8aaf.png)
![Screen Shot 2022-07-12 at 3 57 38 PM](https://user-images.githubusercontent.com/13192976/178596274-067fed21-daf8-43a2-a234-f1e17fbddef9.png)
![Screen Shot 2022-07-11 at 8 01 09 PM](https://user-images.githubusercontent.com/13192976/178596275-9883f331-709a-435c-9b57-f4c8c45b9729.png)

