### PR TITLE
Fix error adding BME680, TSL2591

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino client for Adafruit.io WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, arduino-sht, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit PM25 AQI Sensor, Adafruit VEML7700 Library, Adafruit LC709203F, Adafruit seesaw Library
+depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, arduino-sht, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit PM25 AQI Sensor, Adafruit VEML7700 Library, Adafruit LC709203F, Adafruit seesaw Library, Adafruit BME680 Library

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -67,7 +67,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.52" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.53" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -228,6 +228,17 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _bme280->configureDriver(msgDeviceInitReq);
     drivers.push_back(_bme280);
     WS_DEBUG_PRINTLN("BME280 Initialized Successfully!");
+  } else if (strcmp("bme680", msgDeviceInitReq->i2c_device_name) == 0) {
+    _bme680 = new WipperSnapper_I2C_Driver_BME680(this->_i2c, i2cAddress);
+    if (!_bme680->begin()) {
+      WS_DEBUG_PRINTLN("ERROR: Failed to initialize BME680!");
+      _busStatusResponse =
+          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
+      return false;
+    }
+    _bme680->configureDriver(msgDeviceInitReq);
+    drivers.push_back(_bme680);
+    WS_DEBUG_PRINTLN("BME680 Initialized Successfully!");
   } else if (strcmp("dps310", msgDeviceInitReq->i2c_device_name) == 0) {
     _dps310 = new WipperSnapper_I2C_Driver_DPS310(this->_i2c, i2cAddress);
     if (!_dps310->begin()) {
@@ -878,6 +889,29 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINTLN("ERROR: Failed to obtain Raw sensor reading!");
       }
       (*iter)->setSensorRawPeriodPrv(curTime);
+    }
+
+    // Gas sensor
+    curTime = millis();
+    if ((*iter)->getSensorGasResistancePeriod() != 0L &&
+        curTime - (*iter)->getSensorGasResistancePeriodPrv() >
+            (*iter)->getSensorGasResistancePeriod()) {
+      if ((*iter)->getEventGasResistance(&event)) {
+        WS_DEBUG_PRINT("Sensor 0x");
+        WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
+        WS_DEBUG_PRINTLN("");
+        WS_DEBUG_PRINT("\tGas Resistance: ");
+        WS_DEBUG_PRINT(event.data[0]);
+        WS_DEBUG_PRINT(" ohms");
+
+        fillEventMessage(
+            &msgi2cResponse, event.data[0],
+            wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_GAS_RESISTANCE);
+      } else {
+        WS_DEBUG_PRINTLN(
+            "ERROR: Failed to obtain gas resistance sensor reading!");
+      }
+      (*iter)->setSensorGasResistancePeriodPrv(curTime);
     }
 
     // Did this driver obtain data from sensors?

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -203,7 +203,8 @@ WipperSnapper_Component_I2C::scanAddresses() {
 /*******************************************************************************/
 bool WipperSnapper_Component_I2C::initI2CDevice(
     wippersnapper_i2c_v1_I2CDeviceInitRequest *msgDeviceInitReq) {
-  WS_DEBUG_PRINTLN("Attempting to initialize an I2C device...");
+  WS_DEBUG_PRINT("Attempting to initialize I2C device: ");
+  WS_DEBUG_PRINTLN(msgDeviceInitReq->i2c_device_name);
 
   uint16_t i2cAddress = (uint16_t)msgDeviceInitReq->i2c_device_address;
   if (strcmp("aht20", msgDeviceInitReq->i2c_device_name) == 0) {

--- a/src/components/i2c/WipperSnapper_I2C.h
+++ b/src/components/i2c/WipperSnapper_I2C.h
@@ -22,6 +22,7 @@
 #include "drivers/WipperSnapper_I2C_Driver.h"
 #include "drivers/WipperSnapper_I2C_Driver_AHTX0.h"
 #include "drivers/WipperSnapper_I2C_Driver_BME280.h"
+#include "drivers/WipperSnapper_I2C_Driver_BME680.h"
 #include "drivers/WipperSnapper_I2C_Driver_DPS310.h"
 #include "drivers/WipperSnapper_I2C_Driver_LC709203F.h"
 #include "drivers/WipperSnapper_I2C_Driver_MCP9601.h"
@@ -83,6 +84,7 @@ private:
   WipperSnapper_I2C_Driver_DPS310 *_dps310 = nullptr;
   WipperSnapper_I2C_Driver_SCD30 *_scd30 = nullptr;
   WipperSnapper_I2C_Driver_BME280 *_bme280 = nullptr;
+  WipperSnapper_I2C_Driver_BME680 *_bme680 = nullptr;
   WipperSnapper_I2C_Driver_MCP9808 *_mcp9808 = nullptr;
   WipperSnapper_I2C_Driver_MCP9601 *_mcp9601 = nullptr;
   WipperSnapper_I2C_Driver_TSL2591 *_tsl2591 = nullptr;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -114,6 +114,8 @@ public:
       break;
     case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_OBJECT_TEMPERATURE_FAHRENHEIT:
       _objectTempFPeriod = sensorPeriod;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_GAS_RESISTANCE:
+      _gasResistancePeriod = sensorPeriod;
     default:
       break;
     }
@@ -868,6 +870,57 @@ public:
     return true;
   }
 
+  /****************************** SENSOR_TYPE: Gas Resistance (ohms)
+   * *******************************/
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the gas resistance (ohms)
+     sensor's period, if set.
+      @returns  Time when the  gas resistance sensor should be polled,
+                in seconds.
+  */
+  /*********************************************************************************/
+  virtual long getSensorGasResistancePeriod() { return _gasResistancePeriod; }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the previous time interval at
+                which the gas resistance sensor (ohms) was queried last.
+      @returns  Time when the gas resistance sensor was last queried,
+                in seconds.
+  */
+  /*********************************************************************************/
+  virtual long getSensorGasResistancePeriodPrv() {
+    return _gasResistancePeriodPrv;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Sets a timestamp for when the object gas resistance sensor
+                was queried.
+      @param    period
+                The time when the gas resistance sensor was queried
+     last.
+  */
+  /*******************************************************************************/
+  virtual void setSensorGasResistancePeriodPrv(long period) {
+    _gasResistancePeriodPrv = period;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Base implementation - Reads a gas resistance sensor and converts
+                the reading into the expected SI unit.
+      @param    gasEvent
+                gas resistance sensor reading, in ohms.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  virtual bool getEventGasResistance(sensors_event_t *gasEvent) {
+    return false;
+  }
+
 protected:
   TwoWire *_i2c;           ///< Pointer to the I2C driver's Wire object
   uint16_t _sensorAddress; ///< The I2C driver's unique I2C address.
@@ -921,16 +974,20 @@ protected:
                                         ///< was last read.
   long _rawSensorPeriod =
       0L; ///< The time period between reading the Raw sensor's value.
-  long _rawSensorPeriodPrv = 0L;    ///< The time when the Raw sensor
-                                    ///< was last read.
-  long _ambientTempFPeriod = 0L;    ///< The time period between reading the
-                                    ///< ambient temp. (°F) sensor's value.
-  long _ambientTempFPeriodPrv = 0L; ///< The time when the ambient temp. (°F)
-                                    ///< sensor was last read.
-  long _objectTempFPeriod = 0L;     ///< The time period between reading the
-                                    ///< object temp. (°F) sensor's value.
-  long _objectTempFPeriodPrv = 0L;  ///< The time when the object temp. (°F)
-                                    ///< sensor was last read.
+  long _rawSensorPeriodPrv = 0L;     ///< The time when the Raw sensor
+                                     ///< was last read.
+  long _ambientTempFPeriod = 0L;     ///< The time period between reading the
+                                     ///< ambient temp. (°F) sensor's value.
+  long _ambientTempFPeriodPrv = 0L;  ///< The time when the ambient temp. (°F)
+                                     ///< sensor was last read.
+  long _objectTempFPeriod = 0L;      ///< The time period between reading the
+                                     ///< object temp. (°F) sensor's value.
+  long _objectTempFPeriodPrv = 0L;   ///< The time when the object temp. (°F)
+                                     ///< sensor was last read.
+  long _gasResistancePeriod = 0L;    ///< The time period between reading the
+                                     ///< gas resistance sensor's value.
+  long _gasResistancePeriodPrv = 0L; ///< The time when the gas resistance
+                                     ///< sensor was last read.
 };
 
 #endif // WipperSnapper_I2C_Driver_H

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -114,8 +114,10 @@ public:
       break;
     case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_OBJECT_TEMPERATURE_FAHRENHEIT:
       _objectTempFPeriod = sensorPeriod;
+      break;
     case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_GAS_RESISTANCE:
       _gasResistancePeriod = sensorPeriod;
+      break;
     default:
       break;
     }

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME680.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME680.h
@@ -1,0 +1,178 @@
+/*!
+ * @file WipperSnapper_I2C_Driver_BME680.h
+ *
+ * Device driver for an AHT Humidity and Temperature sensor.
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) Brent Rubell 2021 for Adafruit Industries.
+ *
+ * MIT license, all text here must be included in any redistribution.
+ *
+ */
+
+#ifndef WipperSnapper_I2C_Driver_BME680_H
+#define WipperSnapper_I2C_Driver_BME680_H
+
+#include "WipperSnapper_I2C_Driver.h"
+#include <Adafruit_BME680.h>
+
+#define SEALEVELPRESSURE_HPA (1013.25) ///< Default sea level pressure, in hPa
+
+/**************************************************************************/
+/*!
+    @brief  Class that provides a sensor driver for the BME680 temperature
+            and humidity sensor.
+*/
+/**************************************************************************/
+class WipperSnapper_I2C_Driver_BME680 : public WipperSnapper_I2C_Driver {
+
+public:
+  /*******************************************************************************/
+  /*!
+      @brief    Constructor for an BME680 sensor.
+      @param    i2c
+                The I2C interface.
+      @param    sensorAddress
+                7-bit device address.
+  */
+  /*******************************************************************************/
+  WipperSnapper_I2C_Driver_BME680(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Destructor for an BME680 sensor.
+  */
+  /*******************************************************************************/
+  ~WipperSnapper_I2C_Driver_BME680() { delete _bme; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the BME680 sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _bme = new Adafruit_BME680(_i2c);
+
+    // attempt to initialize BME680
+    if (!_bme->begin())
+      return false;
+
+    // Set up oversampling and filter initialization
+    // defaults from
+    // https://github.com/adafruit/Adafruit_BME680/blob/master/examples/bme680test/bme680test.ino
+    _bme->setTemperatureOversampling(BME680_OS_8X);
+    _bme->setHumidityOversampling(BME680_OS_2X);
+    _bme->setPressureOversampling(BME680_OS_4X);
+    _bme->setIIRFilterSize(BME680_FILTER_SIZE_3);
+    _bme->setGasHeater(320, 150); // 320*C for 150 ms
+
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Performs a reading in blocking mode.
+      @returns  True if the reading succeeded, False otherwise.
+  */
+  /*******************************************************************************/
+  bool bmePerformReading() { return _bme->performReading(); }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the BME680's current temperature.
+      @param    tempEvent
+                Pointer to an Adafruit_Sensor event.
+      @returns  True if the temperature was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
+    if (!bmePerformReading())
+      return false;
+    tempEvent->temperature = _bme->temperature;
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the BME680's current relative humidity reading.
+      @param    humidEvent
+                Pointer to an Adafruit_Sensor event.
+      @returns  True if the humidity was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventRelativeHumidity(sensors_event_t *humidEvent) {
+    if (!bmePerformReading())
+      return false;
+    humidEvent->relative_humidity = _bme->humidity;
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Reads a pressure sensor and converts
+                the reading into the expected SI unit.
+      @param    pressureEvent
+                Pointer to an Adafruit_Sensor event.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventPressure(sensors_event_t *pressureEvent) {
+    if (!bmePerformReading())
+      return false;
+    pressureEvent->pressure = (float)_bme->pressure;
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Reads a the BME680's altitude sensor into an event.
+      @param    altitudeEvent
+                Pointer to an adafruit sensor event.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventAltitude(sensors_event_t *altitudeEvent) {
+    if (!bmePerformReading())
+      return false;
+    // NOTE: This is hacked onto Adafruit_Sensor and should eventually be
+    // removed
+    altitudeEvent->data[0] = (float)_bme->readAltitude(SEALEVELPRESSURE_HPA);
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Base implementation - Reads a gas resistance sensor and converts
+                the reading into the expected SI unit.
+      @param    gasEvent
+                gas resistance sensor reading, in ohms.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  virtual bool getEventGasResistance(sensors_event_t *gasEvent) {
+    if (!bmePerformReading())
+      return false;
+    // NOTE: This is hacked onto Adafruit_Sensor and should eventually be
+    // removed
+    gasEvent->data[0] = (float)_bme->gas_resistance;
+    return true;
+  }
+
+protected:
+  Adafruit_BME680 *_bme; ///< BME680 object
+};
+
+#endif // WipperSnapper_I2C_Driver_BME680

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_TSL2591.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_TSL2591.h
@@ -54,9 +54,9 @@ public:
   */
   /*******************************************************************************/
   bool begin() {
-    _tsl = new Adafruit_TSL2591();
+    _tsl = new Adafruit_TSL2591(2591);
     // Attempt to initialize TSL2591
-    if (!_tsl->begin())
+    if (!_tsl->begin(_i2c, TSL2591_ADDR))
       return false;
 
     // Configure TSL2591 sensor


### PR DESCRIPTION
Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/346 by:
* Adds BME680 driver to WipperSnapper
* Adds gas sensor type to WipperSnapper
* Fixes TSL2591 handling code