### PR TITLE
Add support for LC709203F 

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino client for Adafruit.io WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit SHT4x Library, Adafruit PM25 AQI Sensor
+depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit SHT4x Library, Adafruit PM25 AQI Sensor, Adafruit LC709203F

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.44
+version=1.0.0-beta.45
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -60,7 +60,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.44" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.45" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -713,11 +713,11 @@ void WipperSnapper_Component_I2C::update() {
         // pack event data into msg
         fillEventMessage(&msgi2cResponse, event.data[0],
                          wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM10_STD);
-
-        (*iter)->setSensorPM10_STDPeriodPrv(curTime);
       } else {
         WS_DEBUG_PRINTLN("ERROR: Failed to get PM1.0 sensor reading!");
       }
+      // try again in curTime seconds
+      (*iter)->setSensorPM10_STDPeriodPrv(curTime);
     }
 
     // PM25_STD sensor
@@ -736,11 +736,11 @@ void WipperSnapper_Component_I2C::update() {
         // pack event data into msg
         fillEventMessage(&msgi2cResponse, event.data[0],
                          wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM25_STD);
-
-        (*iter)->setSensorPM25_STDPeriodPrv(curTime);
       } else {
         WS_DEBUG_PRINTLN("ERROR: Failed to get PM2.5 sensor reading!");
       }
+      // try again in curTime seconds
+      (*iter)->setSensorPM25_STDPeriodPrv(curTime);
     }
 
     // PM100_STD sensor
@@ -759,11 +759,11 @@ void WipperSnapper_Component_I2C::update() {
         // pack event data into msg
         fillEventMessage(&msgi2cResponse, event.data[0],
                          wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM100_STD);
-
-        (*iter)->setSensorPM100_STDPeriodPrv(curTime);
       } else {
         WS_DEBUG_PRINTLN("ERROR: Failed to get PM10.0 sensor reading!");
       }
+      (*iter)->setSensorPM100_STDPeriodPrv(
+          curTime); // try again in curTime seconds
     }
 
     // Voltage sensor
@@ -782,11 +782,11 @@ void WipperSnapper_Component_I2C::update() {
         // pack event data into msg
         fillEventMessage(&msgi2cResponse, event.voltage,
                          wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_VOLTAGE);
-
-        (*iter)->setSensorVoltagePeriodPrv(curTime);
       } else {
         WS_DEBUG_PRINTLN("ERROR: Failed to get voltage sensor reading!");
       }
+      // try again in curTime seconds
+      (*iter)->setSensorVoltagePeriodPrv(curTime);
     }
 
     // Unitless % sensor
@@ -806,11 +806,12 @@ void WipperSnapper_Component_I2C::update() {
         fillEventMessage(
             &msgi2cResponse, event.voltage,
             wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_UNITLESS_PERCENT);
-        (*iter)->setSensorUnitlessPercentPeriodPrv(curTime);
       } else {
         WS_DEBUG_PRINTLN(
-            "ERROR: Failed to get unitless-percent sensor reading!");
+            "ERROR: Failed to get unitless percentage sensor reading!");
       }
+      // try again in curTime seconds
+      (*iter)->setSensorUnitlessPercentPeriodPrv(curTime);
     }
 
     // Did this driver obtain data from sensors?

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -315,6 +315,17 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _pm25->configureDriver(msgDeviceInitReq);
     drivers.push_back(_pm25);
     WS_DEBUG_PRINTLN("PM2.5 AQI Sensor Initialized Successfully!");
+  } else if (strcmp("lc709203f", msgDeviceInitReq->i2c_device_name) == 0) {
+    _lc = new WipperSnapper_I2C_Driver_LC709203F(this->_i2c, i2cAddress);
+    if (!_lc->begin()) {
+      WS_DEBUG_PRINTLN("ERROR: Failed to initialize LC709203F Sensor!");
+      _busStatusResponse =
+          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
+      return false;
+    }
+    _lc->configureDriver(msgDeviceInitReq);
+    drivers.push_back(_lc);
+    WS_DEBUG_PRINTLN("LC709203F Sensor Initialized Successfully!");
   } else {
     WS_DEBUG_PRINTLN("ERROR: I2C device type not found!")
     _busStatusResponse =

--- a/src/components/i2c/WipperSnapper_I2C.h
+++ b/src/components/i2c/WipperSnapper_I2C.h
@@ -23,6 +23,7 @@
 #include "drivers/WipperSnapper_I2C_Driver_AHTX0.h"
 #include "drivers/WipperSnapper_I2C_Driver_BME280.h"
 #include "drivers/WipperSnapper_I2C_Driver_DPS310.h"
+#include "drivers/WipperSnapper_I2C_Driver_LC709203F.h"
 #include "drivers/WipperSnapper_I2C_Driver_MCP9601.h"
 #include "drivers/WipperSnapper_I2C_Driver_MCP9808.h"
 #include "drivers/WipperSnapper_I2C_Driver_PM25.h"
@@ -84,6 +85,7 @@ private:
   WipperSnapper_I2C_Driver_SCD40 *_scd40 = nullptr;
   WipperSnapper_I2C_Driver_PM25 *_pm25 = nullptr;
   WipperSnapper_I2C_Driver_SHT4X *_sht4x = nullptr;
+  WipperSnapper_I2C_Driver_LC709203F *_lc = nullptr;
 };
 extern Wippersnapper WS;
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -127,12 +127,12 @@ public:
         break;
       case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_UNITLESS_PERCENT:
         enableSensorUnitlessPercent();
-        setSensorUnitlessPercent(
+        setSensorUnitlessPercentPeriod(
             msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
         break;
       case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_VOLTAGE:
         enableSensorVoltage();
-        setSensorVoltage(
+        setSensorVoltagePeriod(
             msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
         break;
       default:

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -125,6 +125,10 @@ public:
         setSensorPM100_STDPeriod(
             msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
         break;
+      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_UNITLESS_PERCENT:
+        enableSensorUnitlessPercent();
+        setSensorUnitlessPercent(
+            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
       default:
         break;
       }
@@ -1131,6 +1135,97 @@ public:
     setSensorPM100_STDPeriod(period);
   }
 
+  /**************************** SENSOR_TYPE: UNITLESS_PERCENT
+   * ****************************/
+  /*******************************************************************************/
+  /*!
+      @brief    Enables sensor's unitless % readings, if it exists.
+  */
+  /*******************************************************************************/
+  virtual void enableSensorUnitlessPercent(){};
+
+  /*******************************************************************************/
+  /*!
+      @brief    Disables the sensor's unitless % standard readings, if it
+     exists.
+  */
+  /*******************************************************************************/
+  virtual void disableSensorUnitlessPercent() { _unitlessPercentPeriod = 0.0L; }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the object unitless % sensor
+                period, if set.
+      @returns  Time when the object unitless % sensor should be polled, in
+                seconds.
+  */
+  /*********************************************************************************/
+  virtual long sensorUnitlessPercentPeriod() { return _unitlessPercentPeriod; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Set the unitless % sensor's return frequency.
+      @param    period
+                The time interval at which to return new data from the sensor.
+  */
+  /*******************************************************************************/
+  virtual void setSensorUnitlessPercentPeriod(float period) {
+    if (period == 0)
+      disableSensorUnitlessPercent();
+    // Period is in seconds, cast it to long and convert it to milliseconds
+    _unitlessPercentPeriod = (long)period * 1000;
+  }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the previous time interval at
+                which the unitless % sensor was queried last.
+      @returns  Time when the unitless % sensor was last queried,
+                in seconds.
+  */
+  /*********************************************************************************/
+  virtual long SensorUnitlessPercentPeriodPrv() {
+    return _unitlessPercentPeriodPrv;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Sets a timestamp for when the unitless % sensor
+                was queried.
+      @param    period
+                The time when the unitless % sensor was queried last.
+  */
+  /*******************************************************************************/
+  virtual void setSensorUnitlessPercentPeriodPrv(long period) {
+    _unitlessPercentPeriodPrv = period;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Base implementation - Reads a object unitless % std. sensor and
+                converts the reading into the expected SI unit.
+      @param    unitless %StdEvent
+                unitless % std. sensor reading, in ppm.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  virtual bool getEventUnitlessPercent(sensors_event_t *unitlessPercentEvent) {
+    return false;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Updates the properties of a unitless % sensor.
+      @param    period
+                The time interval at which to return new data from the
+                unitless % sensor.
+  */
+  /*******************************************************************************/
+  virtual void updateSensorUnitlessPercent(float period) {
+    setSensorUnitlessPercentPeriod(period);
+  }
+
 protected:
   TwoWire *_i2c;           ///< Pointer to the I2C driver's Wire object
   uint16_t _sensorAddress; ///< The I2C driver's unique I2C address.
@@ -1177,6 +1272,10 @@ protected:
   long _PM100SensorPeriod = 0L;         ///< The time period between reading the
                                         ///< pm100_std sensor's value.
   long _PM100SensorPeriodPrv = 0L;      ///< The time when the pm100_std sensor
+                                        ///< was last read.
+  long _unitlessPercentPeriod = 0L;     ///< The time period between reading the
+                                        ///< unitless % sensor's value.
+  long _unitlessPercentPeriodPrv = 0L;  ///< The time when the unit % sensor
                                         ///< was last read.
 };
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -129,6 +129,12 @@ public:
         enableSensorUnitlessPercent();
         setSensorUnitlessPercent(
             msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
+        break;
+      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_VOLTAGE:
+        enableSensorVoltage();
+        setSensorVoltage(
+            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
+        break;
       default:
         break;
       }
@@ -1226,6 +1232,90 @@ public:
     setSensorUnitlessPercentPeriod(period);
   }
 
+  /**************************** SENSOR_TYPE: VOLTAGE
+   * ****************************/
+  /*******************************************************************************/
+  /*!
+      @brief    Enables sensor's voltage readings, if it exists.
+  */
+  /*******************************************************************************/
+  virtual void enableSensorVoltage(){};
+
+  /*******************************************************************************/
+  /*!
+      @brief    Disables the sensor's voltage standard readings, if it
+     exists.
+  */
+  /*******************************************************************************/
+  virtual void disableSensorVoltage() { _voltagePeriod = 0.0L; }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the voltage sensor's period.
+      @returns  Time when the object voltage sensor should be polled, in
+     seconds.
+  */
+  /*********************************************************************************/
+  virtual long sensorVoltagePeriod() { return _voltagePeriod; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Sets the voltage sensor's return frequency.
+      @param    period
+                The time interval at which to return new data from the sensor.
+  */
+  /*******************************************************************************/
+  virtual void setSensorVoltagePeriod(float period) {
+    if (period == 0)
+      disableSensorVoltage();
+    // Period is in seconds, cast it to long and convert it to milliseconds
+    _voltagePeriod = (long)period * 1000;
+  }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the previous time interval at
+                which the voltage sensor was queried last.
+      @returns  Time when the voltage sensor was last queried, in seconds.
+  */
+  /*********************************************************************************/
+  virtual long SensorVoltagePeriodPrv() { return _voltagePeriodPrv; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Sets a timestamp for when the voltage sensor was queried.
+      @param    period
+                The time when the voltage sensor was queried last.
+  */
+  /*******************************************************************************/
+  virtual void setSensorVoltagePeriodPrv(long period) {
+    _voltagePeriodPrv = period;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Base implementation - Reads a voltage sensor and converts the
+                reading into the expected SI unit.
+      @param    voltageEvent
+                voltage sensor reading, in volts.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  virtual bool getEventVoltage(sensors_event_t *voltageEvent) { return false; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Updates the properties of a voltage sensor.
+      @param    period
+                A new time interval at which to return new data from the
+                voltage sensor.
+  */
+  /*******************************************************************************/
+  virtual void updateSensorVoltage(float period) {
+    setSensorVoltagePeriod(period);
+  }
+
 protected:
   TwoWire *_i2c;           ///< Pointer to the I2C driver's Wire object
   uint16_t _sensorAddress; ///< The I2C driver's unique I2C address.
@@ -1275,7 +1365,11 @@ protected:
                                         ///< was last read.
   long _unitlessPercentPeriod = 0L;     ///< The time period between reading the
                                         ///< unitless % sensor's value.
-  long _unitlessPercentPeriodPrv = 0L;  ///< The time when the unit % sensor
+  long _unitlessPercentPeriodPrv = 0L;  ///< The time when the unitless % sensor
+                                        ///< was last read.
+  long _voltagePeriod = 0L;             ///< The time period between reading the
+                                        ///< voltage sensor's value.
+  long _voltagePeriodPrv = 0L;          ///< The time when the voltage sensor
                                         ///< was last read.
 };
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -1190,7 +1190,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long SensorUnitlessPercentPeriodPrv() {
+  virtual long sensorUnitlessPercentPeriodPrv() {
     return _unitlessPercentPeriodPrv;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -1210,8 +1210,8 @@ public:
   /*!
       @brief    Base implementation - Reads a object unitless % std. sensor and
                 converts the reading into the expected SI unit.
-      @param    unitless %StdEvent
-                unitless % std. sensor reading, in ppm.
+      @param    unitlessPercentEvent
+                unitless %  sensor reading.
       @returns  True if the sensor event was obtained successfully, False
                 otherwise.
   */

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_LC709203F.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_LC709203F.h
@@ -1,0 +1,105 @@
+/*!
+ * @file WipperSnapper_I2C_Driver_LC709203F.h
+ *
+ * Device driver for the LC709203F LiPoly / LiIon Fuel Gauge and
+ * Battery Monitor.
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) Brent Rubell 2022 for Adafruit Industries.
+ *
+ * MIT license, all text here must be included in any redistribution.
+ *
+ */
+#ifndef WipperSnapper_I2C_Driver_LC709203F_H
+#define WipperSnapper_I2C_Driver_LC709203F_H
+
+#include "WipperSnapper_I2C_Driver.h"
+#include <Adafruit_LC709203F.h>
+
+/**************************************************************************/
+/*!
+    @brief  Class that provides a driver interface for a LC709203F sensor.
+*/
+/**************************************************************************/
+class WipperSnapper_I2C_Driver_LC709203F : public WipperSnapper_I2C_Driver {
+public:
+  /*******************************************************************************/
+  /*!
+      @brief    Constructor for a LC709203F sensor.
+      @param    i2c
+                The I2C interface.
+      @param    sensorAddress
+                The 7-bit I2C address of the sensor.
+  */
+  /*******************************************************************************/
+  WipperSnapper_I2C_Driver_LC709203F(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Destructor for an LC709203F sensor.
+  */
+  /*******************************************************************************/
+  ~WipperSnapper_I2C_Driver_LC709203F() { delete _tsl; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the LC709203F sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _lc = new Adafruit_LC709203F(_i2c);
+    if (!_lc->begin())
+      return false;
+
+    // Default settings from LC709203F demo:
+    // https://github.com/adafruit/Adafruit_LC709203F/blob/master/examples/LC709203F_demo/LC709203F_demo.ino
+    // NOTE: in the future, it would be nice if these able to be user-defined!
+    lc->setThermistorB(3950);
+    lc->setPackSize(LC709203F_APA_500MAH);
+    lc->setAlarmVoltage(3.8);
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Reads a voltage sensor and converts the
+                reading into the expected SI unit.
+      @param    voltageEvent
+                voltage sensor reading, in volts.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventVoltage(sensors_event_t *voltageEvent) {
+    voltageEvent->voltage = lc->cellVoltage();
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Reads a sensor's unitless % reading and
+                converts the reading into the expected SI unit.
+      @param    unitlessPercentEvent
+                unitless % sensor reading.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventUnitlessPercent(sensors_event_t *unitlessPercentEvent) {
+    unitlessPercentEvent->data[0] = lc->cellPercent();
+    return false;
+  }
+
+protected:
+  Adafruit_LC709203F *_lc; ///< Pointer to LC709203F sensor object
+};
+
+#endif // WipperSnapper_I2C_Driver_LC709203F

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_LC709203F.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_LC709203F.h
@@ -46,7 +46,7 @@ public:
       @brief    Destructor for an LC709203F sensor.
   */
   /*******************************************************************************/
-  ~WipperSnapper_I2C_Driver_LC709203F() { delete _tsl; }
+  ~WipperSnapper_I2C_Driver_LC709203F() { delete _lc; }
 
   /*******************************************************************************/
   /*!
@@ -55,16 +55,16 @@ public:
   */
   /*******************************************************************************/
   bool begin() {
-    _lc = new Adafruit_LC709203F(_i2c);
-    if (!_lc->begin())
+    _lc = new Adafruit_LC709203F();
+    if (!_lc->begin(_i2c))
       return false;
 
     // Default settings from LC709203F demo:
     // https://github.com/adafruit/Adafruit_LC709203F/blob/master/examples/LC709203F_demo/LC709203F_demo.ino
     // NOTE: in the future, it would be nice if these able to be user-defined!
-    lc->setThermistorB(3950);
-    lc->setPackSize(LC709203F_APA_500MAH);
-    lc->setAlarmVoltage(3.8);
+    _lc->setThermistorB(3950);
+    _lc->setPackSize(LC709203F_APA_500MAH);
+    _lc->setAlarmVoltage(3.8);
     return true;
   }
 
@@ -79,7 +79,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventVoltage(sensors_event_t *voltageEvent) {
-    voltageEvent->voltage = lc->cellVoltage();
+    voltageEvent->voltage = _lc->cellVoltage();
     return true;
   }
 
@@ -94,7 +94,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventUnitlessPercent(sensors_event_t *unitlessPercentEvent) {
-    unitlessPercentEvent->data[0] = lc->cellPercent();
+    unitlessPercentEvent->data[0] = _lc->cellPercent();
     return false;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_LC709203F.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_LC709203F.h
@@ -95,7 +95,7 @@ public:
   /*******************************************************************************/
   bool getEventUnitlessPercent(sensors_event_t *unitlessPercentEvent) {
     unitlessPercentEvent->data[0] = _lc->cellPercent();
-    return false;
+    return true;
   }
 
 protected:


### PR DESCRIPTION
Adding support for [LC709203F LiPoly / LiIon Fuel Gauge and Battery Monitor](https://www.adafruit.com/product/4712).

This pull request also adds support for the unitless-percent Sensor Type.