### PR TITLE
Support °F, large refactoring around I2C

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.50
+version=1.0.0-beta.51
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -67,7 +67,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.50" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.51" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -67,7 +67,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.49" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.50" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -378,6 +378,7 @@ void WipperSnapper_Component_I2C::updateI2CDeviceProperties(
            j++) {
         switch (msgDeviceUpdateReq->i2c_device_properties[j].sensor_type) {
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE:
+          // TODO: Change to: setSensorPeriod(sensor_type, period)?
           drivers[i]->setSensorAmbientTemperaturePeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -509,7 +509,29 @@ void WipperSnapper_Component_I2C::update() {
 
     // AMBIENT_TEMPERATURE sensor (°C)
     curTime = millis();
-    if ((*iter)->getSensorAmbientTempPeriod() != 0L &&
+
+    if ((*iter)->sensorAmbientTempPeriodElapsed(curTime)) {
+        if ((*iter)->getEventAmbientTemp(&event)) {
+            WS_DEBUG_PRINT("Sensor 0x");
+            WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
+            WS_DEBUG_PRINTLN("");
+            WS_DEBUG_PRINT("\tTemperature: ");
+            WS_DEBUG_PRINT(event.temperature);
+            WS_DEBUG_PRINTLN(" degrees C");
+
+            // pack event data into msg
+            fillEventMessage(
+                &msgi2cResponse, event.temperature,
+                wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE);
+
+            (*iter)->setSensorAmbientTempPeriodPrv(curTime);
+        } else {
+        WS_DEBUG_PRINTLN(
+            "ERROR: Failed to get ambient temperature sensor reading!");
+        }
+    }
+
+/*     if ((*iter)->getSensorAmbientTempPeriod() != 0L &&
         curTime - (*iter)->getSensorAmbientTempPeriodPrv() >
             (*iter)->getSensorAmbientTempPeriod()) {
       if ((*iter)->getEventAmbientTemp(&event)) {
@@ -530,7 +552,7 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINTLN(
             "ERROR: Failed to get ambient temperature sensor reading!");
       }
-    }
+    } */
 
     // Ambient Temperature sensor (°F)
     curTime = millis();

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -376,69 +376,14 @@ void WipperSnapper_Component_I2C::updateI2CDeviceProperties(
       // Update the properties of each driver
       for (int j = 0; j < msgDeviceUpdateReq->i2c_device_properties_count;
            j++) {
-        switch (msgDeviceUpdateReq->i2c_device_properties[j].sensor_type) {
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE:
-          // TODO: Change to: setSensorPeriod(sensor_type, period)?
-          drivers[i]->setSensorAmbientTemperaturePeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_OBJECT_TEMPERATURE:
-          drivers[i]->setSensorObjectTempPeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_RELATIVE_HUMIDITY:
-          drivers[i]->setSensorRelativeHumidityPeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PRESSURE:
-          drivers[i]->setSensorPressurePeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_CO2:
-          drivers[i]->setSensorCO2Period(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_ALTITUDE:
-          drivers[i]->setSensorAltitudePeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LIGHT:
-          drivers[i]->setSensorLightPeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM10_STD:
-          drivers[i]->setSensorPM10_STDPeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM25_STD:
-          drivers[i]->setSensorPM25_STDPeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM100_STD:
-          drivers[i]->setSensorPM100_STDPeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_VOLTAGE:
-          drivers[i]->setSensorVoltagePeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_UNITLESS_PERCENT:
-          drivers[i]->setSensorUnitlessPercentPeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_RAW:
-          drivers[i]->setSensorRawPeriod(
-              msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
-          break;
-        default:
-          _busStatusResponse =
-              wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_UNSUPPORTED_SENSOR;
-          WS_DEBUG_PRINTLN("ERROR: Unable to determine sensor_type!");
-          break;
-        }
+        drivers[i]->setSensorPeriod(
+            msgDeviceUpdateReq->i2c_device_properties[j].sensor_period,
+            msgDeviceUpdateReq->i2c_device_properties[j].sensor_type);
       }
     }
   }
+
+  // set response OK
   _busStatusResponse = wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_SUCCESS;
 }
 

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -509,10 +509,10 @@ void WipperSnapper_Component_I2C::update() {
 
     // AMBIENT_TEMPERATURE sensor (°C)
     curTime = millis();
-    if ((*iter)->sensorAmbientTemperaturePeriod() != 0L &&
-        curTime - (*iter)->sensorAmbientTemperaturePeriodPrv() >
-            (*iter)->sensorAmbientTemperaturePeriod()) {
-      if ((*iter)->getEventAmbientTemperature(&event)) {
+    if ((*iter)->getSensorAmbientTempPeriod() != 0L &&
+        curTime - (*iter)->getSensorAmbientTempPeriodPrv() >
+            (*iter)->getSensorAmbientTempPeriod()) {
+      if ((*iter)->getEventAmbientTemp(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
         WS_DEBUG_PRINTLN("");
@@ -525,7 +525,7 @@ void WipperSnapper_Component_I2C::update() {
             &msgi2cResponse, event.temperature,
             wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE);
 
-        (*iter)->setSensorAmbientTemperaturePeriodPrv(curTime);
+        (*iter)->setSensorAmbientTempPeriodPrv(curTime);
       } else {
         WS_DEBUG_PRINTLN(
             "ERROR: Failed to get ambient temperature sensor reading!");
@@ -534,10 +534,10 @@ void WipperSnapper_Component_I2C::update() {
 
     // Ambient Temperature sensor (°F)
     curTime = millis();
-    if ((*iter)->sensorAmbientTempFPeriod() != 0L &&
-        curTime - (*iter)->sensorAmbientTempFPeriodPrv() >
-            (*iter)->sensorAmbientTemperaturePeriod()) {
-      if ((*iter)->getEventAmbientTemperature(&event)) {
+    if ((*iter)->getSensorAmbientTempFPeriod() != 0L &&
+        curTime - (*iter)->getSensorAmbientTempFPeriodPrv() >
+            (*iter)->getSensorAmbientTempPeriod()) {
+      if ((*iter)->getEventAmbientTemp(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
         WS_DEBUG_PRINTLN("");
@@ -557,9 +557,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // OBJECT_TEMPERATURE sensor (°F)
     curTime = millis();
-    if ((*iter)->sensorObjectTempPeriod() != 0L &&
-        curTime - (*iter)->sensorObjectTempPeriodPrv() >
-            (*iter)->sensorObjectTempPeriod()) {
+    if ((*iter)->getSensorObjectTempPeriod() != 0L &&
+        curTime - (*iter)->getSensorObjectTempPeriodPrv() >
+            (*iter)->getSensorObjectTempPeriod()) {
       if ((*iter)->getEventObjectTemp(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -582,9 +582,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // OBJECT_TEMPERATURE sensor (°F)
     curTime = millis();
-    if ((*iter)->sensorObjectTempFPeriod() != 0L &&
-        curTime - (*iter)->sensorObjectTempFPeriodPrv() >
-            (*iter)->sensorObjectTempFPeriod()) {
+    if ((*iter)->getSensorObjectTempFPeriod() != 0L &&
+        curTime - (*iter)->getSensorObjectTempFPeriodPrv() >
+            (*iter)->getSensorObjectTempFPeriod()) {
       if ((*iter)->getEventObjectTempF(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -607,9 +607,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // RELATIVE_HUMIDITY sensor
     curTime = millis();
-    if ((*iter)->sensorRelativeHumidityPeriod() != 0L &&
-        curTime - (*iter)->sensorRelativeHumidityPeriodPrv() >
-            (*iter)->sensorRelativeHumidityPeriod()) {
+    if ((*iter)->getSensorRelativeHumidityPeriod() != 0L &&
+        curTime - (*iter)->getSensorRelativeHumidityPeriodPrv() >
+            (*iter)->getSensorRelativeHumidityPeriod()) {
       if ((*iter)->getEventRelativeHumidity(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -631,9 +631,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // PRESSURE sensor
     curTime = millis();
-    if ((*iter)->sensorPressurePeriod() != 0L &&
-        curTime - (*iter)->sensorPressurePeriodPrv() >
-            (*iter)->sensorPressurePeriod()) {
+    if ((*iter)->getSensorPressurePeriod() != 0L &&
+        curTime - (*iter)->getSensorPressurePeriodPrv() >
+            (*iter)->getSensorPressurePeriod()) {
       if ((*iter)->getEventPressure(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -654,8 +654,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // CO2 sensor
     curTime = millis();
-    if ((*iter)->sensorCO2Period() != 0L &&
-        curTime - (*iter)->sensorCO2PeriodPrv() > (*iter)->sensorCO2Period()) {
+    if ((*iter)->getSensorCO2Period() != 0L &&
+        curTime - (*iter)->getSensorCO2PeriodPrv() >
+            (*iter)->getSensorCO2Period()) {
       if ((*iter)->getEventCO2(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -674,9 +675,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // Altitude sensor
     curTime = millis();
-    if ((*iter)->sensorAltitudePeriod() != 0L &&
-        curTime - (*iter)->sensorAltitudePeriodPrv() >
-            (*iter)->sensorAltitudePeriod()) {
+    if ((*iter)->getSensorAltitudePeriod() != 0L &&
+        curTime - (*iter)->getSensorAltitudePeriodPrv() >
+            (*iter)->getSensorAltitudePeriod()) {
       if ((*iter)->getEventAltitude(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -697,9 +698,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // Light sensor
     curTime = millis();
-    if ((*iter)->sensorLightPeriod() != 0L &&
-        curTime - (*iter)->SensorLightPeriodPrv() >
-            (*iter)->sensorLightPeriod()) {
+    if ((*iter)->getSensorLightPeriod() != 0L &&
+        curTime - (*iter)->getSensorLightPeriodPrv() >
+            (*iter)->getSensorLightPeriod()) {
       if ((*iter)->getEventLight(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -720,9 +721,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // PM10_STD sensor
     curTime = millis();
-    if ((*iter)->sensorPM10_STDPeriod() != 0L &&
-        curTime - (*iter)->SensorPM10_STDPeriodPrv() >
-            (*iter)->sensorPM10_STDPeriod()) {
+    if ((*iter)->getSensorPM10_STDPeriod() != 0L &&
+        curTime - (*iter)->getSensorPM10_STDPeriodPrv() >
+            (*iter)->getSensorPM10_STDPeriod()) {
       if ((*iter)->getEventPM10_STD(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -743,9 +744,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // PM25_STD sensor
     curTime = millis();
-    if ((*iter)->sensorPM25_STDPeriod() != 0L &&
-        curTime - (*iter)->SensorPM25_STDPeriodPrv() >
-            (*iter)->sensorPM25_STDPeriod()) {
+    if ((*iter)->getSensorPM25_STDPeriod() != 0L &&
+        curTime - (*iter)->getSensorPM25_STDPeriodPrv() >
+            (*iter)->getSensorPM25_STDPeriod()) {
       if ((*iter)->getEventPM25_STD(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -766,9 +767,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // PM100_STD sensor
     curTime = millis();
-    if ((*iter)->sensorPM100_STDPeriod() != 0L &&
-        curTime - (*iter)->SensorPM100_STDPeriodPrv() >
-            (*iter)->sensorPM100_STDPeriod()) {
+    if ((*iter)->getSensorPM100_STDPeriod() != 0L &&
+        curTime - (*iter)->getSensorPM100_STDPeriodPrv() >
+            (*iter)->getSensorPM100_STDPeriod()) {
       if ((*iter)->getEventPM100_STD(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -789,9 +790,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // Voltage sensor
     curTime = millis();
-    if ((*iter)->sensorVoltagePeriod() != 0L &&
-        curTime - (*iter)->SensorVoltagePeriodPrv() >
-            (*iter)->sensorVoltagePeriod()) {
+    if ((*iter)->getSensorVoltagePeriod() != 0L &&
+        curTime - (*iter)->getSensorVoltagePeriodPrv() >
+            (*iter)->getSensorVoltagePeriod()) {
       if ((*iter)->getEventVoltage(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -812,9 +813,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // Unitless % sensor
     curTime = millis();
-    if ((*iter)->sensorUnitlessPercentPeriod() != 0L &&
-        curTime - (*iter)->sensorUnitlessPercentPeriodPrv() >
-            (*iter)->sensorUnitlessPercentPeriod()) {
+    if ((*iter)->getSensorUnitlessPercentPeriod() != 0L &&
+        curTime - (*iter)->getSensorUnitlessPercentPeriodPrv() >
+            (*iter)->getSensorUnitlessPercentPeriod()) {
       if ((*iter)->getEventUnitlessPercent(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -837,8 +838,9 @@ void WipperSnapper_Component_I2C::update() {
 
     // Raw sensor
     curTime = millis();
-    if ((*iter)->sensorRawPeriod() != 0L &&
-        curTime - (*iter)->sensorRawPeriodPrv() > (*iter)->sensorRawPeriod()) {
+    if ((*iter)->getSensorRawPeriod() != 0L &&
+        curTime - (*iter)->getSensorRawPeriodPrv() >
+            (*iter)->getSensorRawPeriod()) {
       if ((*iter)->getEventRaw(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -378,55 +378,55 @@ void WipperSnapper_Component_I2C::updateI2CDeviceProperties(
            j++) {
         switch (msgDeviceUpdateReq->i2c_device_properties[j].sensor_type) {
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE:
-          drivers[i]->updateSensorAmbientTemperature(
+          drivers[i]->setSensorAmbientTemperaturePeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_OBJECT_TEMPERATURE:
-          drivers[i]->updateSensorObjectTemp(
+          drivers[i]->setSensorObjectTempPeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_RELATIVE_HUMIDITY:
-          drivers[i]->updateSensorRelativeHumidity(
+          drivers[i]->setSensorRelativeHumidityPeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PRESSURE:
-          drivers[i]->updateSensorPressure(
+          drivers[i]->setSensorPressurePeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_CO2:
-          drivers[i]->updateSensorCO2(
+          drivers[i]->setSensorCO2Period(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_ALTITUDE:
-          drivers[i]->updateSensorAltitude(
+          drivers[i]->setSensorAltitudePeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LIGHT:
-          drivers[i]->updateSensorLight(
+          drivers[i]->setSensorLightPeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM10_STD:
-          drivers[i]->updateSensorPM10_STD(
+          drivers[i]->setSensorPM10_STDPeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM25_STD:
-          drivers[i]->updateSensorPM25_STD(
+          drivers[i]->setSensorPM25_STDPeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM100_STD:
-          drivers[i]->updateSensorPM100_STD(
+          drivers[i]->setSensorPM100_STDPeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_VOLTAGE:
-          drivers[i]->updateSensorVoltage(
+          drivers[i]->setSensorVoltagePeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_UNITLESS_PERCENT:
-          drivers[i]->updateSensorUnitlessPercent(
+          drivers[i]->setSensorUnitlessPercentPeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_RAW:
-          drivers[i]->updateSensorRaw(
+          drivers[i]->setSensorRawPeriod(
               msgDeviceUpdateReq->i2c_device_properties[j].sensor_period);
           break;
         default:

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -511,29 +511,6 @@ void WipperSnapper_Component_I2C::update() {
     curTime = millis();
 
     if ((*iter)->sensorAmbientTempPeriodElapsed(curTime)) {
-        if ((*iter)->getEventAmbientTemp(&event)) {
-            WS_DEBUG_PRINT("Sensor 0x");
-            WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
-            WS_DEBUG_PRINTLN("");
-            WS_DEBUG_PRINT("\tTemperature: ");
-            WS_DEBUG_PRINT(event.temperature);
-            WS_DEBUG_PRINTLN(" degrees C");
-
-            // pack event data into msg
-            fillEventMessage(
-                &msgi2cResponse, event.temperature,
-                wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE);
-
-            (*iter)->setSensorAmbientTempPeriodPrv(curTime);
-        } else {
-        WS_DEBUG_PRINTLN(
-            "ERROR: Failed to get ambient temperature sensor reading!");
-        }
-    }
-
-/*     if ((*iter)->getSensorAmbientTempPeriod() != 0L &&
-        curTime - (*iter)->getSensorAmbientTempPeriodPrv() >
-            (*iter)->getSensorAmbientTempPeriod()) {
       if ((*iter)->getEventAmbientTemp(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -552,7 +529,30 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINTLN(
             "ERROR: Failed to get ambient temperature sensor reading!");
       }
-    } */
+    }
+
+    /*     if ((*iter)->getSensorAmbientTempPeriod() != 0L &&
+            curTime - (*iter)->getSensorAmbientTempPeriodPrv() >
+                (*iter)->getSensorAmbientTempPeriod()) {
+          if ((*iter)->getEventAmbientTemp(&event)) {
+            WS_DEBUG_PRINT("Sensor 0x");
+            WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
+            WS_DEBUG_PRINTLN("");
+            WS_DEBUG_PRINT("\tTemperature: ");
+            WS_DEBUG_PRINT(event.temperature);
+            WS_DEBUG_PRINTLN(" degrees C");
+
+            // pack event data into msg
+            fillEventMessage(
+                &msgi2cResponse, event.temperature,
+                wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE);
+
+            (*iter)->setSensorAmbientTempPeriodPrv(curTime);
+          } else {
+            WS_DEBUG_PRINTLN(
+                "ERROR: Failed to get ambient temperature sensor reading!");
+          }
+        } */
 
     // Ambient Temperature sensor (°F)
     curTime = millis();

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -510,7 +510,9 @@ void WipperSnapper_Component_I2C::update() {
     // AMBIENT_TEMPERATURE sensor (°C)
     curTime = millis();
 
-    if ((*iter)->sensorAmbientTempPeriodElapsed(curTime)) {
+    if ((*iter)->getSensorAmbientTempPeriod() != 0L &&
+        curTime - (*iter)->getSensorAmbientTempPeriodPrv() >
+            (*iter)->getSensorAmbientTempPeriod()) {
       if ((*iter)->getEventAmbientTemp(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
@@ -530,29 +532,6 @@ void WipperSnapper_Component_I2C::update() {
             "ERROR: Failed to get ambient temperature sensor reading!");
       }
     }
-
-    /*     if ((*iter)->getSensorAmbientTempPeriod() != 0L &&
-            curTime - (*iter)->getSensorAmbientTempPeriodPrv() >
-                (*iter)->getSensorAmbientTempPeriod()) {
-          if ((*iter)->getEventAmbientTemp(&event)) {
-            WS_DEBUG_PRINT("Sensor 0x");
-            WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
-            WS_DEBUG_PRINTLN("");
-            WS_DEBUG_PRINT("\tTemperature: ");
-            WS_DEBUG_PRINT(event.temperature);
-            WS_DEBUG_PRINTLN(" degrees C");
-
-            // pack event data into msg
-            fillEventMessage(
-                &msgi2cResponse, event.temperature,
-                wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE);
-
-            (*iter)->setSensorAmbientTempPeriodPrv(curTime);
-          } else {
-            WS_DEBUG_PRINTLN(
-                "ERROR: Failed to get ambient temperature sensor reading!");
-          }
-        } */
 
     // Ambient Temperature sensor (°F)
     curTime = millis();

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -507,7 +507,7 @@ void WipperSnapper_Component_I2C::update() {
     // Event struct
     sensors_event_t event;
 
-    // AMBIENT_TEMPERATURE sensor
+    // AMBIENT_TEMPERATURE sensor (°C)
     curTime = millis();
     if ((*iter)->sensorAmbientTemperaturePeriod() != 0L &&
         curTime - (*iter)->sensorAmbientTemperaturePeriodPrv() >
@@ -532,7 +532,30 @@ void WipperSnapper_Component_I2C::update() {
       }
     }
 
-    // OBJECT_TEMPERATURE sensor
+    // Ambient Temperature sensor (°F)
+    curTime = millis();
+    if ((*iter)->sensorAmbientTempFPeriod() != 0L &&
+        curTime - (*iter)->sensorAmbientTempFPeriodPrv() >
+            (*iter)->sensorAmbientTemperaturePeriod()) {
+      if ((*iter)->getEventAmbientTemperature(&event)) {
+        WS_DEBUG_PRINT("Sensor 0x");
+        WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
+        WS_DEBUG_PRINTLN("");
+        WS_DEBUG_PRINT("\tAmbient Temp.: ");
+        WS_DEBUG_PRINT(event.temperature);
+        WS_DEBUG_PRINTLN("°F");
+
+        fillEventMessage(
+            &msgi2cResponse, event.temperature,
+            wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE_FAHRENHEIT);
+      } else {
+        WS_DEBUG_PRINTLN(
+            "ERROR: Failed to obtain ambient temp. (°F)) sensor reading!");
+      }
+      (*iter)->setSensorRawPeriodPrv(curTime);
+    }
+
+    // OBJECT_TEMPERATURE sensor (°F)
     curTime = millis();
     if ((*iter)->sensorObjectTempPeriod() != 0L &&
         curTime - (*iter)->sensorObjectTempPeriodPrv() >
@@ -553,7 +576,32 @@ void WipperSnapper_Component_I2C::update() {
         (*iter)->setSensorObjectTempPeriodPrv(curTime);
       } else {
         WS_DEBUG_PRINTLN(
-            "ERROR: Failed to get object temperature sensor reading!");
+            "ERROR: Failed to get object temperature sensor (°C) reading!");
+      }
+    }
+
+    // OBJECT_TEMPERATURE sensor (°F)
+    curTime = millis();
+    if ((*iter)->sensorObjectTempFPeriod() != 0L &&
+        curTime - (*iter)->sensorObjectTempFPeriodPrv() >
+            (*iter)->sensorObjectTempFPeriod()) {
+      if ((*iter)->getEventObjectTempF(&event)) {
+        WS_DEBUG_PRINT("Sensor 0x");
+        WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
+        WS_DEBUG_PRINTLN("");
+        WS_DEBUG_PRINT("\tTemperature: ");
+        WS_DEBUG_PRINT(event.temperature);
+        WS_DEBUG_PRINTLN("°F");
+
+        // pack event data into msg
+        fillEventMessage(
+            &msgi2cResponse, event.temperature,
+            wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_OBJECT_TEMPERATURE_FAHRENHEIT);
+
+        (*iter)->setSensorObjectTempPeriodPrv(curTime);
+      } else {
+        WS_DEBUG_PRINTLN(
+            "ERROR: Failed to get object temperature sensor (°F) reading!");
       }
     }
 

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -520,7 +520,6 @@ void WipperSnapper_Component_I2C::update() {
 
     // AMBIENT_TEMPERATURE sensor (°C)
     curTime = millis();
-
     if ((*iter)->getSensorAmbientTempPeriod() != 0L &&
         curTime - (*iter)->getSensorAmbientTempPeriodPrv() >
             (*iter)->getSensorAmbientTempPeriod()) {
@@ -548,14 +547,16 @@ void WipperSnapper_Component_I2C::update() {
     curTime = millis();
     if ((*iter)->getSensorAmbientTempFPeriod() != 0L &&
         curTime - (*iter)->getSensorAmbientTempFPeriodPrv() >
-            (*iter)->getSensorAmbientTempPeriod()) {
-      if ((*iter)->getEventAmbientTemp(&event)) {
+            (*iter)->getSensorAmbientTempFPeriod()) {
+      if ((*iter)->getEventAmbientTempF(&event)) {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
         WS_DEBUG_PRINTLN("");
         WS_DEBUG_PRINT("\tAmbient Temp.: ");
         WS_DEBUG_PRINT(event.temperature);
         WS_DEBUG_PRINTLN("°F");
+
+        (*iter)->setSensorAmbientTempFPeriodPrv(curTime);
 
         fillEventMessage(
             &msgi2cResponse, event.temperature,
@@ -564,10 +565,9 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINTLN(
             "ERROR: Failed to obtain ambient temp. (°F)) sensor reading!");
       }
-      (*iter)->setSensorRawPeriodPrv(curTime);
     }
 
-    // OBJECT_TEMPERATURE sensor (°F)
+    // OBJECT_TEMPERATURE sensor (°C)
     curTime = millis();
     if ((*iter)->getSensorObjectTempPeriod() != 0L &&
         curTime - (*iter)->getSensorObjectTempPeriodPrv() >
@@ -578,7 +578,7 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINTLN("");
         WS_DEBUG_PRINT("\tTemperature: ");
         WS_DEBUG_PRINT(event.temperature);
-        WS_DEBUG_PRINTLN(" degrees C");
+        WS_DEBUG_PRINTLN("°C");
 
         // pack event data into msg
         fillEventMessage(
@@ -610,7 +610,7 @@ void WipperSnapper_Component_I2C::update() {
             &msgi2cResponse, event.temperature,
             wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_OBJECT_TEMPERATURE_FAHRENHEIT);
 
-        (*iter)->setSensorObjectTempPeriodPrv(curTime);
+        (*iter)->setSensorObjectTempFPeriodPrv(curTime);
       } else {
         WS_DEBUG_PRINTLN(
             "ERROR: Failed to get object temperature sensor (°F) reading!");

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -802,7 +802,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getAmbientTempF(sensors_event_t *AmbientTempFEvent) {
+  virtual bool getEventAmbientTempF(sensors_event_t *AmbientTempFEvent) {
     // obtain ambient temp. in °C
     if (!getEventAmbientTemp(AmbientTempFEvent))
       return false;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -56,14 +56,6 @@ public:
   /*******************************************************************************/
   bool begin() { return false; }
 
-  bool sensorAmbientTempPeriodElapsed(long curTime) {
-    if (getSensorAmbientTempPeriod() != 0L &&
-        curTime - getSensorAmbientTempPeriodPrv() >
-            getSensorAmbientTempPeriod())
-      return true;
-    return false;
-  }
-
   /*******************************************************************************/
   /*!
       @brief    Sets the sensor's period, provided a

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -1450,7 +1450,9 @@ public:
                 sensor.
   */
   /*******************************************************************************/
-  virtual void updateSensorAmbientTempF(float period) { setSensorAmbientTempFPeriod(period); }
+  virtual void updateSensorAmbientTempF(float period) {
+    setSensorAmbientTempFPeriod(period);
+  }
 
   /*********************************************************************************/
   /*!
@@ -1492,12 +1494,13 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getAmbientTempF(sensors_event_t *AmbientTempFEvent) { 
+  virtual bool getAmbientTempF(sensors_event_t *AmbientTempFEvent) {
     // obtain ambient temp. in °C
-    if (! getEventAmbientTemperature(AmbientTempFEvent))
-        return false;
+    if (!getEventAmbientTemperature(AmbientTempFEvent))
+      return false;
     // convert event from °C to °F
-    AmbientTempFEvent->temperature = (AmbientTempFEvent->temperature * 9.0) / 5.0 + 32;
+    AmbientTempFEvent->temperature =
+        (AmbientTempFEvent->temperature * 9.0) / 5.0 + 32;
     return true;
   }
 
@@ -1558,12 +1561,12 @@ protected:
                                         ///< was last read.
   long _rawSensorPeriod =
       0L; ///< The time period between reading the Raw sensor's value.
-  long _rawSensorPeriodPrv = 0L; ///< The time when the Raw sensor
-                                 ///< was last read.
-  long _ambientTempFPeriod =
-      0L; ///< The time period between reading the ambient temp. (degF) sensor's value.
-  long _ambientTempFPeriodPrv = 0L; ///< The time when the ambient temp. (degF) sensor
-                                 ///< was last read.
+  long _rawSensorPeriodPrv = 0L;    ///< The time when the Raw sensor
+                                    ///< was last read.
+  long _ambientTempFPeriod = 0L;    ///< The time period between reading the
+                                    ///< ambient temp. (degF) sensor's value.
+  long _ambientTempFPeriodPrv = 0L; ///< The time when the ambient temp. (degF)
+                                    ///< sensor was last read.
 };
 
 #endif // WipperSnapper_I2C_Driver_H

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -59,6 +59,58 @@ public:
   // TODO: consider passing sensor type into enable/disable/set sensor period
   // calls
 
+  void setSensorPeriod(float period,
+                       wippersnapper_i2c_v1_SensorType sensorType) {
+    long sensorPeriod = (long)period * 1000;
+
+    switch (sensorType) {
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE:
+      _tempSensorPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_RELATIVE_HUMIDITY:
+      _humidSensorPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PRESSURE:
+      _pressureSensorPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_CO2:
+      _CO2SensorPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_ALTITUDE:
+      _altitudeSensorPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_OBJECT_TEMPERATURE:
+      _objectTempSensorPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LIGHT:
+      _lightSensorPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM10_STD:
+      _PM10SensorPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM25_STD:
+      _PM25SensorPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM100_STD:
+      _PM100SensorPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_UNITLESS_PERCENT:
+      _unitlessPercentPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_VOLTAGE:
+      _voltagePeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_RAW:
+      _rawSensorPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE_FAHRENHEIT:
+      _ambientTempFPeriod = sensorPeriod;
+      break;
+    default:
+      break;
+    }
+  }
+
   /*******************************************************************************/
   /*!
       @brief    Uses an I2CDeviceInitRequest message to configure the sensors
@@ -69,83 +121,12 @@ public:
   /*******************************************************************************/
   void
   configureDriver(wippersnapper_i2c_v1_I2CDeviceInitRequest *msgDeviceInitReq) {
-    int propertyIdx = 0;
+    int propertyIdx = 0; // contains the amount of i2c sensors in the
+                         // msgDeviceInitReq to configure
     while (propertyIdx < msgDeviceInitReq->i2c_device_properties_count) {
-      switch (
-          msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_type) {
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE:
-        enableSensorAmbientTemperature();
-        setSensorAmbientTemperaturePeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_RELATIVE_HUMIDITY:
-        enableSensorRelativeHumidity();
-        setSensorRelativeHumidityPeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PRESSURE:
-        enableSensorPressure();
-        setSensorPressurePeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_CO2:
-        enableSensorCO2();
-        setSensorCO2Period(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_ALTITUDE:
-        enableSensorAltitude();
-        setSensorAltitudePeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_OBJECT_TEMPERATURE:
-        enableSensorObjectTemp();
-        setSensorObjectTempPeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LIGHT:
-        enableSensorLight();
-        setSensorLightPeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM10_STD:
-        enableSensorPM10_STD();
-        setSensorPM10_STDPeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM25_STD:
-        enableSensorPM25_STD();
-        setSensorPM25_STDPeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM100_STD:
-        enableSensorPM100_STD();
-        setSensorPM100_STDPeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_UNITLESS_PERCENT:
-        enableSensorUnitlessPercent();
-        setSensorUnitlessPercentPeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_VOLTAGE:
-        enableSensorVoltage();
-        setSensorVoltagePeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_RAW:
-        enableSensorRaw();
-        setSensorRawPeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE_FAHRENHEIT:
-        enableSensorAmbientTempF();
-        setSensorAmbientTempFPeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
-      default:
-        break;
-      }
+      setSensorPeriod(
+          msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period,
+          msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_type);
       ++propertyIdx;
     }
   }
@@ -173,23 +154,6 @@ public:
   */
   /*******************************************************************************/
   virtual void disableSensorCO2() { _CO2SensorPeriod = 0.0L; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Set the co2 sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the
-     co2 sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorCO2Period(float period) {
-    if (period == 0.0) {
-      disableSensorCO2();
-      return;
-    }
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _CO2SensorPeriod = (long)period * 1000;
-  }
 
   /*********************************************************************************/
   /*!
@@ -258,23 +222,6 @@ public:
   /*********************************************************************************/
   virtual long sensorAmbientTemperaturePeriod() { return _tempSensorPeriod; }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Sets the ambient temperature (°C) sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the ambient
-                temperature sensor (°C).
-  */
-  /*******************************************************************************/
-  virtual void setSensorAmbientTemperaturePeriod(float period) {
-    if (period == 0.0) {
-      disableSensorAmbientTemperature();
-      return;
-    }
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _tempSensorPeriod = (long)period * 1000;
-  }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the previous time interval at
@@ -339,23 +286,6 @@ public:
   /*********************************************************************************/
   virtual long sensorRelativeHumidityPeriod() { return _humidSensorPeriod; }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Set the humidity sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the humidity
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorRelativeHumidityPeriod(float period) {
-    if (period == 0.0) {
-      disableSensorRelativeHumidity();
-      return;
-    }
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _humidSensorPeriod = (long)period * 1000;
-  }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the previous time interval at
@@ -417,21 +347,6 @@ public:
   /*********************************************************************************/
   virtual long sensorPressurePeriod() { return _pressureSensorPeriod; }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Set the pressure sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the pressure
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorPressurePeriod(float period) {
-    if (period == 0.0)
-      disableSensorPressure();
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _pressureSensorPeriod = (long)period * 1000;
-  }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the previous time interval at
@@ -490,21 +405,6 @@ public:
   */
   /*********************************************************************************/
   virtual long sensorAltitudePeriod() { return _altitudeSensorPeriod; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Set the Altitude sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the Altitude
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorAltitudePeriod(float period) {
-    if (period == 0)
-      disableSensorAltitude();
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _altitudeSensorPeriod = (long)period * 1000;
-  }
 
   /*********************************************************************************/
   /*!
@@ -565,21 +465,6 @@ public:
   */
   /*********************************************************************************/
   virtual long sensorObjectTempPeriod() { return _objectTempSensorPeriod; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Set the object temperature sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the
-                object temperature sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorObjectTempPeriod(float period) {
-    if (period == 0)
-      disableSensorObjectTemp();
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _objectTempSensorPeriod = (long)period * 1000;
-  }
 
   /*********************************************************************************/
   /*!
@@ -645,21 +530,6 @@ public:
   /*********************************************************************************/
   virtual long sensorLightPeriod() { return _lightSensorPeriod; }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Set the object light sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the
-                object light sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorLightPeriod(float period) {
-    if (period == 0)
-      disableSensorLight();
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _lightSensorPeriod = (long)period * 1000;
-  }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the previous time interval at
@@ -719,21 +589,6 @@ public:
   */
   /*********************************************************************************/
   virtual long sensorPM10_STDPeriod() { return _PM10SensorPeriod; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Set the object PM10_STD sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the
-                object PM10_STD sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorPM10_STDPeriod(float period) {
-    if (period == 0)
-      disableSensorPM10_STD();
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _PM10SensorPeriod = (long)period * 1000;
-  }
 
   /*********************************************************************************/
   /*!
@@ -795,21 +650,6 @@ public:
   /*********************************************************************************/
   virtual long sensorPM25_STDPeriod() { return _PM25SensorPeriod; }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Set the object pm25_std sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the
-                object pm25_std sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorPM25_STDPeriod(float period) {
-    if (period == 0)
-      disableSensorPM25_STD();
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _PM25SensorPeriod = (long)period * 1000;
-  }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the previous time interval at
@@ -869,21 +709,6 @@ public:
   */
   /*********************************************************************************/
   virtual long sensorPM100_STDPeriod() { return _PM100SensorPeriod; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Set the object PM100_STD sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the
-                object PM100_STD sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorPM100_STDPeriod(float period) {
-    if (period == 0)
-      disableSensorPM100_STD();
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _PM100SensorPeriod = (long)period * 1000;
-  }
 
   /*********************************************************************************/
   /*!
@@ -947,20 +772,6 @@ public:
   */
   /*********************************************************************************/
   virtual long sensorUnitlessPercentPeriod() { return _unitlessPercentPeriod; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Set the unitless % sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorUnitlessPercentPeriod(float period) {
-    if (period == 0)
-      disableSensorUnitlessPercent();
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _unitlessPercentPeriod = (long)period * 1000;
-  }
 
   /*********************************************************************************/
   /*!
@@ -1026,20 +837,6 @@ public:
   /*********************************************************************************/
   virtual long sensorVoltagePeriod() { return _voltagePeriod; }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Sets the voltage sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorVoltagePeriod(float period) {
-    if (period == 0)
-      disableSensorVoltage();
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _voltagePeriod = (long)period * 1000;
-  }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the previous time interval at
@@ -1087,23 +884,6 @@ public:
   */
   /*******************************************************************************/
   virtual void disableSensorRaw() { _rawSensorPeriod = 0.0L; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Set the raw sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the
-     raw sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorRawPeriod(float period) {
-    if (period == 0.0) {
-      disableSensorRaw();
-      return;
-    }
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _rawSensorPeriod = (long)period * 1000;
-  }
 
   /*********************************************************************************/
   /*!
@@ -1162,23 +942,6 @@ public:
   */
   /*******************************************************************************/
   virtual void disableAmbientTempF() { _ambientTempFPeriod = 0.0L; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Set the ambient temperature (°F) sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the
-     ambient temperature (°F) sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorAmbientTempFPeriod(float period) {
-    if (period == 0.0) {
-      disableAmbientTempF();
-      return;
-    }
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _ambientTempFPeriod = (long)period * 1000;
-  }
 
   /*********************************************************************************/
   /*!

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -56,6 +56,9 @@ public:
   /*******************************************************************************/
   bool begin() { return false; }
 
+  // TODO: consider passing sensor type into enable/disable/set sensor period
+  // calls
+
   /*******************************************************************************/
   /*!
       @brief    Uses an I2CDeviceInitRequest message to configure the sensors
@@ -193,16 +196,6 @@ public:
     _CO2SensorPeriod = (long)period * 1000;
   }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a CO2 sensor.
-      @param    period
-                The time interval at which to return new data from the CO2
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorCO2(float period) { setSensorCO2Period(period); }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the co2 sensor's period, if
@@ -333,18 +326,6 @@ public:
   /*******************************************************************************/
   virtual bool getEventAmbientTemperature(float tempEvent) { return false; }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Base implementation - Update the properties of a temperature
-                  sensor, provided sensor_period.
-      @param    period
-                Sensor's period.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorAmbientTemperature(float period) {
-    setSensorAmbientTemperaturePeriod(period);
-  }
-
   /************************* SENSOR_TYPE: RELATIVE_HUMIDITY
    * ***********************/
   /*******************************************************************************/
@@ -435,18 +416,6 @@ public:
   /*******************************************************************************/
   virtual bool getEventRelativeHumidity(float humidEvent) { return false; }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a relative humidity sensor.
-      @param    period
-                The time interval at which to return new data from the humidity
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorRelativeHumidity(float period) {
-    setSensorRelativeHumidityPeriod(period);
-  }
-
   /**************************** SENSOR_TYPE: PRESSURE
    * ****************************/
   /*******************************************************************************/
@@ -533,18 +502,6 @@ public:
   /*******************************************************************************/
   virtual bool getEventPressure(float pressureEvent) { return false; }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a pressure sensor.
-      @param    period
-                The time interval at which to return new data from the pressure
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorPressure(float period) {
-    setSensorPressurePeriod(period);
-  }
-
   /**************************** SENSOR_TYPE: Gas
    * ****************************/
   /*******************************************************************************/
@@ -615,16 +572,6 @@ public:
   */
   /*******************************************************************************/
   virtual bool getEventGas(uint32_t gas_resistance) { return gas_resistance; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a gas sensor.
-      @param    period
-                The time interval at which to return new data from the Gas
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorGas(float period) { setSensorGasPeriod(period); }
 
   /**************************** SENSOR_TYPE: Altitude
    * ****************************/
@@ -698,18 +645,6 @@ public:
   /*******************************************************************************/
   virtual bool getEventAltitude(sensors_event_t *altitudeEvent) {
     return false;
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a Altitude sensor.
-      @param    period
-                The time interval at which to return new data from the altitude
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorAltitude(float period) {
-    setSensorAltitudePeriod(period);
   }
 
   /**************************** SENSOR_TYPE: Object_Temperature
@@ -791,18 +726,6 @@ public:
     return false;
   }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a object temperature sensor.
-      @param    period
-                The time interval at which to return new data from the
-                object temperature sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorObjectTemp(float period) {
-    setSensorObjectTempPeriod(period);
-  }
-
   /**************************** SENSOR_TYPE: LIGHT
    * ****************************/
   /*******************************************************************************/
@@ -877,16 +800,6 @@ public:
   */
   /*******************************************************************************/
   virtual bool getEventLight(sensors_event_t *lightEvent) { return false; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a object light sensor.
-      @param    period
-                The time interval at which to return new data from the
-                light sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorLight(float period) { setSensorLightPeriod(period); }
 
   /**************************** SENSOR_TYPE: PM10_STD
    * ****************************/
@@ -963,18 +876,6 @@ public:
   /*******************************************************************************/
   virtual bool getEventPM10_STD(sensors_event_t *pm10StdEvent) { return false; }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a object's pm10 std. sensor.
-      @param    period
-                The time interval at which to return new data from the
-                pm10 std. sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorPM10_STD(float period) {
-    setSensorPM10_STDPeriod(period);
-  }
-
   /**************************** SENSOR_TYPE: PM25_STD
    * ****************************/
   /*******************************************************************************/
@@ -1049,18 +950,6 @@ public:
   */
   /*******************************************************************************/
   virtual bool getEventPM25_STD(sensors_event_t *pm25StdEvent) { return false; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a object's pm25 std. sensor.
-      @param    period
-                The time interval at which to return new data from the
-                pm25 std. sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorPM25_STD(float period) {
-    setSensorPM25_STDPeriod(period);
-  }
 
   /**************************** SENSOR_TYPE: PM100_STD
    * ****************************/
@@ -1137,18 +1026,6 @@ public:
   /*******************************************************************************/
   virtual bool getEventPM100_STD(sensors_event_t *pm100StdEvent) {
     return false;
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a object's pm100 std. sensor.
-      @param    period
-                The time interval at which to return new data from the
-                pm100 std. sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorPM100_STD(float period) {
-    setSensorPM100_STDPeriod(period);
   }
 
   /**************************** SENSOR_TYPE: UNITLESS_PERCENT
@@ -1230,18 +1107,6 @@ public:
     return false;
   }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a unitless % sensor.
-      @param    period
-                The time interval at which to return new data from the
-                unitless % sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorUnitlessPercent(float period) {
-    setSensorUnitlessPercentPeriod(period);
-  }
-
   /**************************** SENSOR_TYPE: VOLTAGE
    * ****************************/
   /*******************************************************************************/
@@ -1314,18 +1179,6 @@ public:
   /*******************************************************************************/
   virtual bool getEventVoltage(sensors_event_t *voltageEvent) { return false; }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a voltage sensor.
-      @param    period
-                A new time interval at which to return new data from the
-                voltage sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorVoltage(float period) {
-    setSensorVoltagePeriod(period);
-  }
-
   /****************************** SENSOR_TYPE: Raw
    * *******************************/
   /*******************************************************************************/
@@ -1358,16 +1211,6 @@ public:
     // Period is in seconds, cast it to long and convert it to milliseconds
     _rawSensorPeriod = (long)period * 1000;
   }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a Raw sensor.
-      @param    period
-                The time interval at which to return new data from the Raw
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorRaw(float period) { setSensorRawPeriod(period); }
 
   /*********************************************************************************/
   /*!
@@ -1440,18 +1283,6 @@ public:
     }
     // Period is in seconds, cast it to long and convert it to milliseconds
     _ambientTempFPeriod = (long)period * 1000;
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a Raw sensor.
-      @param    period
-                The time interval at which to return new data from the Raw
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorAmbientTempF(float period) {
-    setSensorAmbientTempFPeriod(period);
   }
 
   /*********************************************************************************/

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -56,9 +56,15 @@ public:
   /*******************************************************************************/
   bool begin() { return false; }
 
-  // TODO: consider passing sensor type into enable/disable/set sensor period
-  // calls
-
+  /*******************************************************************************/
+  /*!
+      @brief    Sets the sensor's period, provided a
+     wippersnapper_i2c_v1_SensorType.
+      @param    period The period for the sensor to return values within, in
+     seconds.
+      @param    sensorType The type of sensor device.
+  */
+  /*******************************************************************************/
   void setSensorPeriod(float period,
                        wippersnapper_i2c_v1_SensorType sensorType) {
     long sensorPeriod = (long)period * 1000;
@@ -164,7 +170,7 @@ public:
       @returns  Time when the co2 sensor should be polled, in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorCO2Period() { return _CO2SensorPeriod; }
+  virtual long getSensorCO2Period() { return _CO2SensorPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -173,7 +179,7 @@ public:
       @returns  Time when the co2 sensor was last queried, in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorCO2PeriodPrv() { return _CO2SensorPeriodPrv; }
+  virtual long getSensorCO2PeriodPrv() { return _CO2SensorPeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -222,7 +228,7 @@ public:
       @returns  Time when the temperature sensor should be polled, in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorAmbientTemperaturePeriod() { return _tempSensorPeriod; }
+  virtual long getSensorAmbientTempPeriod() { return _tempSensorPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -232,9 +238,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorAmbientTemperaturePeriodPrv() {
-    return _tempSensorPeriodPrv;
-  }
+  virtual long getSensorAmbientTempPeriodPrv() { return _tempSensorPeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -245,7 +249,7 @@ public:
      last.
   */
   /*******************************************************************************/
-  virtual void setSensorAmbientTemperaturePeriodPrv(long periodPrv) {
+  virtual void setSensorAmbientTempPeriodPrv(long periodPrv) {
     _tempSensorPeriodPrv = periodPrv;
   }
 
@@ -259,9 +263,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
-    return false;
-  }
+  virtual bool getEventAmbientTemp(sensors_event_t *tempEvent) { return false; }
 
   /************************* SENSOR_TYPE: RELATIVE_HUMIDITY
    * ***********************/
@@ -286,7 +288,7 @@ public:
       @returns  Time when the humidity sensor should be polled, in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorRelativeHumidityPeriod() { return _humidSensorPeriod; }
+  virtual long getSensorRelativeHumidityPeriod() { return _humidSensorPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -295,7 +297,7 @@ public:
       @returns  Time when the humidity sensor was last queried, in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorRelativeHumidityPeriodPrv() {
+  virtual long getSensorRelativeHumidityPeriodPrv() {
     return _humidSensorPeriodPrv;
   }
 
@@ -347,7 +349,7 @@ public:
       @returns  Time when the pressure sensor should be polled, in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorPressurePeriod() { return _pressureSensorPeriod; }
+  virtual long getSensorPressurePeriod() { return _pressureSensorPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -356,7 +358,7 @@ public:
       @returns  Time when the pressure sensor was last queried, in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorPressurePeriodPrv() { return _pressureSensorPeriodPrv; }
+  virtual long getSensorPressurePeriodPrv() { return _pressureSensorPeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -406,7 +408,7 @@ public:
       @returns  Time when the Altitude sensor should be polled, in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorAltitudePeriod() { return _altitudeSensorPeriod; }
+  virtual long getSensorAltitudePeriod() { return _altitudeSensorPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -415,7 +417,7 @@ public:
       @returns  Time when the Altitude sensor was last queried, in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorAltitudePeriodPrv() { return _altitudeSensorPeriodPrv; }
+  virtual long getSensorAltitudePeriodPrv() { return _altitudeSensorPeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -466,7 +468,7 @@ public:
      seconds.
   */
   /*********************************************************************************/
-  virtual long sensorObjectTempPeriod() { return _objectTempSensorPeriod; }
+  virtual long getSensorObjectTempPeriod() { return _objectTempSensorPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -476,7 +478,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorObjectTempPeriodPrv() {
+  virtual long getSensorObjectTempPeriodPrv() {
     return _objectTempSensorPeriodPrv;
   }
 
@@ -530,7 +532,7 @@ public:
      seconds.
   */
   /*********************************************************************************/
-  virtual long sensorLightPeriod() { return _lightSensorPeriod; }
+  virtual long getSensorLightPeriod() { return _lightSensorPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -540,7 +542,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long SensorLightPeriodPrv() { return _lightSensorPeriodPrv; }
+  virtual long getSensorLightPeriodPrv() { return _lightSensorPeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -590,7 +592,7 @@ public:
      seconds.
   */
   /*********************************************************************************/
-  virtual long sensorPM10_STDPeriod() { return _PM10SensorPeriod; }
+  virtual long getSensorPM10_STDPeriod() { return _PM10SensorPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -600,7 +602,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long SensorPM10_STDPeriodPrv() { return _PM10SensorPeriodPrv; }
+  virtual long getSensorPM10_STDPeriodPrv() { return _PM10SensorPeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -650,7 +652,7 @@ public:
      seconds.
   */
   /*********************************************************************************/
-  virtual long sensorPM25_STDPeriod() { return _PM25SensorPeriod; }
+  virtual long getSensorPM25_STDPeriod() { return _PM25SensorPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -660,7 +662,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long SensorPM25_STDPeriodPrv() { return _PM25SensorPeriodPrv; }
+  virtual long getSensorPM25_STDPeriodPrv() { return _PM25SensorPeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -710,7 +712,7 @@ public:
      seconds.
   */
   /*********************************************************************************/
-  virtual long sensorPM100_STDPeriod() { return _PM100SensorPeriod; }
+  virtual long getSensorPM100_STDPeriod() { return _PM100SensorPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -720,7 +722,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long SensorPM100_STDPeriodPrv() { return _PM100SensorPeriodPrv; }
+  virtual long getSensorPM100_STDPeriodPrv() { return _PM100SensorPeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -773,7 +775,9 @@ public:
                 seconds.
   */
   /*********************************************************************************/
-  virtual long sensorUnitlessPercentPeriod() { return _unitlessPercentPeriod; }
+  virtual long getSensorUnitlessPercentPeriod() {
+    return _unitlessPercentPeriod;
+  }
 
   /*********************************************************************************/
   /*!
@@ -783,7 +787,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorUnitlessPercentPeriodPrv() {
+  virtual long getSensorUnitlessPercentPeriodPrv() {
     return _unitlessPercentPeriodPrv;
   }
 
@@ -837,7 +841,7 @@ public:
      seconds.
   */
   /*********************************************************************************/
-  virtual long sensorVoltagePeriod() { return _voltagePeriod; }
+  virtual long getSensorVoltagePeriod() { return _voltagePeriod; }
 
   /*********************************************************************************/
   /*!
@@ -846,7 +850,7 @@ public:
       @returns  Time when the voltage sensor was last queried, in seconds.
   */
   /*********************************************************************************/
-  virtual long SensorVoltagePeriodPrv() { return _voltagePeriodPrv; }
+  virtual long getSensorVoltagePeriodPrv() { return _voltagePeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -894,7 +898,7 @@ public:
       @returns  Time when the raw sensor should be polled, in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorRawPeriod() { return _rawSensorPeriod; }
+  virtual long getSensorRawPeriod() { return _rawSensorPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -903,7 +907,7 @@ public:
       @returns  Time when the raw sensor was last queried, in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorRawPeriodPrv() { return _rawSensorPeriodPrv; }
+  virtual long getSensorRawPeriodPrv() { return _rawSensorPeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -953,7 +957,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorAmbientTempFPeriod() { return _ambientTempFPeriod; }
+  virtual long getSensorAmbientTempFPeriod() { return _ambientTempFPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -963,7 +967,9 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorAmbientTempFPeriodPrv() { return _ambientTempFPeriodPrv; }
+  virtual long getSensorAmbientTempFPeriodPrv() {
+    return _ambientTempFPeriodPrv;
+  }
 
   /*******************************************************************************/
   /*!
@@ -981,7 +987,7 @@ public:
   /*******************************************************************************/
   /*!
       @brief    Helper function to obtain a sensor's ambient temperature value
-                in °F. Requires `getEventAmbientTemperature()` to be fully
+                in °F. Requires `getEventAmbientTemp()` to be fully
                 implemented by a driver.
       @param    AmbientTempFEvent
                 The ambient temperature value, in °F.
@@ -991,7 +997,7 @@ public:
   /*******************************************************************************/
   virtual bool getAmbientTempF(sensors_event_t *AmbientTempFEvent) {
     // obtain ambient temp. in °C
-    if (!getEventAmbientTemperature(AmbientTempFEvent))
+    if (!getEventAmbientTemp(AmbientTempFEvent))
       return false;
     // convert event from °C to °F
     AmbientTempFEvent->temperature =
@@ -1025,7 +1031,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorObjectTempFPeriod() { return _objectTempFPeriod; }
+  virtual long getSensorObjectTempFPeriod() { return _objectTempFPeriod; }
 
   /*********************************************************************************/
   /*!
@@ -1035,7 +1041,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long sensorObjectTempFPeriodPrv() { return _objectTempFPeriodPrv; }
+  virtual long getSensorObjectTempFPeriodPrv() { return _objectTempFPeriodPrv; }
 
   /*******************************************************************************/
   /*!

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -56,6 +56,13 @@ public:
   /*******************************************************************************/
   bool begin() { return false; }
 
+
+  bool sensorAmbientTempPeriodElapsed(long curTime) {
+    if (getSensorAmbientTempPeriod() != 0L && curTime - getSensorAmbientTempPeriodPrv() > getSensorAmbientTempPeriod())
+      return true;
+    return false;
+  }
+
   /*******************************************************************************/
   /*!
       @brief    Sets the sensor's period, provided a
@@ -1073,7 +1080,7 @@ public:
       return false;
     // convert event from °C to °F
     objectTempFEvent->temperature =
-        (objectTempFEvent->temperature * 9.0) / 5.0 + 32;
+        (objectTempFEvent->temperature * 9.0) / 5.0 + 32.0;
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -106,6 +106,8 @@ public:
     case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE_FAHRENHEIT:
       _ambientTempFPeriod = sensorPeriod;
       break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_OBJECT_TEMPERATURE_FAHRENHEIT:
+      _objectTempFPeriod = sensorPeriod;
     default:
       break;
     }
@@ -997,6 +999,78 @@ public:
     return true;
   }
 
+  /****************************** SENSOR_TYPE: Object Temp (°F)
+   * *******************************/
+  /*******************************************************************************/
+  /*!
+      @brief    Enables the device's object temperature (°F) sensor, if it
+     exists.
+  */
+  /*******************************************************************************/
+  virtual void enableSensorObjectTempF() { return; };
+
+  /*******************************************************************************/
+  /*!
+      @brief    Disables the device's object temperature (°F) sensor, if it
+     exists.
+  */
+  /*******************************************************************************/
+  virtual void disableSensorObjectTempF() { _objectTempFPeriod = 0.0L; }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the object temperature (°F)
+     sensor's period, if set.
+      @returns  Time when the object temperature sensor should be polled,
+                in seconds.
+  */
+  /*********************************************************************************/
+  virtual long sensorObjectTempFPeriod() { return _objectTempFPeriod; }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the previous time interval at
+                which the object temperature sensor (°F) was queried last.
+      @returns  Time when the object temperature sensor was last queried,
+                in seconds.
+  */
+  /*********************************************************************************/
+  virtual long sensorObjectTempFPeriodPrv() { return _objectTempFPeriodPrv; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Sets a timestamp for when the object temperature sensor (°F)
+                was queried.
+      @param    period
+                The time when the object temperature sensor (°F) was queried
+     last.
+  */
+  /*******************************************************************************/
+  virtual void setSensorObjectTempFPeriodPrv(long period) {
+    _objectTempFPeriodPrv = period;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Helper function to obtain a sensor's object temperature value
+                in °F. Requires `getEventObjectTemp()` to be fully
+                implemented by a driver.
+      @param    objectTempFEvent
+                The object temperature value, in °F.
+      @returns  True if the sensor value was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  virtual bool getEventObjectTempF(sensors_event_t *objectTempFEvent) {
+    // obtain ambient temp. in °C
+    if (!getEventObjectTemp(objectTempFEvent))
+      return false;
+    // convert event from °C to °F
+    objectTempFEvent->temperature =
+        (objectTempFEvent->temperature * 9.0) / 5.0 + 32;
+    return true;
+  }
+
 protected:
   TwoWire *_i2c;           ///< Pointer to the I2C driver's Wire object
   uint16_t _sensorAddress; ///< The I2C driver's unique I2C address.
@@ -1053,8 +1127,12 @@ protected:
   long _rawSensorPeriodPrv = 0L;    ///< The time when the Raw sensor
                                     ///< was last read.
   long _ambientTempFPeriod = 0L;    ///< The time period between reading the
-                                    ///< ambient temp. (degF) sensor's value.
-  long _ambientTempFPeriodPrv = 0L; ///< The time when the ambient temp. (degF)
+                                    ///< ambient temp. (°F) sensor's value.
+  long _ambientTempFPeriodPrv = 0L; ///< The time when the ambient temp. (°F)
+                                    ///< sensor was last read.
+  long _objectTempFPeriod = 0L;     ///< The time period between reading the
+                                    ///< object temp. (°F) sensor's value.
+  long _objectTempFPeriodPrv = 0L;  ///< The time when the object temp. (°F)
                                     ///< sensor was last read.
 };
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -140,6 +140,11 @@ public:
         setSensorRawPeriod(
             msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
         break;
+      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE_FAHRENHEIT:
+        enableSensorRaw();
+        setSensorRawPeriod(
+            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
+        break;
       default:
         break;
       }
@@ -1404,6 +1409,98 @@ public:
   /*******************************************************************************/
   virtual bool getEventRaw(sensors_event_t *rawEvent) { return false; }
 
+  /****************************** SENSOR_TYPE: Ambient Temp (degF)
+   * *******************************/
+  /*******************************************************************************/
+  /*!
+      @brief    Enables the device's Raw sensor, if it exists.
+  */
+  /*******************************************************************************/
+  virtual void enableSensorAmbientTempF() { return; };
+
+  /*******************************************************************************/
+  /*!
+      @brief    Disables the device's Raw sensor, if it exists.
+  */
+  /*******************************************************************************/
+  virtual void disableAmbientTempF() { _ambientTempFPeriod = 0.0L; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Set the raw sensor's return frequency.
+      @param    period
+                The time interval at which to return new data from the
+     raw sensor.
+  */
+  /*******************************************************************************/
+  virtual void setSensorAmbientTempFPeriod(float period) {
+    if (period == 0.0) {
+      disableAmbientTempF();
+      return;
+    }
+    // Period is in seconds, cast it to long and convert it to milliseconds
+    _ambientTempFPeriod = (long)period * 1000;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Updates the properties of a Raw sensor.
+      @param    period
+                The time interval at which to return new data from the Raw
+                sensor.
+  */
+  /*******************************************************************************/
+  virtual void updateSensorAmbientTempF(float period) { setSensorAmbientTempFPeriod(period); }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the raw sensor's period, if
+     set.
+      @returns  Time when the raw sensor should be polled, in seconds.
+  */
+  /*********************************************************************************/
+  virtual long sensorAmbientTempFPeriod() { return _ambientTempFPeriod; }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the previous time interval at
+                    which the raw sensor was queried last.
+      @returns  Time when the raw sensor was last queried, in seconds.
+  */
+  /*********************************************************************************/
+  virtual long sensorAmbientTempFPeriodPrv() { return _ambientTempFPeriodPrv; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Sets a timestamp for when the raw sensor was queried.
+      @param    period
+                The time when the raw sensor was queried last.
+  */
+  /*******************************************************************************/
+  virtual void setSensorAmbientTempFPeriodPrv(long period) {
+    _ambientTempFPeriodPrv = period;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Helper function to obtain a sensor's ambient temperature value
+                in °F. Requires `getEventAmbientTemperature()` to be fully
+                implemented by a driver.
+      @param    AmbientTempFEvent
+                The ambient temperature value, in °F.
+      @returns  True if the sensor value was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  virtual bool getAmbientTempF(sensors_event_t *AmbientTempFEvent) { 
+    // obtain ambient temp. in °C
+    if (! getEventAmbientTemperature(AmbientTempFEvent))
+        return false;
+    // convert event from °C to °F
+    AmbientTempFEvent->temperature = (AmbientTempFEvent->temperature * 9.0) / 5.0 + 32;
+    return true;
+  }
+
 protected:
   TwoWire *_i2c;           ///< Pointer to the I2C driver's Wire object
   uint16_t _sensorAddress; ///< The I2C driver's unique I2C address.
@@ -1462,6 +1559,10 @@ protected:
   long _rawSensorPeriod =
       0L; ///< The time period between reading the Raw sensor's value.
   long _rawSensorPeriodPrv = 0L; ///< The time when the Raw sensor
+                                 ///< was last read.
+  long _ambientTempFPeriod =
+      0L; ///< The time period between reading the ambient temp. (degF) sensor's value.
+  long _ambientTempFPeriodPrv = 0L; ///< The time when the ambient temp. (degF) sensor
                                  ///< was last read.
 };
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -93,11 +93,6 @@ public:
         setSensorCO2Period(
             msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
         break;
-      case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_GAS_RESISTANCE:
-        enableSensorGas();
-        setSensorGasPeriod(
-            msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
-        break;
       case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_ALTITUDE:
         enableSensorAltitude();
         setSensorAltitudePeriod(
@@ -144,8 +139,8 @@ public:
             msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
         break;
       case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_AMBIENT_TEMPERATURE_FAHRENHEIT:
-        enableSensorRaw();
-        setSensorRawPeriod(
+        enableSensorAmbientTempF();
+        setSensorAmbientTempFPeriod(
             msgDeviceInitReq->i2c_device_properties[propertyIdx].sensor_period);
         break;
       default:
@@ -236,26 +231,28 @@ public:
   /*******************************************************************************/
   virtual bool getEventCO2(sensors_event_t *co2Event) { return false; }
 
-  /********************** SENSOR_TYPE: AMBIENT TEMPERATURE
+  /********************** SENSOR_TYPE: AMBIENT TEMPERATURE (°C)
    * ***********************/
   /*******************************************************************************/
   /*!
-      @brief    Enables the device's temperature sensor, if it exists.
+      @brief    Enables the device's ambient temperature sensor (°C), if it
+     exists.
   */
   /*******************************************************************************/
   virtual void enableSensorAmbientTemperature() { return; };
 
   /*******************************************************************************/
   /*!
-      @brief    Disables the device's temperature sensor, if it exists.
+      @brief    Disables the device's ambient temperature sensor (°C), if it
+     exists.
   */
   /*******************************************************************************/
   virtual void disableSensorAmbientTemperature() { _tempSensorPeriod = 0.0L; }
 
   /*********************************************************************************/
   /*!
-      @brief    Base implementation - Returns the humidity sensor's period, if
-     set.
+      @brief    Base implementation - Returns the ambient temperature (°C)
+     sensor's period, if set.
       @returns  Time when the temperature sensor should be polled, in seconds.
   */
   /*********************************************************************************/
@@ -263,10 +260,10 @@ public:
 
   /*******************************************************************************/
   /*!
-      @brief    Set the temperature sensor's return frequency.
+      @brief    Sets the ambient temperature (°C) sensor's return frequency.
       @param    period
-                The time interval at which to return new data from the
-     temperature sensor.
+                The time interval at which to return new data from the ambient
+                temperature sensor (°C).
   */
   /*******************************************************************************/
   virtual void setSensorAmbientTemperaturePeriod(float period) {
@@ -281,8 +278,9 @@ public:
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the previous time interval at
-     which the temperature sensor was queried last.
-      @returns  Time when the temperature sensor was last queried, in seconds.
+                which the ambient temperature sensor (°C) was queried last.
+      @returns  Time when the ambient temperature sensor (°C) was last queried,
+                in seconds.
   */
   /*********************************************************************************/
   virtual long sensorAmbientTemperaturePeriodPrv() {
@@ -291,9 +289,11 @@ public:
 
   /*******************************************************************************/
   /*!
-      @brief    Sets a timestamp for when the temperature sensor was queried.
+      @brief    Sets a timestamp for when the ambient temperature sensor (°C)
+                was queried.
       @param    periodPrv
-                The time when the temperature sensor was queried last.
+                The time when the ambient temperature sensor (°C) was queried
+     last.
   */
   /*******************************************************************************/
   virtual void setSensorAmbientTemperaturePeriodPrv(long periodPrv) {
@@ -302,8 +302,8 @@ public:
 
   /*******************************************************************************/
   /*!
-      @brief    Base implementation - Reads a temperature sensor. Expects value
-                to return in the proper SI unit.
+      @brief    Base implementation - Reads an ambient temperature sensor (°C).
+                Expects value to return in the proper SI unit.
       @param    tempEvent
                 Pointer to an Adafruit_Sensor event.
       @returns  True if the sensor event was obtained successfully, False
@@ -313,18 +313,6 @@ public:
   virtual bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
     return false;
   }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Base implementation - Reads a temperature sensor. Expects value
-                to return in the proper SI unit.
-      @param    tempEvent
-                Pointer to an temperature value.
-      @returns  True if the sensor event was obtained successfully, False
-                otherwise.
-  */
-  /*******************************************************************************/
-  virtual bool getEventAmbientTemperature(float tempEvent) { return false; }
 
   /************************* SENSOR_TYPE: RELATIVE_HUMIDITY
    * ***********************/
@@ -404,18 +392,6 @@ public:
     return false;
   }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Base implementation - Reads a humidity sensor and converts
-                the reading into the expected SI unit.
-      @param    humidEvent
-                Pointer to a humidity value.
-      @returns  True if the sensor event was obtained successfully, False
-                otherwise.
-  */
-  /*******************************************************************************/
-  virtual bool getEventRelativeHumidity(float humidEvent) { return false; }
-
   /**************************** SENSOR_TYPE: PRESSURE
    * ****************************/
   /*******************************************************************************/
@@ -489,89 +465,6 @@ public:
   virtual bool getEventPressure(sensors_event_t *pressureEvent) {
     return false;
   }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Base implementation - Reads a pressure sensor and converts
-                the reading into the expected SI unit.
-      @param    pressureEvent
-                A pressure value
-      @returns  True if the sensor event was obtained successfully, False
-                otherwise.
-  */
-  /*******************************************************************************/
-  virtual bool getEventPressure(float pressureEvent) { return false; }
-
-  /**************************** SENSOR_TYPE: Gas
-   * ****************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the device's gas sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorGas(){};
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the device's gas sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorGas() { _gasSensorPeriod = 0.0L; }
-
-  /*********************************************************************************/
-  /*!
-      @brief    Base implementation - Returns the gas sensor's period, if set.
-      @returns  Time when the Gas sensor should be polled, in seconds.
-  */
-  /*********************************************************************************/
-  virtual long sensorGasPeriod() { return _gasSensorPeriod; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Set the gas sensor's return frequency.
-      @param    period
-                The time interval at which to return new data from the Gas
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void setSensorGasPeriod(float period) {
-    if (period == 0.0)
-      disableSensorGas();
-    // Period is in seconds, cast it to long and convert it to milliseconds
-    _gasSensorPeriod = (long)period * 1000;
-  }
-
-  /*********************************************************************************/
-  /*!
-      @brief    Base implementation - Returns the previous time interval at
-                    which the gas sensor was queried last.
-      @returns  Time when the gas sensor was last queried, in seconds.
-  */
-  /*********************************************************************************/
-  virtual long sensorGasPeriodPrv() { return _gasSensorPeriodPrv; }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Sets a timestamp for when the gas sensor was queried.
-      @param    period
-                The time when the gas sensor was queried last.
-  */
-  /*******************************************************************************/
-  virtual void setSensorGasPeriodPrv(long period) {
-    _gasSensorPeriodPrv = period;
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Base implementation - Reads a gas sensor and converts
-                the reading into the expected SI unit.
-      @param    gas_resistance
-                Gas resistor (ohms) reading.
-      @returns  True if the sensor event was obtained successfully, False
-                otherwise.
-  */
-  /*******************************************************************************/
-  virtual bool getEventGas(uint32_t gas_resistance) { return gas_resistance; }
 
   /**************************** SENSOR_TYPE: Altitude
    * ****************************/
@@ -1252,28 +1145,30 @@ public:
   /*******************************************************************************/
   virtual bool getEventRaw(sensors_event_t *rawEvent) { return false; }
 
-  /****************************** SENSOR_TYPE: Ambient Temp (degF)
+  /****************************** SENSOR_TYPE: Ambient Temp (°F)
    * *******************************/
   /*******************************************************************************/
   /*!
-      @brief    Enables the device's Raw sensor, if it exists.
+      @brief    Enables the device's ambient temperature (°F) sensor, if it
+     exists.
   */
   /*******************************************************************************/
   virtual void enableSensorAmbientTempF() { return; };
 
   /*******************************************************************************/
   /*!
-      @brief    Disables the device's Raw sensor, if it exists.
+      @brief    Disables the device's ambient temperature (°F) sensor, if it
+     exists.
   */
   /*******************************************************************************/
   virtual void disableAmbientTempF() { _ambientTempFPeriod = 0.0L; }
 
   /*******************************************************************************/
   /*!
-      @brief    Set the raw sensor's return frequency.
+      @brief    Set the ambient temperature (°F) sensor's return frequency.
       @param    period
                 The time interval at which to return new data from the
-     raw sensor.
+     ambient temperature (°F) sensor.
   */
   /*******************************************************************************/
   virtual void setSensorAmbientTempFPeriod(float period) {
@@ -1287,9 +1182,10 @@ public:
 
   /*********************************************************************************/
   /*!
-      @brief    Base implementation - Returns the raw sensor's period, if
-     set.
-      @returns  Time when the raw sensor should be polled, in seconds.
+      @brief    Base implementation - Returns the ambient temperature (°F)
+     sensor's period, if set.
+      @returns  Time when the ambient temperature sensor should be polled,
+                in seconds.
   */
   /*********************************************************************************/
   virtual long sensorAmbientTempFPeriod() { return _ambientTempFPeriod; }
@@ -1297,17 +1193,20 @@ public:
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the previous time interval at
-                    which the raw sensor was queried last.
-      @returns  Time when the raw sensor was last queried, in seconds.
+                which the ambient temperature sensor (°F) was queried last.
+      @returns  Time when the ambient temperature sensor was last queried,
+                in seconds.
   */
   /*********************************************************************************/
   virtual long sensorAmbientTempFPeriodPrv() { return _ambientTempFPeriodPrv; }
 
   /*******************************************************************************/
   /*!
-      @brief    Sets a timestamp for when the raw sensor was queried.
+      @brief    Sets a timestamp for when the ambient temperature sensor (°F)
+                was queried.
       @param    period
-                The time when the raw sensor was queried last.
+                The time when the ambient temperature sensor (°F) was queried
+     last.
   */
   /*******************************************************************************/
   virtual void setSensorAmbientTempFPeriodPrv(long period) {
@@ -1353,10 +1252,6 @@ protected:
   long _CO2SensorPeriod =
       0L; ///< The time period between reading the CO2 sensor's value.
   long _CO2SensorPeriodPrv = 0L; ///< The time when the CO2 sensor
-                                 ///< was last read.
-  long _gasSensorPeriod =
-      0L; ///< The time period between reading the CO2 sensor's value.
-  long _gasSensorPeriodPrv = 0L; ///< The time when the CO2 sensor
                                  ///< was last read.
   long _altitudeSensorPeriod =
       0L; ///< The time period between reading the altitude sensor's value.

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -56,9 +56,10 @@ public:
   /*******************************************************************************/
   bool begin() { return false; }
 
-
   bool sensorAmbientTempPeriodElapsed(long curTime) {
-    if (getSensorAmbientTempPeriod() != 0L && curTime - getSensorAmbientTempPeriodPrv() > getSensorAmbientTempPeriod())
+    if (getSensorAmbientTempPeriod() != 0L &&
+        curTime - getSensorAmbientTempPeriodPrv() >
+            getSensorAmbientTempPeriod())
       return true;
     return false;
   }
@@ -156,20 +157,6 @@ public:
 
   /****************************** SENSOR_TYPE: CO2
    * *******************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the device's CO2 sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorCO2() { return; };
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the device's CO2 sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorCO2() { _CO2SensorPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the co2 sensor's period, if
@@ -212,22 +199,6 @@ public:
 
   /********************** SENSOR_TYPE: AMBIENT TEMPERATURE (°C)
    * ***********************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the device's ambient temperature sensor (°C), if it
-     exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorAmbientTemperature() { return; };
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the device's ambient temperature sensor (°C), if it
-     exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorAmbientTemperature() { _tempSensorPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the ambient temperature (°C)
@@ -274,20 +245,6 @@ public:
 
   /************************* SENSOR_TYPE: RELATIVE_HUMIDITY
    * ***********************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the device's relative humidity sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorRelativeHumidity(){};
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the device's relative humidity sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorRelativeHumidity() { _humidSensorPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the humidity sensor's period, if
@@ -335,20 +292,6 @@ public:
 
   /**************************** SENSOR_TYPE: PRESSURE
    * ****************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the device's pressure sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorPressure(){};
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the device's pressure sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorPressure() { _pressureSensorPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the pressure sensor's period, if
@@ -394,20 +337,6 @@ public:
 
   /**************************** SENSOR_TYPE: Altitude
    * ****************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the device's Altitude sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorAltitude(){};
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the device's Altitude sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorAltitude() { _altitudeSensorPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the Altitude sensor's period, if
@@ -453,20 +382,6 @@ public:
 
   /**************************** SENSOR_TYPE: Object_Temperature
    * ****************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the device's object temperature sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorObjectTemp(){};
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the device's object temperature sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorObjectTemp() { _objectTempSensorPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the object temperature sensor's
@@ -517,20 +432,6 @@ public:
 
   /**************************** SENSOR_TYPE: LIGHT
    * ****************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the device's object light sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorLight(){};
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the device's object light sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorLight() { _lightSensorPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the object light sensor's
@@ -577,20 +478,6 @@ public:
 
   /**************************** SENSOR_TYPE: PM10_STD
    * ****************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables sensor's pm10 standard readings, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorPM10_STD(){};
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the sensor's pm10 standard readings, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorPM10_STD() { _PM10SensorPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the object pm10 standard sensors'
@@ -637,20 +524,6 @@ public:
 
   /**************************** SENSOR_TYPE: PM25_STD
    * ****************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables sensor's pm25 standard readings, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorPM25_STD(){};
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the sensor's pm25 standard readings, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorPM25_STD() { _lightSensorPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the object pm25 standard sensors'
@@ -697,20 +570,6 @@ public:
 
   /**************************** SENSOR_TYPE: PM100_STD
    * ****************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables sensor's pm100 standard readings, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorPM100_STD(){};
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the sensor's pm100 standard readings, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorPM100_STD() { _PM100SensorPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the object pm100 standard sensors'
@@ -759,21 +618,6 @@ public:
 
   /**************************** SENSOR_TYPE: UNITLESS_PERCENT
    * ****************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables sensor's unitless % readings, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorUnitlessPercent(){};
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the sensor's unitless % standard readings, if it
-     exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorUnitlessPercent() { _unitlessPercentPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the object unitless % sensor
@@ -826,21 +670,6 @@ public:
 
   /**************************** SENSOR_TYPE: VOLTAGE
    * ****************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables sensor's voltage readings, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorVoltage(){};
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the sensor's voltage standard readings, if it
-     exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorVoltage() { _voltagePeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the voltage sensor's period.
@@ -884,20 +713,6 @@ public:
 
   /****************************** SENSOR_TYPE: Raw
    * *******************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the device's Raw sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorRaw() { return; };
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the device's Raw sensor, if it exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorRaw() { _rawSensorPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the raw sensor's period, if
@@ -940,13 +755,6 @@ public:
 
   /****************************** SENSOR_TYPE: Ambient Temp (°F)
    * *******************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the device's ambient temperature (°F) sensor, if it
-     exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorAmbientTempF() { return; };
 
   /*******************************************************************************/
   /*!
@@ -1014,22 +822,6 @@ public:
 
   /****************************** SENSOR_TYPE: Object Temp (°F)
    * *******************************/
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the device's object temperature (°F) sensor, if it
-     exists.
-  */
-  /*******************************************************************************/
-  virtual void enableSensorObjectTempF() { return; };
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the device's object temperature (°F) sensor, if it
-     exists.
-  */
-  /*******************************************************************************/
-  virtual void disableSensorObjectTempF() { _objectTempFPeriod = 0.0L; }
-
   /*********************************************************************************/
   /*!
       @brief    Base implementation - Returns the object temperature (°F)

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_AHTX0.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_AHTX0.h
@@ -79,7 +79,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     // is sensor enabled correctly?
     if (_aht_temp == NULL)
       return false;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_AHTX0.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_AHTX0.h
@@ -58,47 +58,16 @@ public:
   */
   /*******************************************************************************/
   bool begin() {
+    // attempt
     _aht = new Adafruit_AHTX0();
-    bool isInit = _aht->begin(_i2c, (int32_t)_sensorAddress);
-    return isInit;
-  }
+    if (! _aht->begin(_i2c, (int32_t)_sensorAddress))
+        return false;
 
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the AHTX0's temperature sensor.
-  */
-  /*******************************************************************************/
-  void enableSensorAmbientTemperature() {
+    // get temperature and humidity sensor
     _aht_temp = _aht->getTemperatureSensor();
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the AHTX0's humidity sensor.
-  */
-  /*******************************************************************************/
-  void enableSensorRelativeHumidity() {
     _aht_humidity = _aht->getHumiditySensor();
-  }
 
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the AHTX0's temperature sensor.
-  */
-  /*******************************************************************************/
-  void disableSensorAmbientTemperature() {
-    _aht_temp = NULL; // TODO: change to nullptr instead!
-    _tempSensorPeriod = 0L;
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the AHTX0's humidity sensor.
-  */
-  /*******************************************************************************/
-  void disableSensorRelativeHumidity() {
-    _aht_humidity = NULL; // TODO: change to nullptr instead!
-    _humidSensorPeriod = 0L;
+    return true;
   }
 
   /*******************************************************************************/
@@ -111,12 +80,12 @@ public:
   */
   /*******************************************************************************/
   bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
-    // update temp, if sensor enabled
-    if (_aht_temp != NULL) {
-      _aht_temp->getEvent(tempEvent);
-      return true;
-    }
-    return false;
+    // is sensor enabled correctly?
+    if(_aht_temp == NULL)
+      return false;
+    // get event
+    _aht_temp->getEvent(tempEvent);
+    return true;
   }
 
   /*******************************************************************************/
@@ -129,12 +98,12 @@ public:
   */
   /*******************************************************************************/
   bool getEventRelativeHumidity(sensors_event_t *humidEvent) {
-    // update humidity, if sensor enabled
-    if (_aht_humidity != NULL) {
-      _aht_humidity->getEvent(humidEvent);
-      return true;
-    }
-    return false;
+    // is sensor enabled correctly?
+    if (_aht_humidity == NULL)
+      return false;
+    // get humidity
+    _aht_humidity->getEvent(humidEvent);
+    return true;
   }
 
 protected:

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_AHTX0.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_AHTX0.h
@@ -60,8 +60,8 @@ public:
   bool begin() {
     // attempt
     _aht = new Adafruit_AHTX0();
-    if (! _aht->begin(_i2c, (int32_t)_sensorAddress))
-        return false;
+    if (!_aht->begin(_i2c, (int32_t)_sensorAddress))
+      return false;
 
     // get temperature and humidity sensor
     _aht_temp = _aht->getTemperatureSensor();
@@ -81,7 +81,7 @@ public:
   /*******************************************************************************/
   bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
     // is sensor enabled correctly?
-    if(_aht_temp == NULL)
+    if (_aht_temp == NULL)
       return false;
     // get event
     _aht_temp->getEvent(tempEvent);

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
@@ -60,33 +60,15 @@ public:
   /*******************************************************************************/
   bool begin() {
     _bme = new Adafruit_BME280();
-    return _bme->begin(_sensorAddress, _i2c);
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the BME280's temperature sensor.
-  */
-  /*******************************************************************************/
-  void enableSensorAmbientTemperature() {
+    // attempt to initialize BME280
+    if (! _bme->begin(_sensorAddress, _i2c))
+        return false;
+    // configure BME280 device
     _bme_temp = _bme->getTemperatureSensor();
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the BME280's humidity sensor.
-  */
-  /*******************************************************************************/
-  void enableSensorRelativeHumidity() {
     _bme_humidity = _bme->getHumiditySensor();
+    _bme_pressure = _bme->getPressureSensor();
+    return true;
   }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the BME280's humidity sensor.
-  */
-  /*******************************************************************************/
-  void enableSensorPressure() { _bme_pressure = _bme->getPressureSensor(); }
 
   /*******************************************************************************/
   /*!

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
@@ -61,8 +61,8 @@ public:
   bool begin() {
     _bme = new Adafruit_BME280();
     // attempt to initialize BME280
-    if (! _bme->begin(_sensorAddress, _i2c))
-        return false;
+    if (!_bme->begin(_sensorAddress, _i2c))
+      return false;
     // configure BME280 device
     _bme_temp = _bme->getTemperatureSensor();
     _bme_humidity = _bme->getHumiditySensor();

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
@@ -97,7 +97,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     if (_bme_temp == NULL)
       return false;
     _bme_temp->getEvent(tempEvent);

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
@@ -60,8 +60,7 @@ public:
   /*******************************************************************************/
   bool begin() {
     _bme = new Adafruit_BME280();
-    bool isInit = _bme->begin(_sensorAddress, _i2c);
-    return isInit;
+    return _bme->begin(_sensorAddress, _i2c);
   }
 
   /*******************************************************************************/
@@ -88,89 +87,6 @@ public:
   */
   /*******************************************************************************/
   void enableSensorPressure() { _bme_pressure = _bme->getPressureSensor(); }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the BME280's temperature sensor.
-  */
-  /*******************************************************************************/
-  void disableSensorAmbientTemperature() {
-    _bme_temp = NULL;
-    _tempSensorPeriod = 0.0;
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the BME280's humidity sensor.
-  */
-  /*******************************************************************************/
-  void disableSensorRelativeHumidity() {
-    _bme_humidity = NULL;
-    _humidSensorPeriod = 0.0;
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the BME280's pressure sensor.
-  */
-  /*******************************************************************************/
-  void disableSensorPressure() {
-    _bme_pressure = NULL;
-    _pressureSensorPeriod = 0.0;
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a pressure sensor.
-      @param    period
-                The time interval at which to return new data from the pressure
-                sensor.
-  */
-  /*******************************************************************************/
-  virtual void updateSensorPressure(float period) {
-    // enable a previously disabled sensor
-    if (period > 0 && _bme_pressure == NULL)
-      enableSensorPressure();
-    setSensorPressurePeriod(period);
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of an ambient temperature
-                  sensor, provided sensor_period.
-      @param    period
-                Sensor's period.
-  */
-  /*******************************************************************************/
-  void updateSensorAmbientTemperature(float period) {
-    // disable the sensor
-    if (period == 0)
-      disableSensorAmbientTemperature();
-    // enable a previously disabled sensor
-    if (period > 0 && _bme_temp == NULL)
-      enableSensorAmbientTemperature();
-
-    setSensorAmbientTemperaturePeriod(period);
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a relative humidity sensor.
-      @param    period
-                The time interval at which to return new data from the humidity
-                sensor.
-  */
-  /*******************************************************************************/
-  void updateSensorRelativeHumidity(float period) {
-    // disable the sensor
-    if (period == 0)
-      disableSensorRelativeHumidity();
-    // enable a previously disabled sensor
-    if (period > 0 && _bme_humidity == NULL)
-      enableSensorRelativeHumidity();
-
-    setSensorRelativeHumidityPeriod(period);
-  }
 
   /*******************************************************************************/
   /*!

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_DPS310.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_DPS310.h
@@ -57,29 +57,21 @@ public:
   */
   /*******************************************************************************/
   bool begin() {
+    // initialize DPS310
     _dps310 = new Adafruit_DPS310();
-    return _dps310->begin_I2C((uint8_t)_sensorAddress, _i2c);
-  }
+    if (! _dps310->begin_I2C((uint8_t)_sensorAddress, _i2c))
+      return false;
 
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the DPS310's temperature sensor. Sets highest precision
-                options
-  */
-  /*******************************************************************************/
-  void enableSensorAmbientTemperature() {
+    // init OK, perform sensor configuration
     _dps310->configureTemperature(DPS310_64HZ, DPS310_64SAMPLES);
-    _dps_temp = _dps310->getTemperatureSensor();
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Enables the DPS310's pressure sensor.
-  */
-  /*******************************************************************************/
-  void enableSensorPressure() {
     _dps310->configurePressure(DPS310_64HZ, DPS310_64SAMPLES);
+    _dps_temp = _dps310->getTemperatureSensor();
     _dps_pressure = _dps310->getPressureSensor();
+    // check if sensors are configured properly
+    if (_dps_temp == NULL || _dps_pressure == NULL)
+      return false;
+
+    return true;
   }
 
   /*******************************************************************************/
@@ -92,7 +84,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventAmbientTemp(sensors_event_t *tempEvent) {
-    if (_dps_temp == NULL && (!_dps310->temperatureAvailable()))
+    if (! _dps310->temperatureAvailable())
       return false;
 
     _dps_temp->getEvent(tempEvent);
@@ -109,7 +101,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventPressure(sensors_event_t *pressureEvent) {
-    if (_dps_pressure == NULL && (!_dps310->pressureAvailable()))
+    if (! _dps310->pressureAvailable())
       return false;
 
     _dps_pressure->getEvent(pressureEvent);

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_DPS310.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_DPS310.h
@@ -91,7 +91,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     if (_dps_temp == NULL && (!_dps310->temperatureAvailable()))
       return false;
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_DPS310.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_DPS310.h
@@ -58,8 +58,7 @@ public:
   /*******************************************************************************/
   bool begin() {
     _dps310 = new Adafruit_DPS310();
-    bool isInit = _dps310->begin_I2C((uint8_t)_sensorAddress, _i2c);
-    return isInit;
+    return _dps310->begin_I2C((uint8_t)_sensorAddress, _i2c);
   }
 
   /*******************************************************************************/
@@ -85,64 +84,6 @@ public:
 
   /*******************************************************************************/
   /*!
-      @brief    Disables the DPS310's pressure sensor.
-  */
-  /*******************************************************************************/
-  void disableSensorAmbientTemperature() {
-    _dps_temp = NULL;
-    _tempSensorPeriod = 0L;
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Disables the DPS310's pressure sensor.
-  */
-  /*******************************************************************************/
-  void disableSensorPressure() {
-    _dps_pressure = NULL;
-    _pressureSensorPeriod = 0L;
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of an ambient temperature
-                  sensor, provided sensor_period.
-      @param    period
-                Sensor's period.
-  */
-  /*******************************************************************************/
-  void updateSensorAmbientTemperature(float period) {
-    // disable the sensor
-    if (period == 0)
-      disableSensorAmbientTemperature();
-    // enable a previously disabled sensor
-    if (period > 0 && _dps_temp == NULL)
-      enableSensorAmbientTemperature();
-
-    setSensorAmbientTemperaturePeriod(period);
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Updates the properties of a pressure sensor.
-      @param    period
-                The time interval at which to return new data from the pressure
-                sensor.
-  */
-  /*******************************************************************************/
-  void updateSensorPressure(float period) {
-    // disable the sensor
-    if (period == 0)
-      disableSensorPressure();
-    // enable a previously disabled sensor
-    if (period > 0 && _dps_pressure == NULL)
-      enableSensorPressure();
-
-    setSensorPressurePeriod(period);
-  }
-
-  /*******************************************************************************/
-  /*!
       @brief    Gets the DPS310's current temperature.
       @param    tempEvent
                 Pointer to an Adafruit_Sensor event.
@@ -151,11 +92,11 @@ public:
   */
   /*******************************************************************************/
   bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
-    if (_dps_temp != NULL && _dps310->temperatureAvailable()) {
-      _dps_temp->getEvent(tempEvent);
-      return true;
-    }
-    return false;
+    if (_dps_temp == NULL && (!_dps310->temperatureAvailable()))
+      return false;
+
+    _dps_temp->getEvent(tempEvent);
+    return true;
   }
 
   /*******************************************************************************/
@@ -168,11 +109,11 @@ public:
   */
   /*******************************************************************************/
   bool getEventPressure(sensors_event_t *pressureEvent) {
-    if (_dps_pressure != NULL && _dps310->pressureAvailable()) {
-      _dps_pressure->getEvent(pressureEvent);
-      return true;
-    }
-    return false;
+    if (_dps_pressure == NULL && (!_dps310->pressureAvailable()))
+      return false;
+
+    _dps_pressure->getEvent(pressureEvent);
+    return true;
   }
 
 protected:

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_DPS310.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_DPS310.h
@@ -59,7 +59,7 @@ public:
   bool begin() {
     // initialize DPS310
     _dps310 = new Adafruit_DPS310();
-    if (! _dps310->begin_I2C((uint8_t)_sensorAddress, _i2c))
+    if (!_dps310->begin_I2C((uint8_t)_sensorAddress, _i2c))
       return false;
 
     // init OK, perform sensor configuration
@@ -84,7 +84,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventAmbientTemp(sensors_event_t *tempEvent) {
-    if (! _dps310->temperatureAvailable())
+    if (!_dps310->temperatureAvailable())
       return false;
 
     _dps_temp->getEvent(tempEvent);
@@ -101,7 +101,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventPressure(sensors_event_t *pressureEvent) {
-    if (! _dps310->pressureAvailable())
+    if (!_dps310->pressureAvailable())
       return false;
 
     _dps_pressure->getEvent(pressureEvent);

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MCP9601.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MCP9601.h
@@ -83,7 +83,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     uint8_t status = _MCP9601->getStatus();
     if (status & MCP9601_STATUS_OPENCIRCUIT) {
       return false; // don't continue, since there's no thermocouple

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MCP9808.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MCP9808.h
@@ -58,8 +58,7 @@ public:
   /*******************************************************************************/
   bool begin() {
     _mcp9808 = new Adafruit_MCP9808();
-    bool isInit = _mcp9808->begin((uint8_t)_sensorAddress, _i2c);
-    return isInit;
+    return _mcp9808->begin((uint8_t)_sensorAddress, _i2c);
   }
 
   /*******************************************************************************/

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MCP9808.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MCP9808.h
@@ -70,7 +70,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     tempEvent->temperature = _mcp9808->readTempC();
     return true;
   }

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD30.h
@@ -50,8 +50,7 @@ public:
   /*******************************************************************************/
   bool begin() {
     _scd = new Adafruit_SCD30();
-    bool isInit = _scd->begin((uint8_t)_sensorAddress, _i2c);
-    return isInit;
+    return _scd->begin((uint8_t)_sensorAddress, _i2c);
   }
 
   /*******************************************************************************/

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD30.h
@@ -62,7 +62,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     // check if sensor is enabled and data is available
     if (_tempSensorPeriod != 0 && (!_scd->dataReady()))
       return false;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD40.h
@@ -75,7 +75,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     // check if sensor is enabled and data is available
     uint16_t co2;
     float temperature;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
@@ -72,7 +72,6 @@ public:
   */
   /*******************************************************************************/
   bool getEventAmbientTemp(sensors_event_t *tempEvent) {
-    sensors_event_t humidityEvent;
     // populate temp and humidity objects with fresh data
     if (!_sht4x->readSample())
       return false;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
@@ -71,7 +71,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     sensors_event_t humidityEvent;
     // populate temp and humidity objects with fresh data
     if (!_sht4x->getEvent(&humidityEvent, tempEvent))

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
@@ -56,7 +56,7 @@ public:
 
     // configure SHT4x sensor
     _sht4x->setPrecision(SHT4X_HIGH_PRECISION); // Use HIGH PRECISION
-    _sht4x->setHeater(SHT4X_NO_HEATER); // default, NO HEATER
+    _sht4x->setHeater(SHT4X_NO_HEATER);         // default, NO HEATER
 
     return true;
   }

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
@@ -54,10 +54,9 @@ public:
     if (!_sht4x->begin(_i2c))
       return false;
 
-    // Use HIGH PRECISION
-    _sht4x->setPrecision(SHT4X_HIGH_PRECISION);
-    // default, NO HEATER
-    _sht4x->setHeater(SHT4X_NO_HEATER);
+    // configure SHT4x sensor
+    _sht4x->setPrecision(SHT4X_HIGH_PRECISION); // Use HIGH PRECISION
+    _sht4x->setHeater(SHT4X_NO_HEATER); // default, NO HEATER
 
     return true;
   }

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
@@ -57,8 +57,7 @@ public:
       return false;
 
     // configure SHT4x sensor
-    _sht4x->setPrecision(SHT4X_HIGH_PRECISION); // Use HIGH PRECISION
-    _sht4x->setHeater(SHT4X_NO_HEATER);         // default, NO HEATER
+    _sht4x->setAccuracy(SHTSensor::SHT_ACCURACY_HIGH);
 
     return true;
   }

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SI7021.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SI7021.h
@@ -46,6 +46,16 @@ public:
 
   /*******************************************************************************/
   /*!
+      @brief    Destructor for an SI7021 sensor.
+  */
+  /*******************************************************************************/
+  ~WipperSnapper_I2C_Driver_SI7021() {
+    // Called when a Si7021 component is deleted.
+    delete _si7021;
+  }
+
+  /*******************************************************************************/
+  /*!
       @brief    Initializes the SI7021 sensor and begins I2C.
       @returns  True if initialized successfully, False otherwise.
   */
@@ -66,7 +76,6 @@ public:
   /*******************************************************************************/
   bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     // check if sensor is enabled and data is available
-
     tempEvent->temperature = _si7021->readTemperature();
     return true;
   }
@@ -82,19 +91,8 @@ public:
   /*******************************************************************************/
   bool getEventRelativeHumidity(sensors_event_t *humidEvent) {
     // check if sensor is enabled and data is available
-
     humidEvent->relative_humidity = _si7021->readHumidity();
     return true;
-  }
-
-  /*******************************************************************************/
-  /*!
-      @brief    Destructor for an SI7021 sensor.
-  */
-  /*******************************************************************************/
-  ~WipperSnapper_I2C_Driver_SI7021() {
-    // Called when a Si7021 component is deleted.
-    delete _si7021;
   }
 
 protected:

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SI7021.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SI7021.h
@@ -64,7 +64,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     // check if sensor is enabled and data is available
 
     tempEvent->temperature = _si7021->readTemperature();

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor.h
@@ -68,7 +68,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     tempEvent->temperature = _seesaw->getTemp();
     return true;
   }


### PR DESCRIPTION
* Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/321
* Large amount of refactoring around I2C driver classes, I2C component, and the I2C base driver class. Easier to read and contribute to.
  * Adds `setSensorPeriod()` to base driver class
    * Removes usage of `updateSensor()`/`enableSensor()`/`disableSensor()`. 
      * Drivers refactored to perform the steps within `enableSensor` inside the `begin()` call so WipperSnapper can catch a failure ahead of time.
  * `sensor{TYPE}Period` and `sensor{TYPE}PeriodPrv` changed to `get`ters 

Tested with sensor types: altitude, humidity, temp, co2, pressure
![beta_test](https://user-images.githubusercontent.com/322428/190237690-b14b0141-b538-4a80-8d23-154b5b629ff8.png)
