### PR TITLE
Allow WipperSnapper to connect to an Open WiFi Network

### DIFF
--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -2125,6 +2125,7 @@ void printDeviceInfo() {
   WS_DEBUG_PRINTLN(WS._username);
   WS_DEBUG_PRINT("WiFi Network: ");
   WS_DEBUG_PRINTLN(WS._network_ssid);
+
   char sMAC[18] = {0};
   sprintf(sMAC, "%02X:%02X:%02X:%02X:%02X:%02X", WS._macAddr[0], WS._macAddr[1],
           WS._macAddr[2], WS._macAddr[3], WS._macAddr[4], WS._macAddr[5]);

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -322,7 +322,8 @@ public:
 
   int32_t totalDigitalPins; /*!< Total number of digital-input capable pins */
 
-  char *_topic_description = NULL; /*!< MQTT topic for the device description  */
+  char *_topic_description =
+      NULL; /*!< MQTT topic for the device description  */
   char *_topic_signal_device = NULL;   /*!< Device->Wprsnpr messages */
   char *_topic_signal_i2c_brkr = NULL; /*!< Topic carries messages from a device
                                    to a broker. */

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -322,8 +322,7 @@ public:
 
   int32_t totalDigitalPins; /*!< Total number of digital-input capable pins */
 
-  char *_topic_description =
-      NULL; /*!< MQTT topic for the device description  */
+  char *_topic_description = NULL; /*!< MQTT topic for the device description */
   char *_topic_signal_device = NULL;   /*!< Device->Wprsnpr messages */
   char *_topic_signal_i2c_brkr = NULL; /*!< Topic carries messages from a device
                                    to a broker. */

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -322,8 +322,7 @@ public:
 
   int32_t totalDigitalPins; /*!< Total number of digital-input capable pins */
 
-  char *_topic_description =
-      NULL; /*!< MQTT topic for the device description  */
+  char *_topic_description = NULL; /*!< MQTT topic for the device description  */
   char *_topic_signal_device = NULL;   /*!< Device->Wprsnpr messages */
   char *_topic_signal_i2c_brkr = NULL; /*!< Topic carries messages from a device
                                    to a broker. */

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -66,7 +66,14 @@ public:
   /********************************************************/
   void set_ssid_pass(const char *ssid, const char *ssidPassword) {
     _ssid = ssid;
-    _pass = ssidPassword;
+
+    // set the AP password
+    // check if ssidPassword was "" in secrets.json
+    if ((ssidPassword != NULL) && (strlen(ssidPassword) == 0)) {
+      _pass = NULL; // Set as NULL for open networks
+    } else {
+      _pass = ssidPassword;
+    }
   }
 
   /**********************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP8266.h
+++ b/src/network_interfaces/Wippersnapper_ESP8266.h
@@ -91,7 +91,14 @@ public:
   /**********************************************************/
   void set_ssid_pass(const char *ssid, const char *ssidPassword) {
     _ssid = ssid;
-    _pass = ssidPassword;
+
+    // set the AP password
+    // check if ssidPassword was "" in secrets.json
+    if ((ssidPassword != NULL) && (strlen(ssidPassword) == 0)) {
+      _pass = NULL; // Set as NULL for open networks
+    } else {
+      _pass = ssidPassword;
+    }
   }
 
   /**********************************************************/


### PR DESCRIPTION
This pull request enables a WipperSnapper device to connect to an Open/Unsecured WiFi network.

Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/276

Tested on:

- [x] ESP32
- [x] ESP8266

