### PR TITLE
Build for ESP32 Arduino 2.0.5 based on ESP-IDF 4.4.2 Latest, patch issues

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.49
+version=1.0.0-beta.50
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -67,7 +67,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.49" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.50" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -46,7 +46,7 @@ bool statusLEDInit() {
     digitalWrite(NEOPIXEL_I2C_POWER, HIGH);
 #elif defined(NEOPIXEL_POWER)
     pinMode(NEOPIXEL_POWER, OUTPUT);
-    digitalWrite(NEOPIXEL_POWER, NEOPIXEL_POWER_ON);
+    digitalWrite(NEOPIXEL_POWER, HIGH);
 #endif
     statusPixel = new Adafruit_NeoPixel(
         STATUS_NEOPIXEL_NUM, STATUS_NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);


### PR DESCRIPTION
Rebuilding WipperSnapper on ESP32 Arduino 2.0.5 based on ESP-IDF 4.4.2 [Latest](https://github.com/espressif/arduino-esp32/releases/latest) and applying patches.