### PR TITLE
Stability fix, keepalive disconnection

### DIFF
--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -1879,7 +1879,7 @@ void Wippersnapper::runNetFSM() {
       break;
     case FSM_NET_ESTABLISH_MQTT:
       WS_DEBUG_PRINTLN("FSM_NET_ESTABLISH_MQTT");
-      WS._mqtt->setKeepAliveInterval(WS_KEEPALIVE_INTERVAL);
+      WS._mqtt->setKeepAliveInterval(WS_KEEPALIVE_INTERVAL_MS / 1000);
       // Attempt to connect
       maxAttempts = 5;
       while (maxAttempts > 0) {
@@ -1966,8 +1966,9 @@ ws_board_status_t Wippersnapper::getBoardStatus() { return WS._boardStatus; }
 */
 /**************************************************************************/
 void Wippersnapper::pingBroker() {
-  // ping within keepalive to keep connection open
-  if (millis() > (_prv_ping + WS_KEEPALIVE_INTERVAL_MS)) {
+  // ping within keepalive-10% to keep connection open
+  if (millis() > (_prv_ping + (WS_KEEPALIVE_INTERVAL_MS -
+                               (WS_KEEPALIVE_INTERVAL_MS * 0.10)))) {
     WS_DEBUG_PRINTLN("PING!");
     WS._mqtt->ping();
     _prv_ping = millis();

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -176,7 +176,7 @@ typedef enum {
 #define WS_WDT_TIMEOUT 60000 ///< WDT timeout
 /* MQTT Configuration */
 #define WS_KEEPALIVE_INTERVAL_MS                                               \
-  4000 ///< Session keepalive interval time, in milliseconds
+  5000 ///< Session keepalive interval time, in milliseconds
 
 #define WS_MQTT_MAX_PAYLOAD_SIZE                                               \
   512 ///< MAXIMUM expected payload size, in bytes

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -175,8 +175,6 @@ typedef enum {
 
 #define WS_WDT_TIMEOUT 60000 ///< WDT timeout
 /* MQTT Configuration */
-// TODO: Redundant, we should reference keepalive_interval_ms and just do math
-#define WS_KEEPALIVE_INTERVAL 4 ///< Session keepalive interval time, in seconds
 #define WS_KEEPALIVE_INTERVAL_MS                                               \
   4000 ///< Session keepalive interval time, in milliseconds
 

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -267,15 +267,15 @@ void statusLEDBlink(ws_led_status_t statusState) {
 #endif
 
   // set number of times to blink
-  int blinkNum = 5;
+  int blinkNum = 2;
   // set blink color
   uint32_t ledColor = ledStatusStateToColor(statusState);
 
   while (blinkNum > 0) {
     setStatusLEDColor(ledColor);
-    delay(300);
+    delay(100);
     setStatusLEDColor(BLACK);
-    delay(300);
+    delay(100);
     blinkNum--;
   }
 }


### PR DESCRIPTION
WipperSnapper devices are being disconnected/reconnected every ~`120000`ms. 

This is due to two issues fixed by this PR:
1) Rigid timing requirement around the MQTT KeepAlive time (_exactly_ every KAT interval)
2) Blinking the status LED every `STATUS_LED_KAT_BLINK_TIME`ms causes a blocking behavior that exceeds the client's configured MQTT KeepAlive time, causing the next PINGREQ to execute out-of-bounds

Pre-PR Behavior, note the delta of 6.019 seconds between pings caused by the status LED blinking.
```
14:37:07.902 -> [235985][V][ssl_client.cpp:369] send_ssl_data(): Writing HTTP request with 2 bytes...
14:37:11.952 -> PING!
14:37:11.952 -> [240019][V][ssl_client.cpp:369] send_ssl_data(): Writing HTTP request with 2 bytes...
14:37:14.963 -> Blinking status LED STATUS_LED_KAT_BLINK_TIME
14:37:17.971 -> PING!
14:37:17.971 -> [246044][V][ssl_client.cpp:369] send_ssl_data(): Writing HTTP request with 2 bytes...
14:37:17.971 -> [246058][V][ssl_client.cpp:324] stop_ssl_socket(): Cleaning SSL connection.
14:37:18.004 -> FSM_NET_ESTABLISH_MQTT
```

Post-PR behavior
```
15:13:06.583 -> [962488][V][ssl_client.cpp:369] send_ssl_data(): Writing HTTP request with 2 bytes...
15:13:06.999 -> Blinking status LED STATUS_LED_KAT_BLINK_TIME
15:13:10.609 -> PING!
15:13:10.609 -> [966523][V][ssl_client.cpp:369] send_ssl_data(): Writing HTTP request with 2 bytes...
15:13:14.647 -> PING!
```

This pull request: 
* Shortens the execution time of `statusLEDBlink()`
* Loosens timing requirement within `pingBroker()`