### PR TITLE
fix crash caused by incorrectly set broker url in mqtt object

### DIFF
--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -67,7 +67,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.51" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.52" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/Wippersnapper_Boards.h
+++ b/src/Wippersnapper_Boards.h
@@ -100,7 +100,7 @@
 #define BOARD_ID "feather-esp8266"
 #define USE_LITTLEFS
 #define USE_STATUS_LED
-#define STATUS_LED_PIN 13
+#define STATUS_LED_PIN 0
 #elif defined(ARDUINO_FEATHER_ESP32)
 #define BOARD_ID "feather-esp32"
 #define USE_LITTLEFS

--- a/src/network_interfaces/Wippersnapper_ESP8266.h
+++ b/src/network_interfaces/Wippersnapper_ESP8266.h
@@ -128,15 +128,15 @@ public:
     if (WS._mqttBrokerURL == nullptr) {
       WS._mqttBrokerURL = "io.adafruit.com";
     } else {
-      _mqttBrokerURL = "io.adafruit.us";
+      WS._mqttBrokerURL = "io.adafruit.us";
     }
 
     // Uncomment the following lines to use MQTT/SSL. You will need to
     // re-compile after. _wifi_client->setFingerprint(fingerprint); WS._mqtt =
-    // new Adafruit_MQTT_Client(_wifi_client, _mqttBrokerURL, _mqtt_port,
+    // new Adafruit_MQTT_Client(_wifi_client, WS._mqttBrokerURL, _mqtt_port,
     // clientID, WS._username, WS._key);
 
-    WS._mqtt = new Adafruit_MQTT_Client(_wifi_client, _mqttBrokerURL, 1883,
+    WS._mqtt = new Adafruit_MQTT_Client(_wifi_client, WS._mqttBrokerURL, 1883,
                                         clientID, WS._username, WS._key);
   }
 


### PR DESCRIPTION
Beta 50 and Beta 51 experienced crashing during the MQTT connection process: 
```
Attempting to connect to WiFi...
CONNECTING
FSM_NET_ESTABLISH_MQTT
--------------- CUT HERE FOR EXCEPTION DECODER ---------------

Exception (28):
```

This was due to a call to `new Adafruit_MQTT_Client()`. The pointer to the char array storing the MQTT broker URL was not set unless the user was using the development (staging) server. This code was changed when we switched to remove MQTTS due to the fingerprinting requirement for ESP8266 boards.

This pull request 
* Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/334
* Adds the correct status LED GPIO for the Adafruit ESP8266 Huzzah

Output of this PR running with incorrect Adafruit IO credentials:
```
Attempting to connect to WiFi...
CONNECTING
FSM_NET_ESTABLISH_MQTT
Unable to connect to Adafruit IO MQTT, retrying in 3 seconds...
Unable to connect to Adafruit IO MQTT, retrying in 3 seconds...
Unable to connect to Adafruit IO MQTT, retrying in 3 seconds...
Unable to connect to Adafruit IO MQTT, retrying in 3 seconds...
Unable to connect to Adafruit IO MQTT, retrying in 3 seconds...
ERROR [WDT RESET]: ERROR: Unable to connect to Adafruit.IO MQTT, rebooting soon...
```

Output of this PR running with correct Adafruit IO credentials:
```
-------Device Information-------
Firmware Version: 1.0.0-beta.52
Board ID: feather-esp8266
Adafruit.io User: brubell
WiFi Network: Adafruit
MAC Address: 84:F3:EB:5B:05:51
-------------------------------
Subscribing to MQTT topics...
Running Network FSM...
Attempting to connect to WiFi...
CONNECTING
FSM_NET_ESTABLISH_MQTT
Registering hardware with WipperSnapper...
Registering hardware with IO...
Encoding registration request...Encoding registration msg...Published!
Polling for registration message response...2
GOT Registration Response Message:
Hardware Response Msg:
	GPIO Pins: 10
	Analog Pins: 1
	Reference voltage: 1.10v
Completed registration process, configuration next!
Polling for message containing hardware configuration...
Polling for message containing hardware configuration...
cbSignalTopic: New Msg on Signal Topic
2 bytes.
decodeSignalMsg
cbSignalMsg
Sub-messages found: 1
Signal Msg Tag: Pin Configuration
Initial Pin Configuration Complete!
Publishing to pin config complete...
Hardware configured successfully!
Registering components...
SERVO: OK!
Registration and configuration complete!
Running application...
PING!
```