### PR TITLE
add missing dependency (demo .ino build)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino client for Adafruit.io WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit SHT4x Library, Adafruit PM25 AQI Sensor, Adafruit LC709203F, Adafruit seesaw Library
+depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit SHT4x Library, Adafruit PM25 AQI Sensor, Adafruit LC709203F, Adafruit seesaw Library


### PR DESCRIPTION
When following the [add component guide](https://learn.adafruit.com/how-to-add-a-new-component-to-adafruit-io-wippersnapper/adding-an-i2c-component-driver), you are told to verify/compile the wippersnapper demo sketch, after installing the library dependencies manually.

  After installing all the mentioned dependencies, my demo build failed and said missing required library Adafruit MQTT Library.

This pull request adds that missing dependency. Worth retesting...