### PR TITLE
Fix watchdog timer on ESP8266

### DIFF
--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -1848,7 +1848,7 @@ void Wippersnapper::runNetFSM() {
     switch (fsmNetwork) {
     case FSM_NET_CHECK_MQTT:
       if (WS._mqtt->connected()) {
-        WS_DEBUG_PRINTLN("Connected to Adafruit IO!");
+        // WS_DEBUG_PRINTLN("Connected to Adafruit IO!");
         fsmNetwork = FSM_NET_CONNECTED;
         return;
       }
@@ -1856,7 +1856,7 @@ void Wippersnapper::runNetFSM() {
       break;
     case FSM_NET_CHECK_NETWORK:
       if (networkStatus() == WS_NET_CONNECTED) {
-        WS_DEBUG_PRINTLN("Connected to WiFi!");
+        // WS_DEBUG_PRINTLN("Connected to WiFi!");
         fsmNetwork = FSM_NET_ESTABLISH_MQTT;
         break;
       }
@@ -1938,8 +1938,14 @@ void Wippersnapper::haltError(String error, ws_led_status_t ledStatusColor) {
   WS_DEBUG_PRINTLN(error);
   for (;;) {
     statusLEDSolid(ledStatusColor);
-    // let the WDT fail out and reset!
+// let the WDT fail out and reset!
+#ifndef ARDUINO_ARCH_ESP8266
     delay(100);
+#else
+    // Calls to delay() and yield() feed the ESP8266's
+    // hardware and software watchdog timers, delayMicroseconds does not.
+    delayMicroseconds(100);
+#endif
   }
 }
 
@@ -2002,11 +2008,7 @@ void Wippersnapper::pingBroker() {
     @brief    Feeds the WDT to prevent hardware reset.
 */
 /*******************************************************/
-void Wippersnapper::feedWDT() {
-#ifndef ESP8266
-  Watchdog.reset();
-#endif
-}
+void Wippersnapper::feedWDT() { Watchdog.reset(); }
 
 /********************************************************/
 /*!
@@ -2017,7 +2019,6 @@ void Wippersnapper::feedWDT() {
 */
 /*******************************************************/
 void Wippersnapper::enableWDT(int timeoutMS) {
-#ifndef ESP8266
   Watchdog.disable();
   if (Watchdog.enable(timeoutMS) == 0) {
     WS_DEBUG_PRINTLN("ERROR: WDT initialization failure!");
@@ -2026,7 +2027,6 @@ void Wippersnapper::enableWDT(int timeoutMS) {
       delay(100);
     }
   }
-#endif
 }
 
 /********************************************************/

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -74,9 +74,7 @@
 // Note: These might be better off in their respective wrappers
 #include <SPI.h>
 
-#ifndef ESP8266
 #include "Adafruit_SleepyDog.h"
-#endif
 
 #if defined(USE_TINYUSB)
 #include "provisioning/tinyusb/Wippersnapper_FS.h"


### PR DESCRIPTION
* Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/234 by re-enabling the watchdog on ESP8266 platform
  * Uses `delayMicroseconds` instead of `delay` within halt function for ESP8266 only.
* Removes 2x annoying `println`s I added in a previous commit.

Beta 55 operation, without a reset at the end
```
17:06:28.723 -> -------Device Information-------
17:06:28.723 -> Firmware Version: 1.0.0-beta.55
17:06:28.723 -> Board ID: feather-esp8266
17:06:28.723 -> Adafruit.io User: bad
17:06:28.723 -> WiFi Network: BADSSID
17:06:28.723 -> MAC Address: 84:F3:EB:5B:05:51
17:06:28.761 -> -------------------------------
17:06:28.761 -> Generating device's MQTT topics...
17:06:28.761 -> Subscribing to device's MQTT topics...
17:06:28.761 -> Running Network FSM...
17:06:31.761 -> Attempting to connect to WiFi...
17:06:32.454 -> CONNECTING
17:06:48.453 -> Attempting to connect to WiFi...
17:06:49.143 -> CONNECTING
17:07:05.146 -> Attempting to connect to WiFi...
17:07:05.852 -> CONNECTING
17:07:21.855 -> Attempting to connect to WiFi...
17:07:22.552 -> CONNECTING
17:07:38.541 -> Attempting to connect to WiFi...
17:07:39.241 -> CONNECTING
17:07:52.245 -> ERROR [WDT RESET]: ERROR: Unable to connect to WiFi, rebooting soon...
```

Beta 66 operation with this PR
```
17:13:36.906 -> Adafruit.io WipperSnapper
17:13:36.906 -> -------Device Information-------
17:13:36.906 -> Firmware Version: 1.0.0-beta.56
17:13:36.906 -> Board ID: feather-esp8266
17:13:36.906 -> Adafruit.io User: bad
17:13:36.906 -> WiFi Network: BADSSID
17:13:36.906 -> MAC Address: 84:F3:EB:5B:05:51
17:13:36.906 -> -------------------------------
17:13:36.906 -> Generating device's MQTT topics...
17:13:36.906 -> Subscribing to device's MQTT topics...
17:13:36.906 -> Running Network FSM...
17:13:36.906 -> Attempting to connect to WiFi
17:13:39.202 -> ERROR: Your requested WiFi network was not found!
17:13:39.202 -> WipperSnapper found these WiFi networks: 
[SNIP]
17:13:39.240 -> ERROR [WDT RESET]: ERROR: Unable to find WiFi network, rebooting soon...
17:13:41.716 -> Soft WDT reset
17:13:41.716 -> 
[snip]
**RESETS HERE**
17:13:41.788 -> 
17:13:41.788 ->  ets Jan  8 2013,rst cause:2, boot mode:(3,6)
17:13:41.788 -> 
17:13:41.788 -> load 0x4010f000, len 3460, room 16 
17:13:41.821 -> tail 4
17:13:41.821 -> chksum 0xcc
17:13:41.821 -> load 0x3fff20b8, len 40, room 4 
17:13:41.821 -> tail 4
17:13:41.821 -> chksum 0xc9
17:13:41.821 -> csum 0xc9
17:13:41.821 -> v00068460
17:13:41.821 -> ~ld
17:13:41.893 -> Adafruit.io WipperSnapper
17:13:41.893 -> -------Device Information-------
17:13:41.893 -> Firmware Version: 1.0.0-beta.56
```