### PR TITLE
Fix servo not working on ESP32-S2

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.47
+version=1.0.0-beta.48
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -67,7 +67,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.47" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.48" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/ledc/drivers/ws_ledc_servo.cpp
+++ b/src/components/ledc/drivers/ws_ledc_servo.cpp
@@ -101,7 +101,6 @@ bool ws_ledc_servo::attached() { return _servo.Pin.isActive; }
 void ws_ledc_servo::writeMicroseconds(int value) {
   // are we attached to a pin?
   if (!attached()) {
-    Serial.println("NOT ATTACHED TO PIN!");
     return;
   }
 
@@ -111,12 +110,13 @@ void ws_ledc_servo::writeMicroseconds(int value) {
   if (value > _maxPulseWidth)
     value = _maxPulseWidth;
 
-  // formula from
+  // formula from ESP32Servo library
   // https://github.com/madhephaestus/ESP32Servo/blob/master/src/ESP32Servo.cpp
   // count = (pulse_high_width / (pulse_period/2**timer_width))
   // 50Hz servo =  20ms pulse_period
-  // count = pulse_high_width /((20000/65536))
-  uint32_t count = ((double)value / 0.30517578);
+  // count = pulse_high_width /((20000/2**timer_width))
+  // uint32_t count = ((double)value / ((double)20000/(double)pow(2, LEDC_TIMER_WIDTH)));
+  uint32_t count = ((double)value / ((double)20000/(double)4096));
   _ledcMgr->setDuty(_servo.Pin.nbr, count);
 }
 #endif // ARDUINO_ARCH_ESP32

--- a/src/components/ledc/drivers/ws_ledc_servo.cpp
+++ b/src/components/ledc/drivers/ws_ledc_servo.cpp
@@ -62,7 +62,8 @@ void ws_ledc_servo::setLEDCDriver(ws_ledc *ledcManager) {
 uint8_t ws_ledc_servo::attach(int pin, int minPulseWidth, int maxPulseWidth,
                               int servoFreq) {
   // Attempt to attach a pin to ledc channel
-  uint8_t chan = _ledcMgr->attachPin((uint8_t)pin, (double)servoFreq, LEDC_TIMER_WIDTH);
+  uint8_t chan =
+      _ledcMgr->attachPin((uint8_t)pin, (double)servoFreq, LEDC_TIMER_WIDTH);
   if (chan == 255) // error!
     return chan;
   // configure the servo object and assign it to a pin
@@ -114,7 +115,8 @@ void ws_ledc_servo::writeMicroseconds(int value) {
   // https://github.com/madhephaestus/ESP32Servo/blob/master/src/ESP32Servo.cpp
   // count = (pulse_high_width / (pulse_period/2**timer_width))
   // 50Hz servo =  20ms pulse_period
-  uint32_t count = ((double)value / ((double)20000/(double)pow(2, LEDC_TIMER_WIDTH)));
+  uint32_t count =
+      ((double)value / ((double)20000 / (double)pow(2, LEDC_TIMER_WIDTH)));
   _ledcMgr->setDuty(_servo.Pin.nbr, count);
 }
 #endif // ARDUINO_ARCH_ESP32

--- a/src/components/ledc/drivers/ws_ledc_servo.cpp
+++ b/src/components/ledc/drivers/ws_ledc_servo.cpp
@@ -62,7 +62,7 @@ void ws_ledc_servo::setLEDCDriver(ws_ledc *ledcManager) {
 uint8_t ws_ledc_servo::attach(int pin, int minPulseWidth, int maxPulseWidth,
                               int servoFreq) {
   // Attempt to attach a pin to ledc channel
-  uint8_t chan = _ledcMgr->attachPin((uint8_t)pin, (double)servoFreq);
+  uint8_t chan = _ledcMgr->attachPin((uint8_t)pin, (double)servoFreq, LEDC_TIMER_WIDTH);
   if (chan == 255) // error!
     return chan;
   // configure the servo object and assign it to a pin
@@ -114,9 +114,7 @@ void ws_ledc_servo::writeMicroseconds(int value) {
   // https://github.com/madhephaestus/ESP32Servo/blob/master/src/ESP32Servo.cpp
   // count = (pulse_high_width / (pulse_period/2**timer_width))
   // 50Hz servo =  20ms pulse_period
-  // count = pulse_high_width /((20000/2**timer_width))
-  // uint32_t count = ((double)value / ((double)20000/(double)pow(2, LEDC_TIMER_WIDTH)));
-  uint32_t count = ((double)value / ((double)20000/(double)4096));
+  uint32_t count = ((double)value / ((double)20000/(double)pow(2, LEDC_TIMER_WIDTH)));
   _ledcMgr->setDuty(_servo.Pin.nbr, count);
 }
 #endif // ARDUINO_ARCH_ESP32

--- a/src/components/ledc/drivers/ws_ledc_servo.h
+++ b/src/components/ledc/drivers/ws_ledc_servo.h
@@ -25,8 +25,13 @@
 #define MAX_PULSE_WIDTH 2400 ///< The longest pulse sent to a servo
 #define INVALID_SERVO 255    ///< Flag indicating an invalid servo index
 
-#define DEFAULT_SERVO_FREQ 50    ///< default servo frequency
-#define LEDC_TIMER_WIDTH 12     ///< timer width to request from LEDC manager component, in bits (NOTE: While ESP32x can go up to 16 bit timer width, ESP32-S2 does not work at this resolution. So, for the purposes of keeping this library compatible with multiple ESP32x platforms, the timer width has been scaled down to 10 bits and the calculation adjusted accordingly)
+#define DEFAULT_SERVO_FREQ 50 ///< default servo frequency
+#define LEDC_TIMER_WIDTH                                                       \
+  12 ///< timer width to request from LEDC manager component, in bits (NOTE:
+     ///< While ESP32x can go up to 16 bit timer width, ESP32-S2 does not work
+     ///< at this resolution. So, for the purposes of keeping this library
+     ///< compatible with multiple ESP32x platforms, the timer width has been
+     ///< scaled down to 10 bits and the calculation adjusted accordingly)
 
 /** Defines a servo attached to a pin */
 typedef struct {

--- a/src/components/ledc/drivers/ws_ledc_servo.h
+++ b/src/components/ledc/drivers/ws_ledc_servo.h
@@ -26,6 +26,7 @@
 #define INVALID_SERVO 255    ///< Flag indicating an invalid servo index
 
 #define DEFAULT_SERVO_FREQ 50    ///< default servo frequency
+#define LEDC_TIMER_WIDTH 10     ///< LEDC timer width of 10 bits (NOTE: While ESP32x can go up to 16 bit timer width, ESP32-S2 does not work at this resolution. So, for the purposes of keeping this library compatible with multiple ESP32x platforms, the timer width has been scaled down to 10 bits and the calculation adjusted accordingly)
 #define MAX_SERVOS MAX_LEDC_PWMS ///< Maximum number of servo instance
 
 /** Defines a servo attached to a pin */

--- a/src/components/ledc/drivers/ws_ledc_servo.h
+++ b/src/components/ledc/drivers/ws_ledc_servo.h
@@ -26,8 +26,7 @@
 #define INVALID_SERVO 255    ///< Flag indicating an invalid servo index
 
 #define DEFAULT_SERVO_FREQ 50    ///< default servo frequency
-#define LEDC_TIMER_WIDTH 10     ///< LEDC timer width of 10 bits (NOTE: While ESP32x can go up to 16 bit timer width, ESP32-S2 does not work at this resolution. So, for the purposes of keeping this library compatible with multiple ESP32x platforms, the timer width has been scaled down to 10 bits and the calculation adjusted accordingly)
-#define MAX_SERVOS MAX_LEDC_PWMS ///< Maximum number of servo instance
+#define LEDC_TIMER_WIDTH 12     ///< timer width to request from LEDC manager component, in bits (NOTE: While ESP32x can go up to 16 bit timer width, ESP32-S2 does not work at this resolution. So, for the purposes of keeping this library compatible with multiple ESP32x platforms, the timer width has been scaled down to 10 bits and the calculation adjusted accordingly)
 
 /** Defines a servo attached to a pin */
 typedef struct {

--- a/src/components/ledc/ws_ledc.cpp
+++ b/src/components/ledc/ws_ledc.cpp
@@ -116,7 +116,7 @@ uint8_t ws_ledc::_allocateChannel(double freq) {
     return 255;
 
   // attempt to set up a ledc_timer on the free channel
-  double rc = ledcSetup(uint8_t(chanNum), freq, 16);
+  double rc = ledcSetup(uint8_t(chanNum), freq , 12);
   if (rc == 0)
     return 255;
 

--- a/src/components/ledc/ws_ledc.cpp
+++ b/src/components/ledc/ws_ledc.cpp
@@ -46,12 +46,13 @@ ws_ledc::~ws_ledc() {
 /*!
     @brief  Allocates a timer + channel for a pin and attaches it.
     @param  pin  Desired GPIO pin number.
-    @param  freq Desired timer frequency, in Hz.
+    @param  freq Desired LEDC timer frequency, in Hz.
+    @param  resolution Desired LEDC timer resolution, in bits.
     @return The channel number if the pin was successfully attached,
             otherwise 255.
 */
 /**************************************************************************/
-uint8_t ws_ledc::attachPin(uint8_t pin, double freq) {
+uint8_t ws_ledc::attachPin(uint8_t pin, double freq, uint8_t resolution) {
   // have we already attached this pin?
   for (int i = 0; i < MAX_LEDC_PWMS; i++) {
     if (_ledcPins[i].pin == pin)
@@ -59,7 +60,7 @@ uint8_t ws_ledc::attachPin(uint8_t pin, double freq) {
   }
 
   // allocate chanel
-  uint8_t chanNum = _allocateChannel(freq);
+  uint8_t chanNum = _allocateChannel(freq, resolution);
   if (chanNum == 255)
     return chanNum;
 
@@ -96,12 +97,13 @@ void ws_ledc::detachPin(uint8_t pin) {
 /**************************************************************************/
 /*!
     @brief  Allocates a channel and timer.
-    @param  freq Desired timer frequency, in Hz.
+    @param  freq Desired LEDC timer frequency, in Hz.
+    @param  resolution Desired LEDC timer resolution, in bits.
     @return The channel number if the timer was successfully initialized,
             otherwise 255.
 */
 /**************************************************************************/
-uint8_t ws_ledc::_allocateChannel(double freq) {
+uint8_t ws_ledc::_allocateChannel(double freq, uint8_t resolution) {
   // attempt to allocate an inactive channel
   uint8_t chanNum = 255;
   for (int i = 0; i < MAX_LEDC_PWMS; i++) {
@@ -116,7 +118,7 @@ uint8_t ws_ledc::_allocateChannel(double freq) {
     return 255;
 
   // attempt to set up a ledc_timer on the free channel
-  double rc = ledcSetup(uint8_t(chanNum), freq , 12);
+  double rc = ledcSetup(uint8_t(chanNum), freq , resolution);
   if (rc == 0)
     return 255;
 

--- a/src/components/ledc/ws_ledc.cpp
+++ b/src/components/ledc/ws_ledc.cpp
@@ -118,7 +118,7 @@ uint8_t ws_ledc::_allocateChannel(double freq, uint8_t resolution) {
     return 255;
 
   // attempt to set up a ledc_timer on the free channel
-  double rc = ledcSetup(uint8_t(chanNum), freq , resolution);
+  double rc = ledcSetup(uint8_t(chanNum), freq, resolution);
   if (rc == 0)
     return 255;
 

--- a/src/components/ledc/ws_ledc.h
+++ b/src/components/ledc/ws_ledc.h
@@ -24,8 +24,6 @@
 #define MAX_LEDC_PWMS                                                          \
   16 ///< maximum # of LEDC channels (see: LEDC Chan to Group/Channel/Timer
      ///< Mapping)
-#define LEDC_RESOLUTION 10 ///< max LEDC resolution
-#define MAX_TIMER_WIDTH 20 ///< max LEDC esp32 timer width
 
 /** Defines a pin attached to an active LEDC timer group */
 typedef struct {
@@ -51,12 +49,12 @@ class ws_ledc {
 public:
   ws_ledc();
   ~ws_ledc();
-  uint8_t attachPin(uint8_t pin, double freq);
+  uint8_t attachPin(uint8_t pin, double freq, uint8_t resolution);
   void detachPin(uint8_t pin);
   void setDuty(uint8_t pin, uint32_t duty);
 
 private:
-  uint8_t _allocateChannel(double freq);
+  uint8_t _allocateChannel(double freq, uint8_t resolution);
   ledcPin_t _ledcPins[MAX_LEDC_PWMS]; ///< Pool of usable LEDC pins
 };
 extern Wippersnapper WS;


### PR DESCRIPTION
Addresses https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/313

* Drops LEDC timer resolution for a servo to 12 bits,
 * Noting, while ESP32x can go up to a 16-bit timer width, ESP32-S2 does not work properly at this resolution. So, for the purposes of keeping this library compatible with multiple ESP32x platforms, the timer width has been scaled down to 12 bits and the calculation for the duty cycle was adjusted accordingly.
* Adds optional `resolution` parameter to `attachPin()` call in LEDC manager.
* Removes hardcoding within the `writeMicroseconds` `count` formula to accept a variable (#define'd) timer resolution.

Tested on:
Adafruit ESP32 Feather V2
Adafruit QT Py ESP32-S2