### PR TITLE
Initialize component classes first and rebuild with Adafruit MQTT v2.5.0

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.53
+version=1.0.0-beta.54
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -1874,6 +1874,22 @@ void Wippersnapper::connect() {
   _status = WS_IDLE;
   WS._boardStatus = WS_BOARD_DEF_IDLE;
 
+  // Initialize components and buses
+  WS_DEBUG_PRINTLN("Initializing component instances...");
+#ifdef ARDUINO_ARCH_ESP32
+  WS_DEBUG_PRINT("LEDC: ");
+  WS._ledc = new ws_ledc();
+  WS_DEBUG_PRINTLN("OK!");
+#endif
+
+  WS_DEBUG_PRINT("SERVO: ");
+  WS._servoComponent = new ws_servo();
+  WS_DEBUG_PRINTLN("OK!");
+
+  WS_DEBUG_PRINT("DS18x20: ");
+  WS._ds18x20Component = new ws_ds18x20();
+  WS_DEBUG_PRINTLN("OK!");
+
   if (!validateAppCreds())
     haltError("Unable to validate application credentials.");
 
@@ -1914,22 +1930,6 @@ void Wippersnapper::connect() {
   runNetFSM();
   publishPinConfigComplete();
   WS_DEBUG_PRINTLN("Hardware configured successfully!");
-
-  // Register components
-  WS_DEBUG_PRINTLN("Initializing component instances...");
-#ifdef ARDUINO_ARCH_ESP32
-  WS_DEBUG_PRINT("LEDC: ");
-  WS._ledc = new ws_ledc();
-  WS_DEBUG_PRINTLN("OK!");
-#endif
-
-  WS_DEBUG_PRINT("SERVO: ");
-  WS._servoComponent = new ws_servo();
-  WS_DEBUG_PRINTLN("OK!");
-
-  WS_DEBUG_PRINT("DS18x20: ");
-  WS._ds18x20Component = new ws_ds18x20();
-  WS_DEBUG_PRINTLN("OK!");
 
   // goto application
   statusLEDFade(GREEN, 3);

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -67,7 +67,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.53" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.54" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic


### PR DESCRIPTION
* Initializes component classes first, prior to MQTT connection
* Build with latest Adafruit_MQTT to include https://github.com/adafruit/Adafruit_MQTT_Library/pull/215