### PR TITLE
Allow setting status pixel brightness from secrets file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.56
+version=1.0.0-beta.57
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -2222,7 +2222,7 @@ void Wippersnapper::connect() {
   WS_DEBUG_PRINTLN("Hardware configured successfully!");
 
   // goto application
-  // statusLEDFade(GREEN, 3);
+  statusLEDFade(GREEN, 3);
   WS_DEBUG_PRINTLN(
       "Registration and configuration complete!\nRunning application...");
 }

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -2222,7 +2222,7 @@ void Wippersnapper::connect() {
   WS_DEBUG_PRINTLN("Hardware configured successfully!");
 
   // goto application
-  statusLEDFade(GREEN, 3);
+  // statusLEDFade(GREEN, 3);
   WS_DEBUG_PRINTLN(
       "Registration and configuration complete!\nRunning application...");
 }

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -209,6 +209,7 @@ public:
   bool lockStatusDotStar =
       false; ///< True if status LED is using the status dotstar
   bool lockStatusLED = false; ///< True if status LED is using the built-in LED
+  float status_pixel_brightness; ///< Global status pixel's brightness (from 0.0 to 1.0)
 
   virtual void set_user_key();
   virtual void set_ssid_pass(const char *ssid, const char *ssidPassword);

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -209,7 +209,9 @@ public:
   bool lockStatusDotStar =
       false; ///< True if status LED is using the status dotstar
   bool lockStatusLED = false; ///< True if status LED is using the built-in LED
-  float status_pixel_brightness; ///< Global status pixel's brightness (from 0.0 to 1.0)
+  float status_pixel_brightness =
+      STATUS_PIXEL_BRIGHTNESS_DEFAULT; ///< Global status pixel's brightness
+                                       ///< (from 0.0 to 1.0)
 
   virtual void set_user_key();
   virtual void set_ssid_pass(const char *ssid, const char *ssidPassword);

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -85,7 +85,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.56" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.57" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -18,7 +18,7 @@
 
 extern Wippersnapper WS;
 float pixel_brightness =
-    0.3; ///< LED's brightness level, 0.0 (0%) to 1.0 (100%)
+    0.2; ///< LED's brightness level, 0.0 (0%) to 1.0 (100%)
 #ifdef USE_STATUS_NEOPIXEL
 Adafruit_NeoPixel *statusPixel = new Adafruit_NeoPixel(
     STATUS_NEOPIXEL_NUM, STATUS_NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
@@ -133,11 +133,7 @@ void setStatusLEDColor(uint32_t color) {
   uint8_t green = (color >> 8) & 0xff; // green
   uint8_t blue = color & 0xff;         // blue
   // map() the pixel_brightness
-
-  float pixel_brightness = 0.1;
   int brightness = pixel_brightness * 255.0;
-  // you were printing this out, the time between blinks increased within the blink function so change it back
-  WS_DEBUG_PRINTLN(brightness);
   // flood all neopixels
   for (int i = 0; i < STATUS_NEOPIXEL_NUM; i++) {
     statusPixel->setPixelColor(i, brightness * red / 255,
@@ -200,7 +196,7 @@ void statusLEDFade(uint32_t color, int numFades = 3) {
       statusPixelDotStar->setBrightness(i);
       statusPixelDotStar->show();
 #elif defined(ARDUINO_ARCH_ESP32) && defined(USE_STATUS_LED)
-      ledcWrite(LEDC_CHANNEL_0, i);
+      WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, i);
 #else
       analogWrite(STATUS_LED_PIN, i);
 #endif
@@ -215,19 +211,13 @@ void statusLEDFade(uint32_t color, int numFades = 3) {
       statusPixelDotStar->setBrightness(i);
       statusPixelDotStar->show();
 #elif defined(ARDUINO_ARCH_ESP32) && defined(USE_STATUS_LED)
-      ledcWrite(LEDC_CHANNEL_0, i);
+      WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, i);
 #else
       analogWrite(STATUS_LED_PIN, i);
 #endif
       delay(10);
     }
   }
-
-// detach LEDC pin and reset its pinMode
-#if defined(ARDUINO_ARCH_ESP32) && defined(USE_STATUS_LED)
-  ledcDetachPin(STATUS_LED_PIN);
-  pinMode(STATUS_LED_PIN, OUTPUT);
-#endif
 
 // turn OFF ESP8266's status LED
 #if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
@@ -314,7 +304,7 @@ void statusLEDBlink(ws_led_status_t statusState) {
 
   while (blinkNum > 0) {
     setStatusLEDColor(ledColor);
-    delay(10000);
+    delay(100);
     setStatusLEDColor(BLACK);
 #if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
     // The Adafruit Feather ESP8266's built-in LED is reverse wired

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -167,6 +167,41 @@ void setStatusLEDColor(uint32_t color) {
 #endif
 }
 
+void setStatusLEDColor(uint32_t color, int brightness) {
+#ifdef USE_STATUS_NEOPIXEL
+  uint8_t red = (color >> 16) & 0xff;  // red
+  uint8_t green = (color >> 8) & 0xff; // green
+  uint8_t blue = color & 0xff;         // blue
+  // flood all neopixels
+  for (int i = 0; i < STATUS_NEOPIXEL_NUM; i++) {
+    statusPixel->setPixelColor(i, brightness * red / 255,
+                               brightness * green / 255,
+                               brightness * blue / 255);
+  }
+  statusPixel->show();
+#endif
+
+#ifdef USE_STATUS_DOTSTAR
+  uint8_t red = (color >> 16) & 0xff;  // red
+  uint8_t green = (color >> 8) & 0xff; // green
+  uint8_t blue = color & 0xff;         // blue
+  // flood all dotstar pixels
+  for (int i = 0; i < STATUS_DOTSTAR_NUM; i++) {
+    statusPixelDotStar->setPixelColor(i, brightness * red / 255,
+                                      brightness * green / 255,
+                                      brightness * blue / 255);
+  }
+  statusPixelDotStar->show();
+#endif
+
+#ifdef USE_STATUS_LED
+  if (color != BLACK)
+    WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, brightness);
+  else
+    WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, 0);
+#endif
+}
+
 /****************************************************************************/
 /*!
     @brief    Fades the status LED.
@@ -177,37 +212,16 @@ void setStatusLEDColor(uint32_t color) {
 */
 /****************************************************************************/
 void statusLEDFade(uint32_t color, int numFades = 3) {
-  setStatusLEDColor(color);
-
-  // pulse numFades times
+  // pulse `numFades` times
   for (int i = 0; i < numFades; i++) {
+    // fade up
     for (int i = 50; i <= 200; i += 5) {
-#if defined(USE_STATUS_NEOPIXEL)
-      statusPixel->setBrightness(i);
-      statusPixel->show();
-#elif defined(USE_STATUS_DOTSTAR)
-      statusPixelDotStar->setBrightness(i);
-      statusPixelDotStar->show();
-#elif defined(ARDUINO_ARCH_ESP32) && defined(USE_STATUS_LED)
-      WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, i);
-#else
-      analogWrite(STATUS_LED_PIN, i);
-#endif
+      setStatusLEDColor(color, i);
       delay(10);
     }
-
+    // fade down
     for (int i = 200; i >= 50; i -= 5) {
-#if defined(USE_STATUS_NEOPIXEL)
-      statusPixel->setBrightness(i);
-      statusPixel->show();
-#elif defined(USE_STATUS_DOTSTAR)
-      statusPixelDotStar->setBrightness(i);
-      statusPixelDotStar->show();
-#elif defined(ARDUINO_ARCH_ESP32) && defined(USE_STATUS_LED)
-      WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, i);
-#else
-      analogWrite(STATUS_LED_PIN, i);
-#endif
+      setStatusLEDColor(color, i);
       delay(10);
     }
   }

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -204,11 +204,13 @@ void setStatusLEDColor(uint32_t color, int brightness) {
 #endif
 
 #ifdef USE_STATUS_LED
-  if (color != BLACK)
+  if (color != BLACK) {
     // re-map for pixel as a LED
     int pulseWidth = map(brightness, 0, 255, 0, 1023);
-  WS._pwmComponent->writeDutyCycle(STATUS_LED_PIN, pulseWidth);
-  else WS._pwmComponent->writeDutyCycle(STATUS_LED_PIN, 0);
+    WS._pwmComponent->writeDutyCycle(STATUS_LED_PIN, pulseWidth);
+  } else {
+    WS._pwmComponent->writeDutyCycle(STATUS_LED_PIN, 0);
+  }
 #endif
 }
 

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -17,7 +17,7 @@
 #include "Wippersnapper.h"
 
 extern Wippersnapper WS;
-float pixel_brightness = 0.5; ///< LED's brightness level, 0.0 (0%) to 1.0 (100%)
+float pixel_brightness = 0.3; ///< LED's brightness level, 0.0 (0%) to 1.0 (100%)
 #ifdef USE_STATUS_NEOPIXEL
 Adafruit_NeoPixel *statusPixel = new Adafruit_NeoPixel(
     STATUS_NEOPIXEL_NUM, STATUS_NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
@@ -133,9 +133,12 @@ void setStatusLEDColor(uint32_t color) {
   uint8_t red = (color >> 16) & 0xff;  // red
   uint8_t green = (color >> 8) & 0xff; // green
   uint8_t blue = color & 0xff;         // blue
+  // map() the pixel_brightness
+  float pixel_brightness = 0.5;
+  int brightness = pixel_brightness * 255.0;
   // flood all neopixels
   for (int i = 0; i < STATUS_NEOPIXEL_NUM; i++) {
-    statusPixel->setPixelColor(i, red, green, blue);
+    statusPixel->setPixelColor(i, brightness*red/255, brightness*green/255, brightness*blue/255);
   }
   statusPixel->show();
 #endif
@@ -144,17 +147,20 @@ void setStatusLEDColor(uint32_t color) {
   uint8_t red = (color >> 16) & 0xff;  // red
   uint8_t green = (color >> 8) & 0xff; // green
   uint8_t blue = color & 0xff;         // blue
+  // map() the pixel_brightness
+  int brightness = pixel_brightness * 255.0;
   // flood all dotstar pixels
   for (int i = 0; i < STATUS_DOTSTAR_NUM; i++) {
-    statusPixelDotStar->setPixelColor(i, green, red, blue);
+    statusPixelDotStar->setPixelColor(i, brightness*red/255, brightness*green/255, brightness*blue/255);
   }
   statusPixelDotStar->show();
 #endif
 
 #ifdef USE_STATUS_LED
-  // via
-  // https://github.com/adafruit/circuitpython/blob/main/supervisor/shared/status_leds.c
-  digitalWrite(STATUS_LED_PIN, color > 0);
+  if (color != BLACK)
+    WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, map(pixel_brightness, 0.0, 1.0, 0, 1023));
+  else
+    WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, 0);
 #endif
 }
 
@@ -179,7 +185,7 @@ void statusLEDFade(uint32_t color, int numFades = 3) {
 
   // pulse numFades times
   for (int i = 0; i < numFades; i++) {
-    for (int i = 50; i <= 200; i += 5) {
+components/statusLED/Wippersnapper_StatusLED.cpp    for (int i = 50; i <= 200; i += 5) {
 #if defined(USE_STATUS_NEOPIXEL)
       statusPixel->setBrightness(i);
       statusPixel->show();

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -116,7 +116,9 @@ void statusLEDDeinit() {
               Desired pixel brightness, from 0.0 (0%) to 1.0 (100%).
 */
 /****************************************************************************/
-void setStatusLEDBrightness(float brightness) { WS.status_pixel_brightness = brightness; }
+void setStatusLEDBrightness(float brightness) {
+  WS.status_pixel_brightness = brightness;
+}
 
 /****************************************************************************/
 /*!
@@ -158,13 +160,22 @@ void setStatusLEDColor(uint32_t color) {
 
 #ifdef USE_STATUS_LED
   if (color != BLACK)
-    WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN,
-                                    map(WS.status_pixel_brightness, 0.0, 1.0, 0, 1023));
+    WS._pwmComponent.writeDutyCycle(
+        STATUS_LED_PIN, map(WS.status_pixel_brightness, 0.0, 1.0, 0, 1023));
   else
     WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, 0);
 #endif
 }
 
+/****************************************************************************/
+/*!
+    @brief    Sets a status RGB LED's color
+    @param    color
+              Desired RGB color.
+    @param    brightness
+              Brightness level, as an integer
+*/
+/****************************************************************************/
 void setStatusLEDColor(uint32_t color, int brightness) {
 #ifdef USE_STATUS_NEOPIXEL
   uint8_t red = (color >> 16) & 0xff;  // red
@@ -194,9 +205,10 @@ void setStatusLEDColor(uint32_t color, int brightness) {
 
 #ifdef USE_STATUS_LED
   if (color != BLACK)
-    WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, brightness);
-  else
-    WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, 0);
+    // re-map for pixel as a LED
+    int pulseWidth = map(brightness, 0, 255, 0, 1023);
+  WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, pulseWidth);
+  else WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, 0);
 #endif
 }
 
@@ -210,15 +222,19 @@ void setStatusLEDColor(uint32_t color, int brightness) {
 */
 /****************************************************************************/
 void statusLEDFade(uint32_t color, int numFades = 3) {
+  // don't fade if our pixel is off
+  if (WS.status_pixel_brightness == 0.0)
+    return;
+
   // pulse `numFades` times
   for (int i = 0; i < numFades; i++) {
     // fade up
-    for (int i = 50; i <= 200; i += 5) {
+    for (int i = 0; i <= 255; i += 5) {
       setStatusLEDColor(color, i);
       delay(10);
     }
     // fade down
-    for (int i = 200; i >= 50; i -= 5) {
+    for (int i = 0; i >= 255; i -= 5) {
       setStatusLEDColor(color, i);
       delay(10);
     }

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -17,8 +17,6 @@
 #include "Wippersnapper.h"
 
 extern Wippersnapper WS;
-float pixel_brightness =
-    0.2; ///< LED's brightness level, 0.0 (0%) to 1.0 (100%)
 #ifdef USE_STATUS_NEOPIXEL
 Adafruit_NeoPixel *statusPixel = new Adafruit_NeoPixel(
     STATUS_NEOPIXEL_NUM, STATUS_NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
@@ -118,7 +116,7 @@ void statusLEDDeinit() {
               Desired pixel brightness, from 0.0 (0%) to 1.0 (100%).
 */
 /****************************************************************************/
-void setStatusLEDBrightness(float brightness) { pixel_brightness = brightness; }
+void setStatusLEDBrightness(float brightness) { WS.status_pixel_brightness = brightness; }
 
 /****************************************************************************/
 /*!
@@ -132,8 +130,8 @@ void setStatusLEDColor(uint32_t color) {
   uint8_t red = (color >> 16) & 0xff;  // red
   uint8_t green = (color >> 8) & 0xff; // green
   uint8_t blue = color & 0xff;         // blue
-  // map() the pixel_brightness
-  int brightness = pixel_brightness * 255.0;
+  // map() the WS.status_pixel_brightness
+  int brightness = WS.status_pixel_brightness * 255.0;
   // flood all neopixels
   for (int i = 0; i < STATUS_NEOPIXEL_NUM; i++) {
     statusPixel->setPixelColor(i, brightness * red / 255,
@@ -147,8 +145,8 @@ void setStatusLEDColor(uint32_t color) {
   uint8_t red = (color >> 16) & 0xff;  // red
   uint8_t green = (color >> 8) & 0xff; // green
   uint8_t blue = color & 0xff;         // blue
-  // map() the pixel_brightness
-  int brightness = pixel_brightness * 255.0;
+  // map() the WS.status_pixel_brightness
+  int brightness = WS.status_pixel_brightness * 255.0;
   // flood all dotstar pixels
   for (int i = 0; i < STATUS_DOTSTAR_NUM; i++) {
     statusPixelDotStar->setPixelColor(i, brightness * red / 255,
@@ -161,7 +159,7 @@ void setStatusLEDColor(uint32_t color) {
 #ifdef USE_STATUS_LED
   if (color != BLACK)
     WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN,
-                                    map(pixel_brightness, 0.0, 1.0, 0, 1023));
+                                    map(WS.status_pixel_brightness, 0.0, 1.0, 0, 1023));
   else
     WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, 0);
 #endif

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -179,13 +179,6 @@ void setStatusLEDColor(uint32_t color) {
 void statusLEDFade(uint32_t color, int numFades = 3) {
   setStatusLEDColor(color);
 
-// attach LEDC pin
-// TODO: Remove and replace with ws pwm component instead
-#if defined(ARDUINO_ARCH_ESP32) && defined(USE_STATUS_LED)
-  ledcSetup(LEDC_CHANNEL_0, LEDC_BASE_FREQ, LEDC_TIMER_12_BIT);
-  ledcAttachPin(STATUS_LED_PIN, LEDC_CHANNEL_0);
-#endif
-
   // pulse numFades times
   for (int i = 0; i < numFades; i++) {
     for (int i = 50; i <= 200; i += 5) {

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -17,7 +17,8 @@
 #include "Wippersnapper.h"
 
 extern Wippersnapper WS;
-float pixel_brightness = 0.3; ///< LED's brightness level, 0.0 (0%) to 1.0 (100%)
+float pixel_brightness =
+    0.3; ///< LED's brightness level, 0.0 (0%) to 1.0 (100%)
 #ifdef USE_STATUS_NEOPIXEL
 Adafruit_NeoPixel *statusPixel = new Adafruit_NeoPixel(
     STATUS_NEOPIXEL_NUM, STATUS_NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
@@ -68,15 +69,15 @@ bool statusLEDInit() {
 #ifdef USE_STATUS_LED
   pinMode(STATUS_LED_PIN, OUTPUT);
 
-  // Turn off LED initially
-  #if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
+// Turn off LED initially
+#if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
   analogWrite(STATUS_LED_PIN, 255);
-  #elif defined(ARDUINO_ARCH_ESP32)
+#elif defined(ARDUINO_ARCH_ESP32)
   WS._pwmComponent.attach(STATUS_LED_PIN, LEDC_BASE_FREQ, LEDC_TIMER_12_BIT);
   WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, 0); // turn OFF
-  #else
+#else
   analogWrite(STATUS_LED_PIN, 0);
-  #endif
+#endif
 
   WS.lockStatusLED = true; // set global pin "lock" flag
   is_success = true;
@@ -117,9 +118,7 @@ void statusLEDDeinit() {
               Desired pixel brightness, from 0.0 (0%) to 1.0 (100%).
 */
 /****************************************************************************/
-void setStatusLEDBrightness(float brightness) {
-  pixel_brightness = brightness;
-}
+void setStatusLEDBrightness(float brightness) { pixel_brightness = brightness; }
 
 /****************************************************************************/
 /*!
@@ -134,11 +133,13 @@ void setStatusLEDColor(uint32_t color) {
   uint8_t green = (color >> 8) & 0xff; // green
   uint8_t blue = color & 0xff;         // blue
   // map() the pixel_brightness
-  float pixel_brightness = 0.5;
+  float pixel_brightness = 1.0;
   int brightness = pixel_brightness * 255.0;
   // flood all neopixels
   for (int i = 0; i < STATUS_NEOPIXEL_NUM; i++) {
-    statusPixel->setPixelColor(i, brightness*red/255, brightness*green/255, brightness*blue/255);
+    statusPixel->setPixelColor(i, brightness * red / 255,
+                               brightness * green / 255,
+                               brightness * blue / 255);
   }
   statusPixel->show();
 #endif
@@ -151,14 +152,17 @@ void setStatusLEDColor(uint32_t color) {
   int brightness = pixel_brightness * 255.0;
   // flood all dotstar pixels
   for (int i = 0; i < STATUS_DOTSTAR_NUM; i++) {
-    statusPixelDotStar->setPixelColor(i, brightness*red/255, brightness*green/255, brightness*blue/255);
+    statusPixelDotStar->setPixelColor(i, brightness * red / 255,
+                                      brightness * green / 255,
+                                      brightness * blue / 255);
   }
   statusPixelDotStar->show();
 #endif
 
 #ifdef USE_STATUS_LED
   if (color != BLACK)
-    WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, map(pixel_brightness, 0.0, 1.0, 0, 1023));
+    WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN,
+                                    map(pixel_brightness, 0.0, 1.0, 0, 1023));
   else
     WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, 0);
 #endif
@@ -185,7 +189,7 @@ void statusLEDFade(uint32_t color, int numFades = 3) {
 
   // pulse numFades times
   for (int i = 0; i < numFades; i++) {
-components/statusLED/Wippersnapper_StatusLED.cpp    for (int i = 50; i <= 200; i += 5) {
+    for (int i = 50; i <= 200; i += 5) {
 #if defined(USE_STATUS_NEOPIXEL)
       statusPixel->setBrightness(i);
       statusPixel->show();

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -226,14 +226,12 @@ void statusLEDFade(uint32_t color, int numFades = 3) {
     }
   }
 
-// turn OFF ESP8266's status LED
-#if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
-  // The Adafruit Feather ESP8266's built-in LED is reverse wired
-  // clear status LED color
-  setStatusLEDColor(BLACK ^ 1);
-#else
-  // clear status LED color
+// Turn status LED off
+#if not defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
   setStatusLEDColor(BLACK);
+#else
+  // The Adafruit Feather ESP8266's built-in LED is reverse wired
+  setStatusLEDColor(BLACK ^ 1);
 #endif
 }
 
@@ -305,14 +303,13 @@ void statusLEDBlink(ws_led_status_t statusState) {
 #endif
 
   // set number of times to blink
-  int blinkNum = 2;
+  int blinkNum = 3;
   // set blink color
   uint32_t ledColor = ledStatusStateToColor(statusState);
 
   while (blinkNum > 0) {
     setStatusLEDColor(ledColor);
     delay(100);
-    setStatusLEDColor(BLACK);
 #if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
     // The Adafruit Feather ESP8266's built-in LED is reverse wired
     setStatusLEDColor(BLACK ^ 1);

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -133,8 +133,9 @@ void setStatusLEDColor(uint32_t color) {
   uint8_t green = (color >> 8) & 0xff; // green
   uint8_t blue = color & 0xff;         // blue
   // map() the pixel_brightness
-  float pixel_brightness = 1.0;
+  float pixel_brightness = 0.1;
   int brightness = pixel_brightness * 255.0;
+  WS_DEBUG_PRINTLN(brightness);
   // flood all neopixels
   for (int i = 0; i < STATUS_NEOPIXEL_NUM; i++) {
     statusPixel->setPixelColor(i, brightness * red / 255,
@@ -311,7 +312,7 @@ void statusLEDBlink(ws_led_status_t statusState) {
 
   while (blinkNum > 0) {
     setStatusLEDColor(ledColor);
-    delay(100);
+    delay(10000);
     setStatusLEDColor(BLACK);
 #if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
     // The Adafruit Feather ESP8266's built-in LED is reverse wired

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -71,8 +71,8 @@ bool statusLEDInit() {
 #if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
   analogWrite(STATUS_LED_PIN, 255);
 #elif defined(ARDUINO_ARCH_ESP32)
-  WS._pwmComponent.attach(STATUS_LED_PIN, LEDC_BASE_FREQ, LEDC_TIMER_12_BIT);
-  WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, 0); // turn OFF
+  WS._pwmComponent->attach(STATUS_LED_PIN, LEDC_BASE_FREQ, LEDC_TIMER_12_BIT);
+  WS._pwmComponent->writeDutyCycle(STATUS_LED_PIN, 0); // turn OFF
 #else
   analogWrite(STATUS_LED_PIN, 0);
 #endif
@@ -160,10 +160,10 @@ void setStatusLEDColor(uint32_t color) {
 
 #ifdef USE_STATUS_LED
   if (color != BLACK)
-    WS._pwmComponent.writeDutyCycle(
+    WS._pwmComponent->writeDutyCycle(
         STATUS_LED_PIN, map(WS.status_pixel_brightness, 0.0, 1.0, 0, 1023));
   else
-    WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, 0);
+    WS._pwmComponent->writeDutyCycle(STATUS_LED_PIN, 0);
 #endif
 }
 
@@ -207,8 +207,8 @@ void setStatusLEDColor(uint32_t color, int brightness) {
   if (color != BLACK)
     // re-map for pixel as a LED
     int pulseWidth = map(brightness, 0, 255, 0, 1023);
-  WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, pulseWidth);
-  else WS._pwmComponent.writeDutyCycle(STATUS_LED_PIN, 0);
+  WS._pwmComponent->writeDutyCycle(STATUS_LED_PIN, pulseWidth);
+  else WS._pwmComponent->writeDutyCycle(STATUS_LED_PIN, 0);
 #endif
 }
 

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -133,8 +133,10 @@ void setStatusLEDColor(uint32_t color) {
   uint8_t green = (color >> 8) & 0xff; // green
   uint8_t blue = color & 0xff;         // blue
   // map() the pixel_brightness
+
   float pixel_brightness = 0.1;
   int brightness = pixel_brightness * 255.0;
+  // you were printing this out, the time between blinks increased within the blink function so change it back
   WS_DEBUG_PRINTLN(brightness);
   // flood all neopixels
   for (int i = 0; i < STATUS_NEOPIXEL_NUM; i++) {

--- a/src/components/statusLED/Wippersnapper_StatusLED.h
+++ b/src/components/statusLED/Wippersnapper_StatusLED.h
@@ -60,6 +60,7 @@ typedef enum ws_led_status_t {
 bool statusLEDInit();
 void statusLEDDeinit();
 uint32_t ledStatusStateToColor(ws_led_status_t statusState);
+void setStatusLEDBrightness(float brightness);
 void setStatusLEDColor(uint32_t color);
 void statusLEDBlink(ws_led_status_t statusState = WS_LED_STATUS_ERROR_RUNTIME);
 void statusLEDFade(uint32_t color, int numFades);

--- a/src/components/statusLED/Wippersnapper_StatusLED.h
+++ b/src/components/statusLED/Wippersnapper_StatusLED.h
@@ -56,6 +56,8 @@ typedef enum ws_led_status_t {
 #define LED_CONNECTED GREEN       ///< Successful registration state
 #define LED_ERROR RED             ///< Error state
 
+#define STATUS_PIXEL_BRIGHTNESS_DEFAULT 0.5 ///< Default status pixel brightness
+
 // Status LED
 bool statusLEDInit();
 void statusLEDDeinit();

--- a/src/components/statusLED/Wippersnapper_StatusLED.h
+++ b/src/components/statusLED/Wippersnapper_StatusLED.h
@@ -62,6 +62,7 @@ void statusLEDDeinit();
 uint32_t ledStatusStateToColor(ws_led_status_t statusState);
 void setStatusLEDBrightness(float brightness);
 void setStatusLEDColor(uint32_t color);
+void setStatusLEDColor(uint32_t color, int brightness);
 void statusLEDBlink(ws_led_status_t statusState = WS_LED_STATUS_ERROR_RUNTIME);
 void statusLEDFade(uint32_t color, int numFades);
 void statusLEDSolid(ws_led_status_t statusState);

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -94,7 +94,8 @@ void WipperSnapper_LittleFS::parseSecrets() {
 
   // Parse SSID
   // Check if network type is WiFi
-  const char *network_type_wifi_ssid = _doc["network_type_wifi"]["network_ssid"];
+  const char *network_type_wifi_ssid =
+      _doc["network_type_wifi"]["network_ssid"];
   if (network_type_wifi_ssid != nullptr) {
     WS._network_ssid = network_type_wifi_ssid;
   }
@@ -105,7 +106,8 @@ void WipperSnapper_LittleFS::parseSecrets() {
   }
 
   // Parse WiFi network password
-  const char *network_type_wifi_password = _doc["network_type_wifi"]["network_password"];
+  const char *network_type_wifi_password =
+      _doc["network_type_wifi"]["network_password"];
   if (network_type_wifi_password != nullptr) {
     WS._network_pass = network_type_wifi_password;
   }
@@ -120,12 +122,12 @@ void WipperSnapper_LittleFS::parseSecrets() {
   WS._mqttBrokerURL = _doc["io_url"];
 
   // Get (optional) setting for the status pixel brightness
-  const char *status_pixel_brightness = doc["status_pixel_brightness"];
+  const char *status_pixel_brightness = _doc["status_pixel_brightness"];
   // Not found, that's ok, we'll use the default brightness instead
   if (status_pixel_brightness == nullptr) {
     WS.status_pixel_brightness = STATUS_PIXEL_BRIGHTNESS_DEFAULT;
   } else {
-    // take status_pixel_brightness and convert to a float 
+    // take status_pixel_brightness and convert to a float
     WS.status_pixel_brightness = atof(status_pixel_brightness);
   }
 

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -125,10 +125,9 @@ void WipperSnapper_LittleFS::parseSecrets() {
   const char *status_pixel_brightness = _doc["status_pixel_brightness"];
   // Not found, that's ok, we'll use the default brightness instead
   if (status_pixel_brightness == nullptr) {
-    WS.status_pixel_brightness = STATUS_PIXEL_BRIGHTNESS_DEFAULT;
+    setStatusLEDBrightness(STATUS_PIXEL_BRIGHTNESS_DEFAULT);
   } else {
-    // take status_pixel_brightness and convert to a float
-    WS.status_pixel_brightness = atof(status_pixel_brightness);
+    setStatusLEDBrightness(atof(status_pixel_brightness));
   }
 
   // close the file

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -119,6 +119,16 @@ void WipperSnapper_LittleFS::parseSecrets() {
   // Optionally set the Adafruit.io URL
   WS._mqttBrokerURL = _doc["io_url"];
 
+  // Get (optional) setting for the status pixel brightness
+  const char *status_pixel_brightness = doc["status_pixel_brightness"];
+  // Not found, that's ok, we'll use the default brightness instead
+  if (status_pixel_brightness == nullptr) {
+    WS.status_pixel_brightness = STATUS_PIXEL_BRIGHTNESS_DEFAULT;
+  } else {
+    // take status_pixel_brightness and convert to a float 
+    WS.status_pixel_brightness = atof(status_pixel_brightness);
+  }
+
   // close the file
   secretsFile.close();
 

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -93,17 +93,8 @@ void WipperSnapper_LittleFS::parseSecrets() {
   WS._key = io_key;
 
   // Parse SSID
-
-  // TODO: Remove the following check in future versions
-  // Check if network type is native WiFi
-  const char *network_type_wifi_ssid =
-      _doc["network_type_wifi_native"]["network_ssid"];
-  if (network_type_wifi_ssid != nullptr) {
-    WS._network_ssid = network_type_wifi_ssid;
-  }
-
   // Check if network type is WiFi
-  network_type_wifi_ssid = _doc["network_type_wifi"]["network_ssid"];
+  const char *network_type_wifi_ssid = _doc["network_type_wifi"]["network_ssid"];
   if (network_type_wifi_ssid != nullptr) {
     WS._network_ssid = network_type_wifi_ssid;
   }
@@ -113,18 +104,8 @@ void WipperSnapper_LittleFS::parseSecrets() {
     fsHalt();
   }
 
-  // Parse SSID password
-
-  // TODO: Remove on next release
-  // Parse WiFi network password, native
-  const char *network_type_wifi_password =
-      _doc["network_type_wifi_native"]["network_password"];
-  if (network_type_wifi_password != nullptr) {
-    WS._network_pass = network_type_wifi_password;
-  }
-
   // Parse WiFi network password
-  network_type_wifi_password = _doc["network_type_wifi"]["network_password"];
+  const char *network_type_wifi_password = _doc["network_type_wifi"]["network_password"];
   if (network_type_wifi_password != nullptr) {
     WS._network_pass = network_type_wifi_password;
   }

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -371,22 +371,6 @@ void Wippersnapper_FS::parseSecrets() {
   WS._key = io_key;
 
   // Parse WiFi Network SSID
-  // TODO: The following lines allow backwards-compatibiity for older
-  // secrets.json files, added in b32
-  // TODO: Remove the following check in future versions
-  // Check if network type is AirLift WiFi
-  const char *network_type_wifi_ssid =
-      doc["network_type_wifi_airlift"]["network_ssid"];
-  if (network_type_wifi_ssid != nullptr) {
-    WS._network_ssid = network_type_wifi_ssid;
-  }
-
-  // TODO: Remove the following check in future versions
-  // Check if network type is native WiFi
-  network_type_wifi_ssid = doc["network_type_wifi_native"]["network_ssid"];
-  if (network_type_wifi_ssid != nullptr) {
-    WS._network_ssid = network_type_wifi_ssid;
-  }
   // Check if network type is WiFi
   network_type_wifi_ssid = doc["network_type_wifi"]["network_ssid"];
   if (network_type_wifi_ssid != nullptr) {
@@ -413,25 +397,6 @@ void Wippersnapper_FS::parseSecrets() {
   }
 
   // Parse WiFi Network Password
-  // TODO: The following lines allow backwards-compatibiity for older
-  // secrets.json files, added in b32
-
-  // TODO: Remove the following check in future versions
-  // Check if network type is AirLift WiFi
-  const char *network_type_wifi_password =
-      doc["network_type_wifi_airlift"]["network_password"];
-  if (network_type_wifi_password != nullptr) {
-    WS._network_pass = network_type_wifi_password;
-  }
-
-  // TODO: Remove the following check in future versions
-  // Check if network type is native WiFi
-  network_type_wifi_password =
-      doc["network_type_wifi_native"]["network_password"];
-  if (network_type_wifi_password != nullptr) {
-    WS._network_pass = network_type_wifi_password;
-  }
-
   // Check if network type is WiFi
   network_type_wifi_password = doc["network_type_wifi"]["network_password"];
   if (network_type_wifi_password != nullptr) {

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -431,10 +431,9 @@ void Wippersnapper_FS::parseSecrets() {
   const char *status_pixel_brightness = doc["status_pixel_brightness"];
   // Not found, that's ok, we'll use the default brightness instead
   if (status_pixel_brightness == nullptr) {
-    WS.status_pixel_brightness = STATUS_PIXEL_BRIGHTNESS_DEFAULT;
+    setStatusLEDBrightness(STATUS_PIXEL_BRIGHTNESS_DEFAULT);
   } else {
-    // take status_pixel_brightness and convert to a float
-    WS.status_pixel_brightness = atof(status_pixel_brightness);
+    setStatusLEDBrightness(atof(status_pixel_brightness));
   }
 
   // clear the document and release all memory from the memory pool

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -422,8 +422,18 @@ void Wippersnapper_FS::parseSecrets() {
   writeToBootOut(WS._network_ssid);
   writeToBootOut("\n");
 
-  // Optional, Set the IO URL
+  // Optionally set the MQTT broker url (used to switch btween prod. and staging)
   WS._mqttBrokerURL = doc["io_url"];
+
+  // Get (optional) setting for the status pixel brightness
+  const char *status_pixel_brightness = doc["status_pixel_brightness"];
+  // Not found, that's ok, we'll use the default brightness instead
+  if (status_pixel_brightness == nullptr) {
+    WS.status_pixel_brightness = STATUS_PIXEL_BRIGHTNESS_DEFAULT;
+  } else {
+    // take status_pixel_brightness and convert to a float 
+    WS.status_pixel_brightness = atof(status_pixel_brightness);
+  }
 
   // clear the document and release all memory from the memory pool
   doc.clear();

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -302,8 +302,8 @@ void Wippersnapper_FS::createConfigFileSkel() {
   secretsFile.print("HERE\",\n\t\"network_type_wifi\":{\n\t\t\"network_"
                     "ssid\":\"YOUR_WIFI_SSID_");
   secretsFile.flush();
-  secretsFile.print(
-      "HERE\",\n\t\t\"network_password\":\"YOUR_WIFI_PASS_HERE\"\n\t}\n}");
+  secretsFile.print("HERE\",\n\t\t\"network_password\":\"YOUR_WIFI_PASS_"
+                    "HERE\"\n\t},\n\t\"status_pixel_brightness\":\"0.5\"\n}");
   secretsFile.flush();
   secretsFile.close();
   writeToBootOut(
@@ -372,7 +372,7 @@ void Wippersnapper_FS::parseSecrets() {
 
   // Parse WiFi Network SSID
   // Check if network type is WiFi
-  network_type_wifi_ssid = doc["network_type_wifi"]["network_ssid"];
+  const char *network_type_wifi_ssid = doc["network_type_wifi"]["network_ssid"];
   if (network_type_wifi_ssid != nullptr) {
     WS._network_ssid = network_type_wifi_ssid;
   }
@@ -398,7 +398,8 @@ void Wippersnapper_FS::parseSecrets() {
 
   // Parse WiFi Network Password
   // Check if network type is WiFi
-  network_type_wifi_password = doc["network_type_wifi"]["network_password"];
+  const char *network_type_wifi_password =
+      doc["network_type_wifi"]["network_password"];
   if (network_type_wifi_password != nullptr) {
     WS._network_pass = network_type_wifi_password;
   }
@@ -422,7 +423,8 @@ void Wippersnapper_FS::parseSecrets() {
   writeToBootOut(WS._network_ssid);
   writeToBootOut("\n");
 
-  // Optionally set the MQTT broker url (used to switch btween prod. and staging)
+  // Optionally set the MQTT broker url (used to switch btween prod. and
+  // staging)
   WS._mqttBrokerURL = doc["io_url"];
 
   // Get (optional) setting for the status pixel brightness
@@ -431,7 +433,7 @@ void Wippersnapper_FS::parseSecrets() {
   if (status_pixel_brightness == nullptr) {
     WS.status_pixel_brightness = STATUS_PIXEL_BRIGHTNESS_DEFAULT;
   } else {
-    // take status_pixel_brightness and convert to a float 
+    // take status_pixel_brightness and convert to a float
     WS.status_pixel_brightness = atof(status_pixel_brightness);
   }
 


### PR DESCRIPTION
Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/365 by:
* Exposing a user-settable configuration field for the pixel's brightness within `secrets.json` as a new field, `status_pixel_brightness`. This field can range from 0.0 (totally off, 0% brightness) to 1.0 (100% brightness, fully on):
```
{
	"io_username":"",
	"io_key":"",
    "io_url":"io.adafruit.",
	"network_type_wifi":{
		"network_ssid":"",
		"network_password":""
	},
    "status_pixel_brightness": "0.2"
}
```
* Removes existing calls to `setBrightness` within `src/components/statusLED/Wippersnapper_StatusLED.cpp`, we'll use math to set the color value instead of calling this setup function repeatedly.
* Replaces ESP32-LEC-HAL calls with calls to WipperSnapper's new PWM manager class 