### PR TITLE
Add VEML7700 Lux sensor

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.51
+version=1.0.0-beta.52
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino client for Adafruit.io WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, arduino-sht, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit PM25 AQI Sensor, Adafruit LC709203F, Adafruit seesaw Library
+depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, arduino-sht, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit PM25 AQI Sensor, Adafruit VEML7700 Library, Adafruit LC709203F, Adafruit seesaw Library

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -67,7 +67,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.51" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.52" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -293,6 +293,17 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _tsl2591->configureDriver(msgDeviceInitReq);
     drivers.push_back(_tsl2591);
     WS_DEBUG_PRINTLN("TSL2591 Initialized Successfully!");
+  } else if (strcmp("veml7700", msgDeviceInitReq->i2c_device_name) == 0) {
+    _veml7700 = new WipperSnapper_I2C_Driver_VEML7700(this->_i2c, i2cAddress);
+    if (!_veml7700->begin()) {
+      WS_DEBUG_PRINTLN("ERROR: Failed to initialize VEML7700!");
+      _busStatusResponse =
+          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
+      return false;
+    }
+    _veml7700->configureDriver(msgDeviceInitReq);
+    drivers.push_back(_veml7700);
+    WS_DEBUG_PRINTLN("VEML7700 Initialized Successfully!");
   } else if (strcmp("scd40", msgDeviceInitReq->i2c_device_name) == 0) {
     _scd40 = new WipperSnapper_I2C_Driver_SCD40(this->_i2c, i2cAddress);
     if (!_scd40->begin()) {

--- a/src/components/i2c/WipperSnapper_I2C.h
+++ b/src/components/i2c/WipperSnapper_I2C.h
@@ -34,6 +34,7 @@
 #include "drivers/WipperSnapper_I2C_Driver_SI7021.h"
 #include "drivers/WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor.h"
 #include "drivers/WipperSnapper_I2C_Driver_TSL2591.h"
+#include "drivers/WipperSnapper_I2C_Driver_VEML7700.h"
 
 #define I2C_TIMEOUT_MS 50 ///< Default I2C timeout, in milliseconds.
 
@@ -85,6 +86,7 @@ private:
   WipperSnapper_I2C_Driver_MCP9808 *_mcp9808 = nullptr;
   WipperSnapper_I2C_Driver_MCP9601 *_mcp9601 = nullptr;
   WipperSnapper_I2C_Driver_TSL2591 *_tsl2591 = nullptr;
+  WipperSnapper_I2C_Driver_VEML7700 *_veml7700 = nullptr;
   WipperSnapper_I2C_Driver_SCD40 *_scd40 = nullptr;
   WipperSnapper_I2C_Driver_PM25 *_pm25 = nullptr;
   WipperSnapper_I2C_Driver_SI7021 *_si7021 = nullptr;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VEML7700.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VEML7700.h
@@ -56,7 +56,7 @@ public:
   bool begin() {
     _veml = new Adafruit_VEML7700();
     // Attempt to initialize and configure VEML7700
-    return _veml->begin();
+    return _veml->begin(_i2c);
   }
 
   /*******************************************************************************/

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VEML7700.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VEML7700.h
@@ -72,7 +72,7 @@ public:
   /*******************************************************************************/
   bool getEventLight(sensors_event_t *lightEvent) {
     // Get sensor event
-    lightEvent->light = _veml->autoLux();
+    lightEvent->light = _veml->readLux(VEML_LUX_AUTO);
 
     return true;
   }

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VEML7700.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VEML7700.h
@@ -7,7 +7,6 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Copyright (c) Brent Rubell 2022 for Adafruit Industries.
  * Copyright (c) Tyeth Gundry 2022 for Adafruit Industries.
  *
  * MIT license, all text here must be included in any redistribution.
@@ -63,7 +62,8 @@ public:
   /*******************************************************************************/
   /*!
       @brief    Performs a light sensor read using the Adafruit
-                Unified Sensor API.
+                Unified Sensor API. Always uses VEML_LUX_AUTO,
+                controlling sensor integration time and gain.
       @param    lightEvent
                 Light sensor reading, in lux.
       @returns  True if the sensor event was obtained successfully, False
@@ -71,7 +71,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventLight(sensors_event_t *lightEvent) {
-    // Get sensor event
+    // Get sensor event populated in lux via AUTO integration and gain
     lightEvent->light = _veml->readLux(VEML_LUX_AUTO);
 
     return true;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VEML7700.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VEML7700.h
@@ -1,0 +1,84 @@
+/*!
+ * @file WipperSnapper_I2C_Driver_VEML7700.h
+ *
+ * Device driver for the VEML7700 digital luminosity (light) sensor.
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) Brent Rubell 2022 for Adafruit Industries.
+ * Copyright (c) Tyeth Gundry 2022 for Adafruit Industries.
+ *
+ * MIT license, all text here must be included in any redistribution.
+ *
+ */
+#ifndef WipperSnapper_I2C_Driver_VEML7700_H
+#define WipperSnapper_I2C_Driver_VEML7700_H
+
+#include "WipperSnapper_I2C_Driver.h"
+#include <Adafruit_VEML7700.h>
+
+/**************************************************************************/
+/*!
+    @brief  Class that provides a driver interface for a VEML7700 sensor.
+*/
+/**************************************************************************/
+class WipperSnapper_I2C_Driver_VEML7700 : public WipperSnapper_I2C_Driver {
+public:
+  /*******************************************************************************/
+  /*!
+      @brief    Constructor for a VEML7700 sensor.
+      @param    i2c
+                The I2C interface.
+      @param    sensorAddress
+                The 7-bit I2C address of the sensor.
+  */
+  /*******************************************************************************/
+  WipperSnapper_I2C_Driver_VEML7700(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Destructor for an VEML7700 sensor.
+  */
+  /*******************************************************************************/
+  ~WipperSnapper_I2C_Driver_VEML7700() { delete _veml; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the VEML7700 sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _veml = new Adafruit_VEML7700();
+    // Attempt to initialize and configure VEML7700
+    return _veml->begin();
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Performs a light sensor read using the Adafruit
+                Unified Sensor API.
+      @param    lightEvent
+                Light sensor reading, in lux.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventLight(sensors_event_t *lightEvent) {
+    // Get sensor event
+    lightEvent->light = _veml->autoLux();
+
+    return true;
+  }
+
+protected:
+  Adafruit_VEML7700 *_veml; ///< Pointer to VEML7700 light sensor object
+};
+
+#endif // WipperSnapper_I2C_Driver_VEML7700


### PR DESCRIPTION
This adds Vishay VEML7700-TR
Ambient Light Photo Sensor, I2C Output, 550nm, 0-120 000lx Range, 2.5V to 3.6V Supply,
https://www.adafruit.com/product/5378

Relates to https://github.com/adafruit/Wippersnapper_Components/pull/91

Closes https://github.com/adafruit/Wippersnapper_Components/issues/89