### PR TITLE
Refactor SHT40 and Add SHT3x

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.49
+version=1.0.0-beta.50
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino client for Adafruit.io WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit SHT4x Library, Adafruit PM25 AQI Sensor, Adafruit LC709203F, Adafruit seesaw Library
+depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, arduino-sht, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit PM25 AQI Sensor, Adafruit LC709203F, Adafruit seesaw Library

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino client for Adafruit.io WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, arduino-sht, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit PM25 AQI Sensor, Adafruit LC709203F, Adafruit seesaw Library
+depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, arduino-sht, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit PM25 AQI Sensor, Adafruit LC709203F, Adafruit seesaw Library

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -67,7 +67,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.49" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.50" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -304,7 +304,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _scd40->configureDriver(msgDeviceInitReq);
     drivers.push_back(_scd40);
     WS_DEBUG_PRINTLN("SCD40 Initialized Successfully!");
-  } else if (strcmp("SHT40", msgDeviceInitReq->i2c_device_name) == 0) {
+  } else if (strcmp("sht40", msgDeviceInitReq->i2c_device_name) == 0) {
     _sht4x = new WipperSnapper_I2C_Driver_SHT4X(this->_i2c, i2cAddress);
     if (!_sht4x->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize sht4x!");
@@ -315,7 +315,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _sht4x->configureDriver(msgDeviceInitReq);
     drivers.push_back(_sht4x);
     WS_DEBUG_PRINTLN("SHT4X Initialized Successfully!");
-  } else if (strcmp("SHT3X", msgDeviceInitReq->i2c_device_name) == 0) {
+  } else if (strcmp("sht3X", msgDeviceInitReq->i2c_device_name) == 0) {
     _sht3x = new WipperSnapper_I2C_Driver_SHT3X(this->_i2c, i2cAddress);
     if (!_sht3x->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize sht3x!");

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -315,6 +315,17 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _sht4x->configureDriver(msgDeviceInitReq);
     drivers.push_back(_sht4x);
     WS_DEBUG_PRINTLN("SHT4X Initialized Successfully!");
+  } else if (strcmp("SHT3X", msgDeviceInitReq->i2c_device_name) == 0) {
+    _sht3x = new WipperSnapper_I2C_Driver_SHT3X(this->_i2c, i2cAddress);
+    if (!_sht3x->begin()) {
+      WS_DEBUG_PRINTLN("ERROR: Failed to initialize sht3x!");
+      _busStatusResponse =
+          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
+      return false;
+    }
+    _sht3x->configureDriver(msgDeviceInitReq);
+    drivers.push_back(_sht3x);
+    WS_DEBUG_PRINTLN("SHT3X Initialized Successfully!");
   } else if (strcmp("pmsa003i", msgDeviceInitReq->i2c_device_name) == 0) {
     _pm25 = new WipperSnapper_I2C_Driver_PM25(this->_i2c, i2cAddress);
     if (!_pm25->begin()) {

--- a/src/components/i2c/WipperSnapper_I2C.h
+++ b/src/components/i2c/WipperSnapper_I2C.h
@@ -30,6 +30,7 @@
 #include "drivers/WipperSnapper_I2C_Driver_SCD30.h"
 #include "drivers/WipperSnapper_I2C_Driver_SCD40.h"
 #include "drivers/WipperSnapper_I2C_Driver_SHT4X.h"
+#include "drivers/WipperSnapper_I2C_Driver_SHT3X.h"
 #include "drivers/WipperSnapper_I2C_Driver_SI7021.h"
 #include "drivers/WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor.h"
 #include "drivers/WipperSnapper_I2C_Driver_TSL2591.h"
@@ -88,6 +89,7 @@ private:
   WipperSnapper_I2C_Driver_PM25 *_pm25 = nullptr;
   WipperSnapper_I2C_Driver_SI7021 *_si7021 = nullptr;
   WipperSnapper_I2C_Driver_SHT4X *_sht4x = nullptr;
+  WipperSnapper_I2C_Driver_SHT3X *_sht3x = nullptr;
   WipperSnapper_I2C_Driver_LC709203F *_lc = nullptr;
   WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor *_ss = nullptr;
 };

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT3X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT3X.h
@@ -8,6 +8,8 @@
  * products from Adafruit!
  *
  * Copyright (c) Marni Brewster 2022 for Adafruit Industries.
+ * Copyright (c) Tyeth Gundry 2022. Original code by Marni, 
+ * rewritten to use driver by Sensirion, help from Brent Rubell.
  *
  * MIT license, all text here must be included in any redistribution.
  *

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT3X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT3X.h
@@ -1,7 +1,7 @@
 /*!
- * @file WipperSnapper_I2C_Driver_SHT4X.h
+ * @file WipperSnapper_I2C_Driver_SHT3X.h
  *
- * Device driver for the SHT4X Temperature and Humidity Sensor
+ * Device driver for the SHT3X Temperature and Humidity Sensor
  *
  * Adafruit invests time and resources providing this open source code,
  * please support Adafruit and open-source hardware by purchasing
@@ -13,8 +13,8 @@
  *
  */
 
-#ifndef WipperSnapper_I2C_Driver_SHT4X_H
-#define WipperSnapper_I2C_Driver_SHT4X_H
+#ifndef WipperSnapper_I2C_Driver_SHT3X_H
+#define WipperSnapper_I2C_Driver_SHT3X_H
 
 #include "WipperSnapper_I2C_Driver.h"
 #include <SHTSensor.h>
@@ -22,22 +22,22 @@
 
 /**************************************************************************/
 /*!
-    @brief  Class that provides a driver interface for the SHT4X sensor.
+    @brief  Class that provides a driver interface for the SHT3X sensor.
 */
 /**************************************************************************/
-class WipperSnapper_I2C_Driver_SHT4X : public WipperSnapper_I2C_Driver {
+class WipperSnapper_I2C_Driver_SHT3X : public WipperSnapper_I2C_Driver {
 
 public:
   /*******************************************************************************/
   /*!
-      @brief    Constructor for a SHT4X sensor.
+      @brief    Constructor for a SHT3X sensor.
       @param    i2c
                 The I2C interface.
       @param    sensorAddress
                 7-bit device address.
   */
   /*******************************************************************************/
-  WipperSnapper_I2C_Driver_SHT4X(TwoWire *i2c, uint16_t sensorAddress)
+  WipperSnapper_I2C_Driver_SHT3X(TwoWire *i2c, uint16_t sensorAddress)
       : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
     _i2c = i2c;
     _sensorAddress = sensorAddress;
@@ -45,24 +45,26 @@ public:
 
   /*******************************************************************************/
   /*!
-      @brief    Initializes the SHT4X sensor and begins I2C.
+      @brief    Initializes the SHT3X sensor and begins I2C.
       @returns  True if initialized successfully, False otherwise.
   */
   /*******************************************************************************/
   bool begin() {
-    _sht4x = new SHTSensor(SHTSensor::SHT4X);
-    if (!_sht4x->init(*_i2c))
+    if(_sensorAddress==0x44) // if address 0x44 (dec:68), alternative = 0x45
+      _sht3x = new SHTSensor(SHTSensor::SHT3X);
+    else
+      _sht3x = new SHTSensor(SHTSensor::SHT3X_ALT);
+
+    if (!_sht3x->init(*_i2c))
       return false;
 
     // Use HIGH PRECISION - only supported by 3X/4X
-    _sht4x->setAccuracy(SHTSensor::SHT_ACCURACY_HIGH);
-    
-    return true;
+    return _sht3x->setAccuracy(SHTSensor::SHT_ACCURACY_HIGH);
   }
 
   /*******************************************************************************/
   /*!
-      @brief    Gets the SHT4X's current temperature.
+      @brief    Gets the SHT3X's current temperature.
       @param    tempEvent
                 Pointer to an Adafruit_Sensor event.
       @returns  True if the temperature was obtained successfully, False
@@ -71,15 +73,15 @@ public:
   /*******************************************************************************/
   bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
     // populate temp and humidity objects with fresh data
-    if (!_sht4x->readSample())
+    if (!_sht3x->readSample())
       return false;
-    tempEvent->temperature = _sht4x->getTemperature();
+    tempEvent->temperature = _sht3x->getTemperature();
     return true;
   }
 
   /*******************************************************************************/
   /*!
-      @brief    Gets the SHT4X's current relative humidity reading.
+      @brief    Gets the SHT3X's current relative humidity reading.
       @param    humidEvent
                 Pointer to an Adafruit_Sensor event.
       @returns  True if the humidity was obtained successfully, False
@@ -88,14 +90,14 @@ public:
   /*******************************************************************************/
   bool getEventRelativeHumidity(sensors_event_t *humidEvent) {
     // populate temp and humidity objects with fresh data
-    if (!_sht4x->readSample())
+    if (!_sht3x->readSample())
       return false;
-    humidEvent->relative_humidity =  _sht4x->getHumidity();
+    humidEvent->relative_humidity =  _sht3x->getHumidity();
     return true;
   }
 
 protected:
-  SHTSensor *_sht4x; ///< SHT4X object
+  SHTSensor *_sht3x; ///< SHT3X object
 };
 
-#endif // WipperSnapper_I2C_Driver_SHT4X
+#endif // WipperSnapper_I2C_Driver_SHT3X

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT4X.h
@@ -8,6 +8,8 @@
  * products from Adafruit!
  *
  * Copyright (c) Marni Brewster 2022 for Adafruit Industries.
+ * Copyright (c) Tyeth Gundry 2022. Original code by Marni, 
+ * rewritten to use driver by Sensirion, help from Brent Rubell.
  *
  * MIT license, all text here must be included in any redistribution.
  *


### PR DESCRIPTION
This refactors the SHT40 / SHT41 to use the Sensirion library arduino-sht which brings support for SHT3x SHTCx SHTWx.
Also added driver entry for SHT3x.