### PR TITLE
Fix sht3x after fahrenheit refactor

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -315,7 +315,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _sht4x->configureDriver(msgDeviceInitReq);
     drivers.push_back(_sht4x);
     WS_DEBUG_PRINTLN("SHT4X Initialized Successfully!");
-  } else if (strcmp("sht3X", msgDeviceInitReq->i2c_device_name) == 0) {
+  } else if (strcmp("sht3x", msgDeviceInitReq->i2c_device_name) == 0) {
     _sht3x = new WipperSnapper_I2C_Driver_SHT3X(this->_i2c, i2cAddress);
     if (!_sht3x->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize sht3x!");

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT3X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SHT3X.h
@@ -73,7 +73,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemperature(sensors_event_t *tempEvent) {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     // populate temp and humidity objects with fresh data
     if (!_sht3x->readSample())
       return false;


### PR DESCRIPTION
Tidy up the sht35/sht30/sht31-dis sensor driver. It lost a lowercase name change and changed method name due to being slipped in in the middle of a bigger refactor.

Relates to #339 