### PR TITLE
Add SHT4X Support

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.42
+version=1.0.0-beta.43
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper
@@ -7,4 +7,4 @@ paragraph=Arduino client for Adafruit.io WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library
+depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit SHT4x Library

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,9 +13,8 @@ default_envs = featheresp32v2, featheresp32s2
 framework = arduino
 monitor_speed = 115200
 lib_compat_mode = strict
-lib_deps =
-    adafruit/Adafruit TinyUSB Library@^1.10.3
 lib_extra_dirs = ~/Documents/Arduino/libraries
+
 
 ; WipperSnapper local build environment for Adafruit Feather ESP32 v2
 [env:featheresp32v2]
@@ -23,12 +22,28 @@ platform = https://github.com/platformio/platform-espressif32.git
 monitor_filters = time, esp32_exception_decoder, colorize
 board = adafruit_feather_esp32_v2
 build_flags = -D ARDUINO_ADAFRUIT_FEATHER_ESP32_V2
-upload_port = /dev/cu.usbserial-10
-monitor_port = /dev/cu.usbserial-10
+upload_port = /dev/cu.usbserial-11330
+monitor_port = /dev/cu.usbserial-11330
+lib_deps = adafruit/Adafruit TinyUSB Library@^1.10.3
 
 ; WipperSnapper local build environment for Adafruit Feather ESP32-S2
 [env:featheresp32s2]
 platform = espressif32
 board = featheresp32-s2
+upload_port = /dev/cu.usbmodem01
+monitor_port = /dev/cu.usbmodem1330
 build_flags = -D ARDUINO_ADAFRUIT_FEATHER_ESP32S2
 monitor_filters = time, esp32_exception_decoder, colorize
+extra_scripts = 
+    pre:rename_usb_config.py
+lib_deps = adafruit/Adafruit TinyUSB Library@^1.10.3
+
+; WipperSnapper local build environment for Adafruit Feather ESP8266
+[env:featheresp8266]
+platform = https://github.com/platformio/platform-espressif8266.git
+board = huzzah
+build_flags = -D ARDUINO_ESP8266_ADAFRUIT_HUZZAH
+lib_ignore = Adafruit TinyUSB Library
+build_src_filter = +<*> -<../.pio/libdeps/featheresp8266/Adafruit TinyUSB Library>
+upload_port = /dev/cu.usbserial-11330
+monitor_port = /dev/cu.usbserial-11330

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -60,7 +60,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.42" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.43" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -293,6 +293,17 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _scd40->configureDriver(msgDeviceInitReq);
     drivers.push_back(_scd40);
     WS_DEBUG_PRINTLN("SCD40 Initialized Successfully!");
+  } else if (strcmp("SHT40", msgDeviceInitReq->i2c_device_name) == 0) {
+    _sht4x = new WipperSnapper_I2C_Driver_SHT4X(this->_i2c, i2cAddress);
+    if (!_sht4x->begin()) {
+      WS_DEBUG_PRINTLN("ERROR: Failed to initialize sht4x!");
+      _busStatusResponse =
+          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
+      return false;
+    }
+    _sht4x->configureDriver(msgDeviceInitReq);
+    drivers.push_back(_sht4x);
+    WS_DEBUG_PRINTLN("SHT4X Initialized Successfully!");
   } else {
     WS_DEBUG_PRINTLN("ERROR: I2C device type not found!")
     _busStatusResponse =

--- a/src/components/i2c/WipperSnapper_I2C.h
+++ b/src/components/i2c/WipperSnapper_I2C.h
@@ -27,6 +27,7 @@
 #include "drivers/WipperSnapper_I2C_Driver_MCP9808.h"
 #include "drivers/WipperSnapper_I2C_Driver_SCD30.h"
 #include "drivers/WipperSnapper_I2C_Driver_SCD40.h"
+#include "drivers/WipperSnapper_I2C_Driver_SHT4X.h"
 #include "drivers/WipperSnapper_I2C_Driver_TSL2591.h"
 
 #define I2C_TIMEOUT_MS 50 ///< Default I2C timeout, in milliseconds.
@@ -80,6 +81,7 @@ private:
   WipperSnapper_I2C_Driver_MCP9601 *_mcp9601 = nullptr;
   WipperSnapper_I2C_Driver_TSL2591 *_tsl2591 = nullptr;
   WipperSnapper_I2C_Driver_SCD40 *_scd40 = nullptr;
+  WipperSnapper_I2C_Driver_SHT4X *_sht4x = nullptr;
 };
 extern Wippersnapper WS;
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
@@ -1,0 +1,103 @@
+/*!
+ * @file WipperSnapper_I2C_Driver_SHT4X.h
+ *
+ * Device driver for the SHT4X Temperature and Humidity Sensor
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) Marni Brewster 2022 for Adafruit Industries.
+ *
+ * MIT license, all text here must be included in any redistribution.
+ *
+ */
+
+#ifndef WipperSnapper_I2C_Driver_SHT4X_H
+#define WipperSnapper_I2C_Driver_SHT4X_H
+
+#include "WipperSnapper_I2C_Driver.h"
+#include <Adafruit_SHT4x.h>
+#include <Wire.h>
+
+/**************************************************************************/
+/*!
+    @brief  Class that provides a driver interface for the SHT4X sensor.
+*/
+/**************************************************************************/
+class WipperSnapper_I2C_Driver_SHT4X : public WipperSnapper_I2C_Driver {
+
+public:
+  /*******************************************************************************/
+  /*!
+      @brief    Constructor for a SHT4X sensor.
+      @param    i2c
+                The I2C interface.
+      @param    sensorAddress
+                7-bit device address.
+  */
+  /*******************************************************************************/
+  WipperSnapper_I2C_Driver_SHT4X(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the SHT4X sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _sht4x = new Adafruit_SHT4x();
+    if (!_sht4x->begin(_i2c))
+      return false;
+
+    // Use HIGH PRECISION
+    _sht4x->setPrecision(SHT4X_HIGH_PRECISION);
+    // default, NO HEATER
+    _sht4x->setHeater(SHT4X_NO_HEATER);
+
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SHT4X's current temperature.
+      @param    tempEvent
+                Pointer to an Adafruit_Sensor event.
+      @returns  True if the temperature was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+    sensors_event_t humidityEvent;
+    // populate temp and humidity objects with fresh data
+    if (!_sht4x->getEvent(&humidityEvent, tempEvent))
+      return false;
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SHT4X's current relative humidity reading.
+      @param    humidEvent
+                Pointer to an Adafruit_Sensor event.
+      @returns  True if the humidity was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventRelativeHumidity(sensors_event_t *humidEvent) {
+    sensors_event_t tempEvent;
+    // populate temp and humidity objects with fresh data
+    if (!_sht4x->getEvent(humidEvent, &tempEvent))
+      return false;
+    return true;
+  }
+
+protected:
+  Adafruit_SHT4x *_sht4x; ///< SHT4X object
+};
+
+#endif // WipperSnapper_I2C_Driver_SHT4X


### PR DESCRIPTION
Adds support for the SHT4X temperature / humidity sensor via [Adafruit_SHT4x](https://github.com/adafruit/Adafruit_SHT4X).

Tested on Adafruit Feather ESP32-S2 + Adafruit SHT4x Breakout
![sht40_test](https://user-images.githubusercontent.com/322428/184946375-a87b0625-2255-4cc6-ab91-b24ce8b77140.png)

