### PR TITLE
Add Sensirion SEN55 (maybe SEN54/SEN50 for free)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino client for Adafruit.io WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, arduino-sht, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit_VL53L0X, Adafruit PM25 AQI Sensor, Adafruit VEML7700 Library, Adafruit LC709203F, Adafruit seesaw Library, Adafruit BME680 Library
+depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, Sensirion I2C SEN5X, arduino-sht, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit_VL53L0X, Adafruit PM25 AQI Sensor, Adafruit VEML7700 Library, Adafruit LC709203F, Adafruit seesaw Library, Adafruit BME680 Library

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -945,6 +945,49 @@ void WipperSnapper_Component_I2C::update() {
       (*iter)->setSensorGasResistancePeriodPrv(curTime);
     }
 
+    // NOx-index sensor
+    curTime = millis();
+    if ((*iter)->getSensorNOxIndexPeriod() != 0L &&
+        curTime - (*iter)->getSensorNOxIndexPeriodPrv() >
+            (*iter)->getSensorNOxIndexPeriod()) {
+      if ((*iter)->getEventNOxIndex(&event)) {
+        WS_DEBUG_PRINT("Sensor 0x");
+        WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
+        WS_DEBUG_PRINTLN("");
+        WS_DEBUG_PRINT("\tNOx Index: ");
+        WS_DEBUG_PRINT(event.nox_index);
+
+        fillEventMessage(
+            &msgi2cResponse, event.data[0],
+            wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_NOX_INDEX);
+      } else {
+        WS_DEBUG_PRINTLN(
+            "ERROR: Failed to obtain NOx index sensor reading!");
+      }
+      (*iter)->setSensorNOxIndexPeriodPrv(curTime);
+    }
+
+    // VOC-index sensor
+    curTime = millis();
+    if ((*iter)->getSensorVOCIndexPeriod() != 0L &&
+        curTime - (*iter)->getSensorVOCIndexPeriodPrv() >
+            (*iter)->getSensorVOCIndexPeriod()) {
+      if ((*iter)->getEventVOCIndex(&event)) {
+        WS_DEBUG_PRINT("Sensor 0x");
+        WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
+        WS_DEBUG_PRINTLN("");
+        WS_DEBUG_PRINT("\tVOC Index: ");
+        WS_DEBUG_PRINT(event.voc_index);
+
+        fillEventMessage(
+            &msgi2cResponse, event.data[0],
+            wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_VOC_INDEX);
+      } else {
+        WS_DEBUG_PRINTLN(
+            "ERROR: Failed to obtain VOC index sensor reading!");
+      }
+      (*iter)->setSensorVOCIndexPeriodPrv(curTime);
+    }
     // Proximity sensor
     curTime = millis();
     if ((*iter)->sensorProximityPeriod() != 0L &&

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -957,12 +957,10 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINT("\tNOx Index: ");
         WS_DEBUG_PRINT(event.nox_index);
 
-        fillEventMessage(
-            &msgi2cResponse, event.data[0],
-            wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_NOX_INDEX);
+        fillEventMessage(&msgi2cResponse, event.data[0],
+                         wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_NOX_INDEX);
       } else {
-        WS_DEBUG_PRINTLN(
-            "ERROR: Failed to obtain NOx index sensor reading!");
+        WS_DEBUG_PRINTLN("ERROR: Failed to obtain NOx index sensor reading!");
       }
       (*iter)->setSensorNOxIndexPeriodPrv(curTime);
     }
@@ -979,12 +977,10 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINT("\tVOC Index: ");
         WS_DEBUG_PRINT(event.voc_index);
 
-        fillEventMessage(
-            &msgi2cResponse, event.data[0],
-            wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_VOC_INDEX);
+        fillEventMessage(&msgi2cResponse, event.data[0],
+                         wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_VOC_INDEX);
       } else {
-        WS_DEBUG_PRINTLN(
-            "ERROR: Failed to obtain VOC index sensor reading!");
+        WS_DEBUG_PRINTLN("ERROR: Failed to obtain VOC index sensor reading!");
       }
       (*iter)->setSensorVOCIndexPeriodPrv(curTime);
     }

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -325,7 +325,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _scd40->configureDriver(msgDeviceInitReq);
     drivers.push_back(_scd40);
     WS_DEBUG_PRINTLN("SCD40 Initialized Successfully!");
-  } else if (strcmp("sen55", msgDeviceInitReq->i2c_device_name) == 0) {
+  } else if (strcmp("sen5x", msgDeviceInitReq->i2c_device_name) == 0) {
     _sen5x = new WipperSnapper_I2C_Driver_SEN5X(this->_i2c, i2cAddress);
     if (!_sen5x->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize SEN5X!");

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -325,6 +325,17 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _scd40->configureDriver(msgDeviceInitReq);
     drivers.push_back(_scd40);
     WS_DEBUG_PRINTLN("SCD40 Initialized Successfully!");
+  } else if (strcmp("sen55", msgDeviceInitReq->i2c_device_name) == 0) {
+    _sen5x = new WipperSnapper_I2C_Driver_SEN5X(this->_i2c, i2cAddress);
+    if (!_sen5x->begin()) {
+      WS_DEBUG_PRINTLN("ERROR: Failed to initialize SEN5X!");
+      _busStatusResponse =
+          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
+      return false;
+    }
+    _sen5x->configureDriver(msgDeviceInitReq);
+    drivers.push_back(_sen5x);
+    WS_DEBUG_PRINTLN("SEN5X Initialized Successfully!");
   } else if (strcmp("sht40", msgDeviceInitReq->i2c_device_name) == 0) {
     _sht4x = new WipperSnapper_I2C_Driver_SHT4X(this->_i2c, i2cAddress);
     if (!_sht4x->begin()) {

--- a/src/components/i2c/WipperSnapper_I2C.h
+++ b/src/components/i2c/WipperSnapper_I2C.h
@@ -29,6 +29,7 @@
 #include "drivers/WipperSnapper_I2C_Driver_PM25.h"
 #include "drivers/WipperSnapper_I2C_Driver_SCD30.h"
 #include "drivers/WipperSnapper_I2C_Driver_SCD40.h"
+#include "drivers/WipperSnapper_I2C_Driver_SEN5X.h"
 #include "drivers/WipperSnapper_I2C_Driver_SHT3X.h"
 #include "drivers/WipperSnapper_I2C_Driver_SHT4X.h"
 #include "drivers/WipperSnapper_I2C_Driver_SHTC3.h"
@@ -90,6 +91,7 @@ private:
   WipperSnapper_I2C_Driver_TSL2591 *_tsl2591 = nullptr;
   WipperSnapper_I2C_Driver_VEML7700 *_veml7700 = nullptr;
   WipperSnapper_I2C_Driver_SCD40 *_scd40 = nullptr;
+  WipperSnapper_I2C_Driver_SEN5X *_sen5x = nullptr;
   WipperSnapper_I2C_Driver_PM25 *_pm25 = nullptr;
   WipperSnapper_I2C_Driver_SI7021 *_si7021 = nullptr;
   WipperSnapper_I2C_Driver_SHT4X *_sht4x = nullptr;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -121,6 +121,12 @@ public:
     case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_GAS_RESISTANCE:
       _gasResistancePeriod = sensorPeriod;
       break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_NOX_INDEX:
+      _NOxIndexPeriod = sensorPeriod;
+      break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_VOC_INDEX:
+      _VOCIndexPeriod = sensorPeriod;
+      break;
     default:
       break;
     }
@@ -926,6 +932,109 @@ public:
     return false;
   }
 
+  /****************************** SENSOR_TYPE: NOx Index (index)
+   * *******************************/
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the NOx Index
+     sensor's period, if set.
+      @returns  Time when the  NOx Index sensor should be polled,
+                in seconds.
+  */
+  /*********************************************************************************/
+  virtual long getSensorNOxIndexPeriod() { return _NOxIndexPeriod; }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the previous time interval at
+                which the NOx Index sensor was queried last.
+      @returns  Time when the NOx Index sensor was last queried,
+                in seconds.
+  */
+  /*********************************************************************************/
+  virtual long getSensorNOxIndexPeriodPrv() {
+    return _NOxIndexPeriodPrv;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Sets a timestamp for when the object NOx Index sensor
+                was queried.
+      @param    period
+                The time when the NOx Index sensor was queried
+     last.
+  */
+  /*******************************************************************************/
+  virtual void setSensorNOxIndexPeriodPrv(long period) {
+    _NOxIndexPeriodPrv = period;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Base implementation - Reads a NOx Index sensor and converts
+                the reading into the expected SI unit.
+      @param    gasEvent
+                NOx Index sensor reading, in ohms.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  virtual bool getEventNOxIndex(sensors_event_t *gasEvent) {
+    return false;
+  }
+
+  /****************************** SENSOR_TYPE: VOC Index (index)
+   * *******************************/
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the VOC Index
+     sensor's period, if set.
+      @returns  Time when the  VOC Index sensor should be polled,
+                in seconds.
+  */
+  /*********************************************************************************/
+  virtual long getSensorVOCIndexPeriod() { return _VOCIndexPeriod; }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the previous time interval at
+                which the VOC Index sensor was queried last.
+      @returns  Time when the VOC Index sensor was last queried,
+                in seconds.
+  */
+  /*********************************************************************************/
+  virtual long getSensorVOCIndexPeriodPrv() {
+    return _VOCIndexPeriodPrv;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Sets a timestamp for when the object VOC Index sensor
+                was queried.
+      @param    period
+                The time when the VOC Index sensor was queried
+     last.
+  */
+  /*******************************************************************************/
+  virtual void setSensorVOCIndexPeriodPrv(long period) {
+    _VOCIndexPeriodPrv = period;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Base implementation - Reads a VOC Index sensor and converts
+                the reading into the expected SI unit.
+      @param    gasEvent
+                VOC Index sensor reading, in ohms.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  virtual bool getEventVOCIndex(sensors_event_t *gasEvent) {
+    return false;
+  }
+
+
   /**************************** SENSOR_TYPE: PROXIMITY
    * ****************************/
   /*******************************************************************************/
@@ -1080,6 +1189,14 @@ protected:
   long _gasResistancePeriod = 0L;    ///< The time period between reading the
                                      ///< gas resistance sensor's value.
   long _gasResistancePeriodPrv = 0L; ///< The time when the gas resistance
+                                     ///< sensor was last read.
+  long _NOxIndexPeriod = 0L;    ///< The time period between reading the
+                                     ///< NOx Index sensor's value.
+  long _NOxIndexPeriodPrv = 0L; ///< The time when the NOx Index
+                                     ///< sensor was last read.
+  long _VOCIndexPeriod = 0L;    ///< The time period between reading the
+                                     ///< VOC Index sensor's value.
+  long _VOCIndexPeriodPrv = 0L; ///< The time when the VOC Index
                                      ///< sensor was last read.
   long _proximitySensorPeriod = 0L;  ///< The time period between reading the
                                      ///< proximity sensor's value.

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -952,9 +952,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long getSensorNOxIndexPeriodPrv() {
-    return _NOxIndexPeriodPrv;
-  }
+  virtual long getSensorNOxIndexPeriodPrv() { return _NOxIndexPeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -965,9 +963,7 @@ public:
      last.
   */
   /*******************************************************************************/
-  virtual void setSensorNOxIndexPeriodPrv(long period) {
-    _NOxIndexPeriodPrv = period;
-  }
+  virtual void setSensorNOxIndexPeriodPrv(long period) { _NOxIndexPeriodPrv = period; }
 
   /*******************************************************************************/
   /*!
@@ -979,9 +975,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventNOxIndex(sensors_event_t *gasEvent) {
-    return false;
-  }
+  virtual bool getEventNOxIndex(sensors_event_t *gasEvent) { return false; }
 
   /****************************** SENSOR_TYPE: VOC Index (index)
    * *******************************/
@@ -1003,9 +997,7 @@ public:
                 in seconds.
   */
   /*********************************************************************************/
-  virtual long getSensorVOCIndexPeriodPrv() {
-    return _VOCIndexPeriodPrv;
-  }
+  virtual long getSensorVOCIndexPeriodPrv() { return _VOCIndexPeriodPrv; }
 
   /*******************************************************************************/
   /*!
@@ -1016,9 +1008,7 @@ public:
      last.
   */
   /*******************************************************************************/
-  virtual void setSensorVOCIndexPeriodPrv(long period) {
-    _VOCIndexPeriodPrv = period;
-  }
+  virtual void setSensorVOCIndexPeriodPrv(long period) { _VOCIndexPeriodPrv = period; }
 
   /*******************************************************************************/
   /*!
@@ -1030,10 +1020,7 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventVOCIndex(sensors_event_t *gasEvent) {
-    return false;
-  }
-
+  virtual bool getEventVOCIndex(sensors_event_t *gasEvent) { return false; }
 
   /**************************** SENSOR_TYPE: PROXIMITY
    * ****************************/
@@ -1190,13 +1177,13 @@ protected:
                                      ///< gas resistance sensor's value.
   long _gasResistancePeriodPrv = 0L; ///< The time when the gas resistance
                                      ///< sensor was last read.
-  long _NOxIndexPeriod = 0L;    ///< The time period between reading the
+  long _NOxIndexPeriod = 0L;         ///< The time period between reading the
                                      ///< NOx Index sensor's value.
-  long _NOxIndexPeriodPrv = 0L; ///< The time when the NOx Index
+  long _NOxIndexPeriodPrv = 0L;      ///< The time when the NOx Index
                                      ///< sensor was last read.
-  long _VOCIndexPeriod = 0L;    ///< The time period between reading the
+  long _VOCIndexPeriod = 0L;         ///< The time period between reading the
                                      ///< VOC Index sensor's value.
-  long _VOCIndexPeriodPrv = 0L; ///< The time when the VOC Index
+  long _VOCIndexPeriodPrv = 0L;      ///< The time when the VOC Index
                                      ///< sensor was last read.
   long _proximitySensorPeriod = 0L;  ///< The time period between reading the
                                      ///< proximity sensor's value.

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -972,7 +972,7 @@ public:
       @brief    Base implementation - Reads a NOx Index sensor and converts
                 the reading into the expected SI unit.
       @param    gasEvent
-                NOx Index sensor reading, in ohms.
+                NOx Index sensor reading, unitless.
       @returns  True if the sensor event was obtained successfully, False
                 otherwise.
   */
@@ -1019,7 +1019,7 @@ public:
       @brief    Base implementation - Reads a VOC Index sensor and converts
                 the reading into the expected SI unit.
       @param    gasEvent
-                VOC Index sensor reading, in ohms.
+                VOC Index sensor reading, unitless.
       @returns  True if the sensor event was obtained successfully, False
                 otherwise.
   */

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -963,7 +963,9 @@ public:
      last.
   */
   /*******************************************************************************/
-  virtual void setSensorNOxIndexPeriodPrv(long period) { _NOxIndexPeriodPrv = period; }
+  virtual void setSensorNOxIndexPeriodPrv(long period) {
+    _NOxIndexPeriodPrv = period;
+  }
 
   /*******************************************************************************/
   /*!
@@ -1008,7 +1010,9 @@ public:
      last.
   */
   /*******************************************************************************/
-  virtual void setSensorVOCIndexPeriodPrv(long period) { _VOCIndexPeriodPrv = period; }
+  virtual void setSensorVOCIndexPeriodPrv(long period) {
+    _VOCIndexPeriodPrv = period;
+  }
 
   /*******************************************************************************/
   /*!

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
@@ -59,7 +59,7 @@ public:
     if (error_stop != 0) {
       return false;
     }
-    // Wait 1 second for sensors to start recording + 100ms for reset i2c command
+    // Wait 1 second for sensors to start recording + 100ms for reset command
     delay(1100); 
     u_int16_t error_start = _sen->startMeasurement();
     if (error_start != 0) {

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
@@ -59,6 +59,7 @@ public:
     if (error_stop != 0) {
       return false;
     }
+    delay(1100); // Wait 1 second for sensors to start recording + 100ms for reset
     u_int16_t error_start = _sen->startMeasurement();
     if (error_start != 0) {
       return false;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
@@ -145,7 +145,7 @@ public:
         massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
         massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
         noxIndex);
-    if ((_rawSensorPeriod != 0 && error) || noxIndex == NAN) {
+    if ((_NOxIndexPeriod != 0 && error != 0) || noxIndex == NAN) {
       return false;
     }
 
@@ -172,7 +172,7 @@ public:
         massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
         massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
         noxIndex);
-    if ((_rawSensorPeriod != 0 && error) || vocIndex == NAN) {
+    if ((_VOCIndexPeriod != 0 && error != 0) || vocIndex == NAN) {
       return false;
     }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
@@ -1,0 +1,284 @@
+/*!
+ * @file WipperSnapper_I2C_Driver_SEN5X.h
+ *
+ * Device driver for the SEN5X CO2, Temperature, and Humidity sensor.
+ * TEMPORARY HACK
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) Marni Brewster 2022 for Adafruit Industries.
+ *
+ * MIT license, all text here must be included in any redistribution.
+ *
+ */
+
+#ifndef WipperSnapper_I2C_Driver_SEN5X_H
+#define WipperSnapper_I2C_Driver_SEN5X_H
+
+#include "WipperSnapper_I2C_Driver.h"
+#include <SensirionI2CSen5x.h>
+#include <Wire.h>
+
+/**************************************************************************/
+/*!
+    @brief  Class that provides a driver interface for the SEN5X sensor.
+*/
+/**************************************************************************/
+class WipperSnapper_I2C_Driver_SEN5X : public WipperSnapper_I2C_Driver
+{
+
+  const float OVERFLOW_SEN55 = (0xFFFF / 10);  // maxes out at u_int16 / 10
+
+public:
+  /*******************************************************************************/
+  /*!
+      @brief    Constructor for a SEN5X sensor.
+      @param    i2c
+                The I2C interface.
+      @param    sensorAddress
+                7-bit device address.
+  */
+  /*******************************************************************************/
+  WipperSnapper_I2C_Driver_SEN5X(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress)
+  {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the SEN5X sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin()
+  {
+    _sen = new SensirionI2CSen5x();
+    _sen->begin(*_i2c);
+    u_int16_t error_stop = _sen->deviceReset();
+    if (error_stop != 0)
+    {
+      return false;
+    }
+    u_int16_t error_start = _sen->startMeasurement();
+    if (error_start != 0)
+    {
+      return false;
+    }
+
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SEN5X's current temperature.
+      @param    tempEvent
+                Pointer to an Adafruit_Sensor event.
+      @returns  True if the temperature was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventAmbientTemp(sensors_event_t *tempEvent)
+  {
+    float massConcentrationPm1p0, massConcentrationPm2p5,
+        massConcentrationPm4p0, massConcentrationPm10p0,
+        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+    uint16_t error;
+
+    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
+                                     massConcentrationPm4p0, massConcentrationPm10p0,
+                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
+    if ((_tempSensorPeriod != 0 && error != 0) || ambientTemperature == NAN)
+    {
+      return false;
+    }
+
+    tempEvent->temperature = ambientTemperature;
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SEN5X's current relative humidity reading.
+      @param    humidEvent
+                Pointer to an Adafruit_Sensor event.
+      @returns  True if the humidity was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventRelativeHumidity(sensors_event_t *humidEvent)
+  {
+    float massConcentrationPm1p0, massConcentrationPm2p5,
+        massConcentrationPm4p0, massConcentrationPm10p0,
+        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+    uint16_t error;
+
+    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
+                                     massConcentrationPm4p0, massConcentrationPm10p0,
+                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
+    if ((_humidSensorPeriod != 0 && error != 0) || ambientHumidity == NAN)
+    {
+      return false;
+    }
+
+    humidEvent->relative_humidity = ambientHumidity;
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SEN5X's current NOX/VOC reading.
+      @param    rawEvent
+                  Adafruit Sensor event for Raw data (4 float array)
+      @returns  True if the sensor value was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventRaw(sensors_event_t *rawEvent)
+  {
+    float massConcentrationPm1p0, massConcentrationPm2p5,
+        massConcentrationPm4p0, massConcentrationPm10p0,
+        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+    uint16_t error;
+
+    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
+                                     massConcentrationPm4p0, massConcentrationPm10p0,
+                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
+    if ((_rawSensorPeriod != 0 && error) || noxIndex == 0 || vocIndex == 0)
+    {
+      return false;
+    }
+
+    rawEvent->data[0] = noxIndex; // alphabetical?
+    rawEvent->data[1] = vocIndex;
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SEN5X sensor's PM1.0 STD reading.
+      @param    pm10StdEvent
+                  Adafruit Sensor event for PM1.0
+      @returns  True if the sensor value was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventPM10_STD(sensors_event_t *pm10StdEvent)
+  {
+    float massConcentrationPm1p0, massConcentrationPm2p5,
+        massConcentrationPm4p0, massConcentrationPm10p0,
+        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+    uint16_t error;
+
+    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
+                                     massConcentrationPm4p0, massConcentrationPm10p0,
+                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
+    if ((_PM10SensorPeriod != 0 && error != 0) || massConcentrationPm1p0 == NAN ||
+        massConcentrationPm1p0 == OVERFLOW_SEN55)
+    {
+      return false;
+    }
+
+    pm10StdEvent->data[0] = massConcentrationPm1p0;
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SEN5X sensor's PM2.5 STD reading.
+      @param    pm25StdEvent
+                  Adafruit Sensor event for PM2.5
+      @returns  True if the sensor value was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventPM25_STD(sensors_event_t *pm25StdEvent)
+  {
+    float massConcentrationPm1p0, massConcentrationPm2p5,
+        massConcentrationPm4p0, massConcentrationPm10p0,
+        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+    uint16_t error;
+
+    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
+                                     massConcentrationPm4p0, massConcentrationPm10p0,
+                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
+    if ((_PM25SensorPeriod != 0 && error != 0) || massConcentrationPm2p5 == NAN ||
+        massConcentrationPm2p5 == OVERFLOW_SEN55)
+    {
+      return false;
+    }
+
+    pm25StdEvent->data[0] = massConcentrationPm10p0;
+    return true;
+  }
+
+
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SEN5X sensor's PM4.0 STD reading.
+      @param    pm40StdEvent
+                  Adafruit Sensor event for PM4.0
+      @returns  True if the sensor value was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventPM40_STD(sensors_event_t *pm40StdEvent)
+  {
+    float massConcentrationPm1p0, massConcentrationPm2p5,
+        massConcentrationPm4p0, massConcentrationPm10p0,
+        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+    uint16_t error;
+
+    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
+                                     massConcentrationPm4p0, massConcentrationPm10p0,
+                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
+    if ((_PM25SensorPeriod != 0 && error != 0) || massConcentrationPm4p0 == NAN ||
+        massConcentrationPm4p0 == OVERFLOW_SEN55)
+    {
+      return false;
+    }
+
+    pm40StdEvent->data[0] = massConcentrationPm4p0;
+    return true;
+  }
+
+
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SEN5X sensor's PM10.0 STD reading.
+      @param    pm100StdEvent
+                  Adafruit Sensor event for PM10.0
+      @returns  True if the sensor value was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventPM100_STD(sensors_event_t *pm100StdEvent)
+  {
+    float massConcentrationPm1p0, massConcentrationPm2p5,
+        massConcentrationPm4p0, massConcentrationPm10p0,
+        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+    uint16_t error;
+
+    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
+                                     massConcentrationPm4p0, massConcentrationPm10p0,
+                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
+    if ((_PM100SensorPeriod != 0 && error != 0) || massConcentrationPm10p0 == NAN ||
+        massConcentrationPm10p0 == OVERFLOW_SEN55)
+    {
+      return false;
+    }
+
+    pm100StdEvent->data[0] = massConcentrationPm10p0;
+    return true;
+  }
+
+protected:
+  SensirionI2CSen5x *_sen; ///< SEN5X driver object
+};
+
+#endif // WipperSnapper_I2C_Driver_SEN5X

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
@@ -60,7 +60,7 @@ public:
       return false;
     }
     // Wait 1 second for sensors to start recording + 100ms for reset command
-    delay(1100); 
+    delay(1100);
     u_int16_t error_start = _sen->startMeasurement();
     if (error_start != 0) {
       return false;
@@ -152,7 +152,6 @@ public:
     noxIndexEvent->nox_index = noxIndex;
     return true;
   }
-
 
   /*******************************************************************************/
   /*!

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
@@ -59,7 +59,8 @@ public:
     if (error_stop != 0) {
       return false;
     }
-    delay(1100); // Wait 1 second for sensors to start recording + 100ms for reset
+    // Wait 1 second for sensors to start recording + 100ms for reset i2c command
+    delay(1100); 
     u_int16_t error_start = _sen->startMeasurement();
     if (error_start != 0) {
       return false;
@@ -124,20 +125,20 @@ public:
 
   /*******************************************************************************/
   /*!
-      @brief    Gets the SEN5X's current NOX/VOC reading.
-      @param    rawEvent
-                  Adafruit Sensor event for Raw data (4 float array)
+      @brief    Gets the SEN5X's current NOX reading.
+      @param    noxIndexEvent
+                  Adafruit Sensor event for NOx Index (1-500, 100 is normal)
       @returns  True if the sensor value was obtained successfully, False
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventRaw(sensors_event_t *rawEvent) {
-    float massConcentrationPm1p0, massConcentrationPm2p5,
-        massConcentrationPm4p0, massConcentrationPm10p0, ambientHumidity,
-        ambientTemperature, vocIndex, noxIndex;
+  bool getEventNOxIndex(sensors_event_t *noxIndexEvent) {
+    u_int16_t massConcentrationPm1p0, massConcentrationPm2p5,
+        massConcentrationPm4p0, massConcentrationPm10p0;
+    int16_t ambientHumidity, ambientTemperature, vocIndex, noxIndex;
     uint16_t error;
 
-    error = _sen->readMeasuredValues(
+    error = _sen->readMeasuredValuesAsIntegers(
         massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
         massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
         noxIndex);
@@ -145,8 +146,35 @@ public:
       return false;
     }
 
-    rawEvent->data[0] = noxIndex; // alphabetical?
-    rawEvent->data[1] = vocIndex;
+    noxIndexEvent->nox_index = noxIndex;
+    return true;
+  }
+
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the SEN5X's current VOC reading.
+      @param    vocIndexEvent
+                  Adafruit Sensor event for VOC Index (1-500, 100 is normal)
+      @returns  True if the sensor value was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventVOCIndex(sensors_event_t *vocIndexEvent) {
+    u_int16_t massConcentrationPm1p0, massConcentrationPm2p5,
+        massConcentrationPm4p0, massConcentrationPm10p0;
+    int16_t ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+    uint16_t error;
+
+    error = _sen->readMeasuredValuesAsIntegers(
+        massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
+        massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
+        noxIndex);
+    if ((_rawSensorPeriod != 0 && error) || noxIndex == 0 || vocIndex == 0) {
+      return false;
+    }
+
+    vocIndexEvent->voc_index = vocIndex;
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
@@ -26,10 +26,9 @@
     @brief  Class that provides a driver interface for the SEN5X sensor.
 */
 /**************************************************************************/
-class WipperSnapper_I2C_Driver_SEN5X : public WipperSnapper_I2C_Driver
-{
+class WipperSnapper_I2C_Driver_SEN5X : public WipperSnapper_I2C_Driver {
 
-  const float OVERFLOW_SEN55 = (0xFFFF / 10);  // maxes out at u_int16 / 10
+  const float OVERFLOW_SEN55 = (0xFFFF / 10); // maxes out at u_int16 / 10
 
 public:
   /*******************************************************************************/
@@ -42,8 +41,7 @@ public:
   */
   /*******************************************************************************/
   WipperSnapper_I2C_Driver_SEN5X(TwoWire *i2c, uint16_t sensorAddress)
-      : WipperSnapper_I2C_Driver(i2c, sensorAddress)
-  {
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
     _i2c = i2c;
     _sensorAddress = sensorAddress;
   }
@@ -54,18 +52,15 @@ public:
       @returns  True if initialized successfully, False otherwise.
   */
   /*******************************************************************************/
-  bool begin()
-  {
+  bool begin() {
     _sen = new SensirionI2CSen5x();
     _sen->begin(*_i2c);
     u_int16_t error_stop = _sen->deviceReset();
-    if (error_stop != 0)
-    {
+    if (error_stop != 0) {
       return false;
     }
     u_int16_t error_start = _sen->startMeasurement();
-    if (error_start != 0)
-    {
+    if (error_start != 0) {
       return false;
     }
 
@@ -81,18 +76,17 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventAmbientTemp(sensors_event_t *tempEvent)
-  {
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
     float massConcentrationPm1p0, massConcentrationPm2p5,
-        massConcentrationPm4p0, massConcentrationPm10p0,
-        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+        massConcentrationPm4p0, massConcentrationPm10p0, ambientHumidity,
+        ambientTemperature, vocIndex, noxIndex;
     uint16_t error;
 
-    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
-                                     massConcentrationPm4p0, massConcentrationPm10p0,
-                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
-    if ((_tempSensorPeriod != 0 && error != 0) || ambientTemperature == NAN)
-    {
+    error = _sen->readMeasuredValues(
+        massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
+        massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
+        noxIndex);
+    if ((_tempSensorPeriod != 0 && error != 0) || ambientTemperature == NAN) {
       return false;
     }
 
@@ -109,18 +103,17 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventRelativeHumidity(sensors_event_t *humidEvent)
-  {
+  bool getEventRelativeHumidity(sensors_event_t *humidEvent) {
     float massConcentrationPm1p0, massConcentrationPm2p5,
-        massConcentrationPm4p0, massConcentrationPm10p0,
-        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+        massConcentrationPm4p0, massConcentrationPm10p0, ambientHumidity,
+        ambientTemperature, vocIndex, noxIndex;
     uint16_t error;
 
-    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
-                                     massConcentrationPm4p0, massConcentrationPm10p0,
-                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
-    if ((_humidSensorPeriod != 0 && error != 0) || ambientHumidity == NAN)
-    {
+    error = _sen->readMeasuredValues(
+        massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
+        massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
+        noxIndex);
+    if ((_humidSensorPeriod != 0 && error != 0) || ambientHumidity == NAN) {
       return false;
     }
 
@@ -137,18 +130,17 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventRaw(sensors_event_t *rawEvent)
-  {
+  bool getEventRaw(sensors_event_t *rawEvent) {
     float massConcentrationPm1p0, massConcentrationPm2p5,
-        massConcentrationPm4p0, massConcentrationPm10p0,
-        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+        massConcentrationPm4p0, massConcentrationPm10p0, ambientHumidity,
+        ambientTemperature, vocIndex, noxIndex;
     uint16_t error;
 
-    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
-                                     massConcentrationPm4p0, massConcentrationPm10p0,
-                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
-    if ((_rawSensorPeriod != 0 && error) || noxIndex == 0 || vocIndex == 0)
-    {
+    error = _sen->readMeasuredValues(
+        massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
+        massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
+        noxIndex);
+    if ((_rawSensorPeriod != 0 && error) || noxIndex == 0 || vocIndex == 0) {
       return false;
     }
 
@@ -166,19 +158,19 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventPM10_STD(sensors_event_t *pm10StdEvent)
-  {
+  bool getEventPM10_STD(sensors_event_t *pm10StdEvent) {
     float massConcentrationPm1p0, massConcentrationPm2p5,
-        massConcentrationPm4p0, massConcentrationPm10p0,
-        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+        massConcentrationPm4p0, massConcentrationPm10p0, ambientHumidity,
+        ambientTemperature, vocIndex, noxIndex;
     uint16_t error;
 
-    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
-                                     massConcentrationPm4p0, massConcentrationPm10p0,
-                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
-    if ((_PM10SensorPeriod != 0 && error != 0) || massConcentrationPm1p0 == NAN ||
-        massConcentrationPm1p0 == OVERFLOW_SEN55)
-    {
+    error = _sen->readMeasuredValues(
+        massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
+        massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
+        noxIndex);
+    if ((_PM10SensorPeriod != 0 && error != 0) ||
+        massConcentrationPm1p0 == NAN ||
+        massConcentrationPm1p0 == OVERFLOW_SEN55) {
       return false;
     }
 
@@ -195,27 +187,25 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventPM25_STD(sensors_event_t *pm25StdEvent)
-  {
+  bool getEventPM25_STD(sensors_event_t *pm25StdEvent) {
     float massConcentrationPm1p0, massConcentrationPm2p5,
-        massConcentrationPm4p0, massConcentrationPm10p0,
-        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+        massConcentrationPm4p0, massConcentrationPm10p0, ambientHumidity,
+        ambientTemperature, vocIndex, noxIndex;
     uint16_t error;
 
-    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
-                                     massConcentrationPm4p0, massConcentrationPm10p0,
-                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
-    if ((_PM25SensorPeriod != 0 && error != 0) || massConcentrationPm2p5 == NAN ||
-        massConcentrationPm2p5 == OVERFLOW_SEN55)
-    {
+    error = _sen->readMeasuredValues(
+        massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
+        massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
+        noxIndex);
+    if ((_PM25SensorPeriod != 0 && error != 0) ||
+        massConcentrationPm2p5 == NAN ||
+        massConcentrationPm2p5 == OVERFLOW_SEN55) {
       return false;
     }
 
     pm25StdEvent->data[0] = massConcentrationPm10p0;
     return true;
   }
-
-
 
   /*******************************************************************************/
   /*!
@@ -226,27 +216,25 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventPM40_STD(sensors_event_t *pm40StdEvent)
-  {
+  bool getEventPM40_STD(sensors_event_t *pm40StdEvent) {
     float massConcentrationPm1p0, massConcentrationPm2p5,
-        massConcentrationPm4p0, massConcentrationPm10p0,
-        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+        massConcentrationPm4p0, massConcentrationPm10p0, ambientHumidity,
+        ambientTemperature, vocIndex, noxIndex;
     uint16_t error;
 
-    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
-                                     massConcentrationPm4p0, massConcentrationPm10p0,
-                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
-    if ((_PM25SensorPeriod != 0 && error != 0) || massConcentrationPm4p0 == NAN ||
-        massConcentrationPm4p0 == OVERFLOW_SEN55)
-    {
+    error = _sen->readMeasuredValues(
+        massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
+        massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
+        noxIndex);
+    if ((_PM25SensorPeriod != 0 && error != 0) ||
+        massConcentrationPm4p0 == NAN ||
+        massConcentrationPm4p0 == OVERFLOW_SEN55) {
       return false;
     }
 
     pm40StdEvent->data[0] = massConcentrationPm4p0;
     return true;
   }
-
-
 
   /*******************************************************************************/
   /*!
@@ -257,19 +245,19 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventPM100_STD(sensors_event_t *pm100StdEvent)
-  {
+  bool getEventPM100_STD(sensors_event_t *pm100StdEvent) {
     float massConcentrationPm1p0, massConcentrationPm2p5,
-        massConcentrationPm4p0, massConcentrationPm10p0,
-        ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+        massConcentrationPm4p0, massConcentrationPm10p0, ambientHumidity,
+        ambientTemperature, vocIndex, noxIndex;
     uint16_t error;
 
-    error = _sen->readMeasuredValues(massConcentrationPm1p0, massConcentrationPm2p5,
-                                     massConcentrationPm4p0, massConcentrationPm10p0,
-                                     ambientHumidity, ambientTemperature, vocIndex, noxIndex);
-    if ((_PM100SensorPeriod != 0 && error != 0) || massConcentrationPm10p0 == NAN ||
-        massConcentrationPm10p0 == OVERFLOW_SEN55)
-    {
+    error = _sen->readMeasuredValues(
+        massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
+        massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
+        noxIndex);
+    if ((_PM100SensorPeriod != 0 && error != 0) ||
+        massConcentrationPm10p0 == NAN ||
+        massConcentrationPm10p0 == OVERFLOW_SEN55) {
       return false;
     }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
@@ -130,7 +130,7 @@ public:
                 NAN is returned. During the first 10..11 seconds after
                 power-on or device reset, this value will be NAN as well.
       @param    noxIndexEvent
-                  Adafruit Sensor event for NOx Index (1-500, 100 is normal)
+                  Adafruit Sensor event for NOx Index (0-500, 1 is normal)
       @returns  True if the sensor value was obtained successfully, False
                 otherwise.
   */

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
@@ -126,6 +126,9 @@ public:
   /*******************************************************************************/
   /*!
       @brief    Gets the SEN5X's current NOX reading.
+                Note: If this value is unknown, which is true for SEN54,
+                NAN is returned. During the first 10..11 seconds after
+                power-on or device reset, this value will be NAN as well.
       @param    noxIndexEvent
                   Adafruit Sensor event for NOx Index (1-500, 100 is normal)
       @returns  True if the sensor value was obtained successfully, False
@@ -133,16 +136,16 @@ public:
   */
   /*******************************************************************************/
   bool getEventNOxIndex(sensors_event_t *noxIndexEvent) {
-    u_int16_t massConcentrationPm1p0, massConcentrationPm2p5,
-        massConcentrationPm4p0, massConcentrationPm10p0;
-    int16_t ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+    float massConcentrationPm1p0, massConcentrationPm2p5,
+        massConcentrationPm4p0, massConcentrationPm10p0, ambientHumidity,
+        ambientTemperature, vocIndex, noxIndex;
     uint16_t error;
 
-    error = _sen->readMeasuredValuesAsIntegers(
+    error = _sen->readMeasuredValues(
         massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
         massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
         noxIndex);
-    if ((_rawSensorPeriod != 0 && error) || noxIndex == 0 || vocIndex == 0) {
+    if ((_rawSensorPeriod != 0 && error) || noxIndex == NAN) {
       return false;
     }
 
@@ -161,16 +164,16 @@ public:
   */
   /*******************************************************************************/
   bool getEventVOCIndex(sensors_event_t *vocIndexEvent) {
-    u_int16_t massConcentrationPm1p0, massConcentrationPm2p5,
-        massConcentrationPm4p0, massConcentrationPm10p0;
-    int16_t ambientHumidity, ambientTemperature, vocIndex, noxIndex;
+    float massConcentrationPm1p0, massConcentrationPm2p5,
+        massConcentrationPm4p0, massConcentrationPm10p0, ambientHumidity,
+        ambientTemperature, vocIndex, noxIndex;
     uint16_t error;
 
-    error = _sen->readMeasuredValuesAsIntegers(
+    error = _sen->readMeasuredValues(
         massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
         massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
         noxIndex);
-    if ((_rawSensorPeriod != 0 && error) || noxIndex == 0 || vocIndex == 0) {
+    if ((_rawSensorPeriod != 0 && error) || vocIndex == NAN) {
       return false;
     }
 


### PR DESCRIPTION
This adds the implementation for particulates <1 <2.5 <4 <10 in ug/m3, although <4 is yet to be included in wippersnapper, it is scaffolded out and there will be a corresponding patch when the respective sensor period implemented. 

The NOx and VOCs are supplied in the raw value, bytes 0 and 1 respectively. They correspond to an index, not a unit. 

There are also the usual humidity and temperature metrics.

It would be nice to test this with a SEN50 as there is a separate method in the driver to avoid returning metrics other than particle size. I'm hoping the user would deselect the metrics that their model doesn't have, and if not they'll just gracefully not update. Makes sense to test with a SEN54 if possible too. https://www.sparkfun.com/products/19325 is probably your best bet, I went with https://www.anglia-live.com/product/2080075001/SEN55-SDN-T/SENSIRION-AG (UK)