### PR TITLE
Fix Adafruit Feather HUZZAH ESP8266 builtin LED behavior

### DIFF
--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -1998,6 +1998,7 @@ void Wippersnapper::pingBroker() {
   }
   // blink status LED every STATUS_LED_KAT_BLINK_TIME millis
   if (millis() > (_prvKATBlink + STATUS_LED_KAT_BLINK_TIME)) {
+    WS_DEBUG_PRINTLN("KAT BLINK!");
     statusLEDBlink(WS_LED_STATUS_KAT);
     _prvKATBlink = millis();
   }

--- a/src/components/digitalIO/Wippersnapper_DigitalGPIO.cpp
+++ b/src/components/digitalIO/Wippersnapper_DigitalGPIO.cpp
@@ -79,7 +79,8 @@ void Wippersnapper_DigitalGPIO::initDigitalPin(
     // the pin LOW will turn the LED on.
     digitalWrite(STATUS_LED_PIN, !0);
 #else
-    digitalWrite(STATUS_LED_PIN, 0);
+    pinMode(pinName, OUTPUT);
+    digitalWrite(pinName, LOW); // initialize LOW
 #endif
   } else if (
       direction ==

--- a/src/components/digitalIO/Wippersnapper_DigitalGPIO.cpp
+++ b/src/components/digitalIO/Wippersnapper_DigitalGPIO.cpp
@@ -73,7 +73,14 @@ void Wippersnapper_DigitalGPIO::initDigitalPin(
     WS_DEBUG_PRINT("Configured digital output pin on D");
     WS_DEBUG_PRINTLN(pinName);
     pinMode(pinName, OUTPUT);
-    digitalWrite(pinName, LOW); // initialize LOW
+// Initialize LOW
+#if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
+    // The Adafruit Feather ESP8266's built-in LED is reverse wired so setting
+    // the pin LOW will turn the LED on.
+    digitalWrite(STATUS_LED_PIN, !0);
+#else
+    digitalWrite(STATUS_LED_PIN, 0);
+#endif
   } else if (
       direction ==
       wippersnapper_pin_v1_ConfigurePinRequest_Direction_DIRECTION_INPUT) {
@@ -173,7 +180,16 @@ void Wippersnapper_DigitalGPIO::digitalWriteSvc(uint8_t pinName, int pinValue) {
   WS_DEBUG_PRINT(pinName);
   WS_DEBUG_PRINT(" to ");
   WS_DEBUG_PRINTLN(pinValue);
+
+// Write to the GPIO pin
+#if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
+  // The Adafruit Feather ESP8266's built-in LED is reverse wired so setting the
+  // pin LOW will turn the LED on.
+  if (pinName == 0)
+    digitalWrite(pinName, !pinValue);
+#else
   digitalWrite(pinName, pinValue);
+#endif
 }
 
 /**********************************************************/

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -72,8 +72,8 @@ bool statusLEDInit() {
 
 // Turn OFF LED
 #if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
-                   // The Adafruit Feather ESP8266's built-in LED is reverse
-                   // wired so setting the pin LOW will turn the LED on.
+  // The Adafruit Feather ESP8266's built-in LED is reverse
+  // wired so setting the pin LOW will turn the LED on.
   digitalWrite(STATUS_LED_PIN, !0);
 #else
   digitalWrite(STATUS_LED_PIN, 0);
@@ -205,8 +205,15 @@ void statusLEDFade(uint32_t color, int numFades = 3) {
   pinMode(STATUS_LED_PIN, OUTPUT);
 #endif
 
+// turn OFF ESP8266's status LED
+#if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
+  // The Adafruit Feather ESP8266's built-in LED is reverse wired
+  // clear status LED color
+  setStatusLEDColor(BLACK ^ 1);
+#else
   // clear status LED color
   setStatusLEDColor(BLACK);
+#endif
 }
 
 /****************************************************************************/
@@ -285,14 +292,13 @@ void statusLEDBlink(ws_led_status_t statusState) {
     setStatusLEDColor(ledColor);
     delay(100);
     setStatusLEDColor(BLACK);
+#if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
+    // The Adafruit Feather ESP8266's built-in LED is reverse wired
+    setStatusLEDColor(BLACK ^ 1);
+#else
+    setStatusLEDColor(BLACK);
+#endif
     delay(100);
     blinkNum--;
   }
-
-// turn OFF ESP8266's status LED
-#if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
-  // The Adafruit Feather ESP8266's built-in LED is reverse wired so setting the
-  // pin LOW will turn the LED on.
-  digitalWrite(STATUS_LED_PIN, !0);
-#endif
 }

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -67,9 +67,19 @@ bool statusLEDInit() {
 #endif
 
 #ifdef USE_STATUS_LED
-  pinMode(STATUS_LED_PIN, OUTPUT); // Initialize LED
-  digitalWrite(STATUS_LED_PIN, 0); // Turn OFF LED
-  WS.lockStatusLED = true;         // set global pin "lock" flag
+  pinMode(STATUS_LED_PIN,
+          OUTPUT); // Initialize LED
+
+// Turn OFF LED
+#if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
+                   // The Adafruit Feather ESP8266's built-in LED is reverse
+                   // wired so setting the pin LOW will turn the LED on.
+  digitalWrite(STATUS_LED_PIN, !0);
+#else
+  digitalWrite(STATUS_LED_PIN, 0);
+#endif
+
+  WS.lockStatusLED = true; // set global pin "lock" flag
   is_success = true;
 #endif
   return is_success;
@@ -278,4 +288,11 @@ void statusLEDBlink(ws_led_status_t statusState) {
     delay(100);
     blinkNum--;
   }
+
+// turn OFF ESP8266's status LED
+#if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
+  // The Adafruit Feather ESP8266's built-in LED is reverse wired so setting the
+  // pin LOW will turn the LED on.
+  digitalWrite(STATUS_LED_PIN, !0);
+#endif
 }

--- a/src/components/statusLED/Wippersnapper_StatusLED.h
+++ b/src/components/statusLED/Wippersnapper_StatusLED.h
@@ -40,14 +40,14 @@ typedef enum ws_led_status_t {
   WS_LED_STATUS_KAT,
 } ws_led_status_t;
 
-#define RED 0xFF0000                   ///< Red (as a uint32)
-#define CYAN 0x00FFFF                  ///< Cyan (as a uint32)
-#define YELLOW 0xFFFF00                ///< Yellow (as a uint32)
-#define GREEN 0x00A300                 ///< Green (as a uint32)
-#define BLACK 0x000000                 ///< Black (as a uint32)
-#define PINK 0xFF00FF                  ///< Pink (as a uint32)
-#define BLUE 0x0000FF                  ///< Blue (as a uint32)
-#define AMBER 0xFFBF00                 ///< Amber (as a uint32)
+#define RED 0xFF0000    ///< Red (as a uint32)
+#define CYAN 0x00FFFF   ///< Cyan (as a uint32)
+#define YELLOW 0xFFFF00 ///< Yellow (as a uint32)
+#define GREEN 0x00A300  ///< Green (as a uint32)
+#define BLACK 0x000000  ///< Black (as a uint32)
+#define PINK 0xFF00FF   ///< Pink (as a uint32)
+#define BLUE 0x0000FF   ///< Blue (as a uint32)
+#define AMBER 0xFFBF00  ///< Amber (as a uint32)
 
 // colors for each status state
 #define LED_NET_CONNECT PINK      ///< Network connection state

--- a/src/components/statusLED/Wippersnapper_StatusLED.h
+++ b/src/components/statusLED/Wippersnapper_StatusLED.h
@@ -40,14 +40,14 @@ typedef enum ws_led_status_t {
   WS_LED_STATUS_KAT,
 } ws_led_status_t;
 
-#define RED 0xFF0000    ///< Red (as a uint32)
-#define CYAN 0x00FFFF   ///< Cyan (as a uint32)
-#define YELLOW 0xFFFF00 ///< Yellow (as a uint32)
-#define GREEN 0x00A300  ///< Green (as a uint32)
-#define BLACK 0x000000  ///< Black (as a uint32)
-#define PINK 0xFF00FF   ///< Pink (as a uint32)
-#define BLUE 0x0000FF   ///< Blue (as a uint32)
-#define AMBER 0xFFBF00  ///< Amber (as a uint32)
+#define RED 0xFF0000                   ///< Red (as a uint32)
+#define CYAN 0x00FFFF                  ///< Cyan (as a uint32)
+#define YELLOW 0xFFFF00                ///< Yellow (as a uint32)
+#define GREEN 0x00A300                 ///< Green (as a uint32)
+#define BLACK 0x000000                 ///< Black (as a uint32)
+#define PINK 0xFF00FF                  ///< Pink (as a uint32)
+#define BLUE 0x0000FF                  ///< Blue (as a uint32)
+#define AMBER 0xFFBF00                 ///< Amber (as a uint32)
 
 // colors for each status state
 #define LED_NET_CONNECT PINK      ///< Network connection state


### PR DESCRIPTION
Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/229 by:
* Fixes default toggle operation of the Feather Huzzah ESP8266's built-in LED to match that of other boards
* Fixes incorrect status-led behavior, where the ESP8266's status led, is consistently red (on) during runtime