### PR TITLE
Fix push buttons with internal pull-up resistor 

### DIFF
--- a/src/components/digitalIO/Wippersnapper_DigitalGPIO.h
+++ b/src/components/digitalIO/Wippersnapper_DigitalGPIO.h
@@ -24,6 +24,7 @@ struct digitalInputPin {
   long period;     ///< Timer interval, in millis, -1 if disabled.
   long prvPeriod;  ///< When timer was previously serviced, in millis
   int prvPinVal;   ///< Previous pin value
+  bool isPullUp;   ///< True if the pin has a pull-up resistor enabled
 };
 
 // forward decl.


### PR DESCRIPTION
Previously, this was handled on the application (invert the value whenever its shown). This functionality was not optimal and was removed in a recent revision of how the device interface buttons work. This PR allows the device to track if a digital GPIO pin has a pull-up resistor enabled, and invert the value prior to sending it to Adafruit IO.

Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/284