### PR TITLE
Fix and refactor analog input class

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.59
+version=1.0.0-beta.60
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -2390,7 +2390,7 @@ ws_status_t Wippersnapper::run() {
   WS.feedWDT();
 
   // Process analog inputs
-  WS._analogIO->processAnalogInputs();
+  WS._analogIO->update();
   WS.feedWDT();
 
   // Process I2C sensor events

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -225,24 +225,31 @@ void Wippersnapper::set_user_key() {
     @returns  True if analog pin configured successfully, False otherwise.
 */
 /****************************************************************************/
-bool Wippersnapper::configAnalogInPinReq(wippersnapper_pin_v1_ConfigurePinRequest *pinMsg) {
-    bool is_success= true;
-    char *pinName = pinMsg->pin_name + 1;
-    int pin = atoi(pinName);
+bool Wippersnapper::configAnalogInPinReq(
+    wippersnapper_pin_v1_ConfigurePinRequest *pinMsg) {
+  bool is_success = true;
 
-    if (pinMsg->request_type ==
-        wippersnapper_pin_v1_ConfigurePinRequest_RequestType_REQUEST_TYPE_CREATE) {
-        WS._analogIO->initAnalogInputPin(pin, pinMsg->period, pinMsg->pull,
-                                         pinMsg->analog_read_mode);
-    } else if (
-        pinMsg->request_type ==
-        wippersnapper_pin_v1_ConfigurePinRequest_RequestType_REQUEST_TYPE_DELETE) {
-      WS._analogIO->deinitAnalogPin(pinMsg->direction, pin);
-    } else {
-      WS_DEBUG_PRINTLN("ERROR: Could not decode analog pin request!");
-      is_success = false;
-    }
-    return is_success;
+#if defined(ARDUINO_ARCH_RP2040)
+  char *pinName = pinMsg->pin_name + 1;
+  int pin = atoi(pinName);
+#else
+  char *pinName = pinMsg->pin_name + 1;
+  int pin = atoi(pinName);
+#endif
+
+  if (pinMsg->request_type ==
+      wippersnapper_pin_v1_ConfigurePinRequest_RequestType_REQUEST_TYPE_CREATE) {
+    WS._analogIO->initAnalogInputPin(pin, pinMsg->period, pinMsg->pull,
+                                     pinMsg->analog_read_mode);
+  } else if (
+      pinMsg->request_type ==
+      wippersnapper_pin_v1_ConfigurePinRequest_RequestType_REQUEST_TYPE_DELETE) {
+    WS._analogIO->deinitAnalogPin(pinMsg->direction, pin);
+  } else {
+    WS_DEBUG_PRINTLN("ERROR: Could not decode analog pin request!");
+    is_success = false;
+  }
+  return is_success;
 }
 
 /****************************************************************************/
@@ -256,23 +263,23 @@ bool Wippersnapper::configAnalogInPinReq(wippersnapper_pin_v1_ConfigurePinReques
 /****************************************************************************/
 bool Wippersnapper::configureDigitalPinReq(
     wippersnapper_pin_v1_ConfigurePinRequest *pinMsg) {
-    bool is_success = true;
-    char *pinName = pinMsg->pin_name + 1;
-    int pin = atoi(pinName);
+  bool is_success = true;
+  char *pinName = pinMsg->pin_name + 1;
+  int pin = atoi(pinName);
 
-    if (pinMsg->request_type ==
-        wippersnapper_pin_v1_ConfigurePinRequest_RequestType_REQUEST_TYPE_CREATE) {
-      // Initialize GPIO pin
-      WS._digitalGPIO->initDigitalPin(pinMsg->direction, pin, pinMsg->period,
-                                      pinMsg->pull);
-    } else if (
-        pinMsg->request_type ==
-        wippersnapper_pin_v1_ConfigurePinRequest_RequestType_REQUEST_TYPE_DELETE) {
-      // Delete digital GPIO pin
-      WS._digitalGPIO->deinitDigitalPin(pinMsg->direction, pin);
-    } else {
-      WS_DEBUG_PRINTLN("ERROR: Could not decode digital pin request type");
-    }
+  if (pinMsg->request_type ==
+      wippersnapper_pin_v1_ConfigurePinRequest_RequestType_REQUEST_TYPE_CREATE) {
+    // Initialize GPIO pin
+    WS._digitalGPIO->initDigitalPin(pinMsg->direction, pin, pinMsg->period,
+                                    pinMsg->pull);
+  } else if (
+      pinMsg->request_type ==
+      wippersnapper_pin_v1_ConfigurePinRequest_RequestType_REQUEST_TYPE_DELETE) {
+    // Delete digital GPIO pin
+    WS._digitalGPIO->deinitDigitalPin(pinMsg->direction, pin);
+  } else {
+    WS_DEBUG_PRINTLN("ERROR: Could not decode digital pin request type");
+  }
 
   return is_success;
 }

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -260,10 +260,6 @@ bool Wippersnapper::configurePinRequest(
           wippersnapper_pin_v1_ConfigurePinRequest_Direction_DIRECTION_INPUT) {
         WS._analogIO->initAnalogInputPin(pin, pinMsg->period, pinMsg->pull,
                                          pinMsg->analog_read_mode);
-      } else if (
-          pinMsg->direction ==
-          wippersnapper_pin_v1_ConfigurePinRequest_Direction_DIRECTION_OUTPUT) {
-        WS._analogIO->initAnalogOutputPin(pin);
       } else {
         WS_DEBUG_PRINTLN("ERROR: Unable to decode analog pin direction.")
         is_success = false;

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -227,7 +227,7 @@ void Wippersnapper::set_user_key() {
 /****************************************************************************/
 bool Wippersnapper::configAnalogInPinReq(wippersnapper_pin_v1_ConfigurePinRequest *pinMsg) {
     bool is_success= true;
-    char *pinName = pinMsg->pin_name;
+    char *pinName = pinMsg->pin_name + 1;
     int pin = atoi(pinName);
 
     if (pinMsg->request_type ==

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -229,11 +229,11 @@ bool Wippersnapper::configurePinRequest(
   WS_DEBUG_PRINTLN("configurePinRequest");
 
   bool is_success = true;
-  char *pinName = pinMsg->pin_name + 1;
-  int pin = atoi(pinName);
 
   // Decode pin mode
   if (pinMsg->mode == wippersnapper_pin_v1_Mode_MODE_DIGITAL) {
+    char *pinName = pinMsg->pin_name + 1;
+    int pin = atoi(pinName);
     if (pinMsg->request_type ==
         wippersnapper_pin_v1_ConfigurePinRequest_RequestType_REQUEST_TYPE_CREATE) {
       // Initialize GPIO pin
@@ -250,6 +250,9 @@ bool Wippersnapper::configurePinRequest(
   }
 
   else if (pinMsg->mode == wippersnapper_pin_v1_Mode_MODE_ANALOG) {
+    // TODO: We should really be passing the message here, not decoding!
+    char *pinName = pinMsg->pin_name;
+    int pin = atoi(pinName);
     if (pinMsg->request_type ==
         wippersnapper_pin_v1_ConfigurePinRequest_RequestType_REQUEST_TYPE_CREATE) {
       // Initialize analog io pin

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -279,7 +279,8 @@ public:
                  uint8_t pinName, int pinVal);
 
   // Pin configure message
-  bool configurePinRequest(wippersnapper_pin_v1_ConfigurePinRequest *pinMsg);
+  bool configureDigitalPinReq(wippersnapper_pin_v1_ConfigurePinRequest *pinMsg);
+  bool configAnalogInPinReq(wippersnapper_pin_v1_ConfigurePinRequest *pinMsg);
 
   // I2C
   std::vector<WipperSnapper_Component_I2C *>

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -90,7 +90,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.59" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.60" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -236,6 +236,8 @@ float Wippersnapper_AnalogIO::getPinValueVolts(int pin) {
                 signal message and publish it to IO.
     @param    pinName
               Specifies the pin's name.
+    @param    readMode
+              Read mode - raw ADC or voltage.
     @param    pinValRaw
               Raw pin value, used if readmode is raw.
     @param    pinValVolts
@@ -373,7 +375,7 @@ void Wippersnapper_AnalogIO::update() {
                          pinValVolts);
 
         } else {
-          WS_DEBUG_PRINTLN("ADC has not changed enough, continue...");
+          // WS_DEBUG_PRINTLN("ADC has not changed enough, continue...");
           continue;
         }
         // set the pin value in the digital pin object for comparison on next

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -228,7 +228,11 @@ void Wippersnapper_AnalogIO::deinitAnalogPin(
 /**********************************************************/
 uint16_t Wippersnapper_AnalogIO::readAnalogPinRaw(int pin) {
   uint16_t value;
+  WS_DEBUG_PRINT("Pin: ");
+  WS_DEBUG_PRINTLN(pin);
   value = analogRead(pin);
+  WS_DEBUG_PRINT("readAnalogPinRaw (raw): ");
+  WS_DEBUG_PRINTLN(value);
 
   // scale by the ADC resolution manually if not implemented by BSP
   if (scaleAnalogRead) {
@@ -280,7 +284,7 @@ bool Wippersnapper_AnalogIO::encodePinEvent(
   // fill the pin_event message
   outgoingSignalMsg->which_payload =
       wippersnapper_signal_v1_CreateSignalRequest_pin_event_tag;
-  sprintf(outgoingSignalMsg->payload.pin_event.pin_name, "A%d", pinName);
+  sprintf(outgoingSignalMsg->payload.pin_event.pin_name, "%d", pinName);
   sprintf(outgoingSignalMsg->payload.pin_event.pin_value, "%u", pinVal);
 
   // Encode signal message
@@ -318,7 +322,7 @@ bool Wippersnapper_AnalogIO::encodePinEvent(
   // fill the pin_event message
   outgoingSignalMsg->which_payload =
       wippersnapper_signal_v1_CreateSignalRequest_pin_event_tag;
-  sprintf(outgoingSignalMsg->payload.pin_event.pin_name, "A%d", pinName);
+  sprintf(outgoingSignalMsg->payload.pin_event.pin_name, "%d", pinName);
   sprintf(outgoingSignalMsg->payload.pin_event.pin_value, "%0.3f", pinVal);
 
   // Encode signal message
@@ -344,6 +348,7 @@ void Wippersnapper_AnalogIO::update() {
   for (int i = 0; i < _totalAnalogInputPins; i++) {
     if (_analog_input_pins[i].enabled == true) {
       // Does the pin execute on-period?
+      // TODO: Does THIS work? Print out all conditionals
       if (_curTime - _analog_input_pins[i].prvPeriod >
               _analog_input_pins[i].period &&
           _analog_input_pins[i].period != 0L) {

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -258,7 +258,7 @@ bool Wippersnapper_AnalogIO::encodePinEvent(
   // Fill payload
   outgoingSignalMsg.which_payload =
       wippersnapper_signal_v1_CreateSignalRequest_pin_event_tag;
-  sprintf(outgoingSignalMsg.payload.pin_event.pin_name, "%d", pinName);
+  sprintf(outgoingSignalMsg.payload.pin_event.pin_name, "A%d", pinName);
 
   // Fill pinValue based on the analog read mode
   if (readMode ==

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -130,10 +130,6 @@ void Wippersnapper_AnalogIO::initAnalogInputPin(
     wippersnapper_pin_v1_ConfigurePinRequest_Pull pullMode,
     wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode analogReadMode) {
 
-  // TODO: Take in pinmsg here, dont do decoding in .cpp, however realize
-  // Wippersnapper::configureDigitalPinReq takes in a ptr. to pinMsg instead and
-  // calls this
-
   // Set analog read pull mode
   if (pullMode == wippersnapper_pin_v1_ConfigurePinRequest_Pull_PULL_UP)
     pinMode(pin, INPUT_PULLUP);
@@ -142,8 +138,6 @@ void Wippersnapper_AnalogIO::initAnalogInputPin(
 
   // Period is in seconds, cast it to long and convert it to milliseconds
   long periodMs = (long)period * 1000;
-  WS_DEBUG_PRINT("Interval (ms):");
-  WS_DEBUG_PRINTLN(periodMs);
 
   // TODO: Maybe pull this out into a func. or use map() lookup instead
   // attempt to allocate pin within _analog_input_pins[]
@@ -156,23 +150,21 @@ void Wippersnapper_AnalogIO::initAnalogInputPin(
       break;
     }
   }
+  WS_DEBUG_PRINT("Configured Analog Input pin with polling time (ms):");
+  WS_DEBUG_PRINTLN(periodMs);
 }
 
 /***********************************************************************************/
 /*!
-    @brief  Deinitializes an analog input pin.
+    @brief  Disables an analog input pin from sampling
     @param  pin
-                The analog input pin to deinitialize.
+            The analog input pin to disable.
 */
 /***********************************************************************************/
-void Wippersnapper_AnalogIO::deinitAnalogInputPinObj(int pin) {
-  // de-allocate the pin within digital_input_pins[]
+void Wippersnapper_AnalogIO::disableAnalogInPin(int pin) {
   for (int i = 0; i < _totalAnalogInputPins; i++) {
     if (_analog_input_pins[i].pinName == pin) {
-      _analog_input_pins[i].pinName = 0;
-      _analog_input_pins[i].period = -1;
-      _analog_input_pins[i].prvPinVal = 0.0;
-      _analog_input_pins[i].prvPeriod = 0L;
+      _analog_input_pins[i].enabled = false;
       break;
     }
   }
@@ -195,7 +187,7 @@ void Wippersnapper_AnalogIO::deinitAnalogPin(
   if (direction ==
       wippersnapper_pin_v1_ConfigurePinRequest_Direction_DIRECTION_INPUT) {
     WS_DEBUG_PRINTLN("Deinitialized analog input pin obj.");
-    deinitAnalogInputPinObj(pin);
+    disableAnalogInPin(pin);
   }
   pinMode(pin, INPUT); // hi-z
 }

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -131,7 +131,7 @@ void Wippersnapper_AnalogIO::initAnalogInputPin(
     wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode analogReadMode) {
 
   // TODO: Take in pinmsg here, dont do decoding in .cpp, however realize
-  // Wippersnapper::configurePinRequest takes in a ptr. to pinMsg instead and
+  // Wippersnapper::configureDigitalPinReq takes in a ptr. to pinMsg instead and
   // calls this
 
   // Set analog read pull mode
@@ -357,13 +357,15 @@ void Wippersnapper_AnalogIO::update() {
     // Does the pin execute on_change?
     else if (_analog_input_pins[i].period == 0L) {
 
-      // note: on-change requires ADC hysterisis check against prv value
+      // note: on-change requires ADC DEFAULT_HYSTERISIS check against prv value
       uint16_t pinValRaw = getPinValue(_analog_input_pins[i].pinName);
 
-      if (!(pinValRaw > _analog_input_pins[i].prvPinVal +
-                            (_analog_input_pins[i].prvPinVal * HYSTERISIS)) ||
-          !pinValRaw < (_analog_input_pins[i].prvPinVal -
-                        (_analog_input_pins[i].prvPinVal * HYSTERISIS))) {
+      if (!(pinValRaw >
+            _analog_input_pins[i].prvPinVal +
+                (_analog_input_pins[i].prvPinVal * DEFAULT_HYSTERISIS)) ||
+          !pinValRaw <
+              (_analog_input_pins[i].prvPinVal -
+               (_analog_input_pins[i].prvPinVal * DEFAULT_HYSTERISIS))) {
         WS_DEBUG_PRINTLN(
             "ADC pin value has not changed enough to report, continuing...");
         continue;

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -399,13 +399,7 @@ void Wippersnapper_AnalogIO::update() {
 
       // set the pin value in the digital pin object for comparison on next
       // run
-      _analog_input_pins[i].prvPinVal = _pinValue;
-
-      // reset the digital pin
-      _analog_input_pins[i].prvPeriod = millis();
-
-      // delay by _pinValue to prevent fast readings back to IO
-      delay(_pinValue);
+      _analog_input_pins[i].prvPinVal = pinValRaw;
     }
   }
 }

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -83,12 +83,10 @@ float Wippersnapper_AnalogIO::getAref() { return _aRef; }
 /***********************************************************************************/
 void Wippersnapper_AnalogIO::setADCResolution(int resolution) {
 // set the resolution natively in the BSP
-#ifdef ARDUINO_ARCH_SAMD
+#if defined(ARDUINO_ARCH_SAMD)
   analogReadResolution(16);
   _nativeResolution = 12;
-#endif
-
-#ifdef ARDUINO_ARCH_ESP32
+#elif defined(ARDUINO_ARCH_ESP32)
   scaleAnalogRead = true;
   _nativeResolution = 13;
 #endif
@@ -113,19 +111,6 @@ int Wippersnapper_AnalogIO::getADCresolution() { return _adcResolution; }
 */
 /***********************************************************************************/
 int Wippersnapper_AnalogIO::getNativeResolution() { return _nativeResolution; }
-
-/***********************************************************************************/
-/*!
-    @brief  Initializes an analog output pin.
-    @param  pin
-                The analog pin to read from.
-*/
-/***********************************************************************************/
-void Wippersnapper_AnalogIO::initAnalogOutputPin(int pin) {
-  WS_DEBUG_PRINT("ERROR: Analog output on pin ");
-  WS_DEBUG_PRINT(pin);
-  WS_DEBUG_PRINTLN("not implemented yet.");
-}
 
 /***********************************************************************************/
 /*!
@@ -225,12 +210,8 @@ void Wippersnapper_AnalogIO::deinitAnalogPin(
 */
 /**********************************************************/
 uint16_t Wippersnapper_AnalogIO::getPinValue(int pin) {
-  uint16_t value;
-  WS_DEBUG_PRINT("Pin: ");
-  WS_DEBUG_PRINTLN(pin);
-  value = analogRead(pin);
-  WS_DEBUG_PRINT("getPinValue (raw): ");
-  WS_DEBUG_PRINTLN(value);
+  // get pin value
+  uint16_t value = analogRead(pin);
 
   // scale by the ADC resolution manually if not implemented by BSP
   if (scaleAnalogRead) {
@@ -342,6 +323,7 @@ void Wippersnapper_AnalogIO::update() {
   uint16_t pinValRaw = 0;
   // Process analog input pins
   for (int i = 0; i < _totalAnalogInputPins; i++) {
+    // TODO: Can we collapse the conditionals below?
     if (_analog_input_pins[i].enabled == true) {
       // Does the pin execute on-period?
       if (millis() - _analog_input_pins[i].prvPeriod >

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -7,7 +7,7 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Copyright (c) Brent Rubell 2020-2021 for Adafruit Industries.
+ * Copyright (c) Brent Rubell 2020-2023 for Adafruit Industries.
  *
  * BSD license, all text here must be included in any redistribution.
  *
@@ -18,7 +18,7 @@
 
 #include "Wippersnapper.h"
 
-#define HYSTERISIS 0.2 ///< Default hysterisis of 2%
+#define DEFAULT_HYSTERISIS 0.2 ///< Default DEFAULT_HYSTERISIS of 2%
 
 /** Data about an analog input pin */
 struct analogInputPin {
@@ -68,7 +68,6 @@ public:
   void update();
   bool encodePinEvent(uint8_t pinName, wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode readMode, uint16_t pinValRaw = 0, float pinValVolts = 0.0);
 
-  analogInputPin *_analog_input_pins; /*!< Array of analog pin objects */
 private:
   float _aRef;           /*!< Hardware's reported voltage reference */
   int _adcResolution;    /*!< Resolution returned by the analogRead() funcn. */
@@ -76,9 +75,7 @@ private:
   bool scaleAnalogRead = false; /*!< True if we need to manually scale the value
                                    returned by analogRead(). */
   int32_t _totalAnalogInputPins; /*!< Total number of analog input pins */
-
-  uint16_t _pinValue; /*!< Pin's raw value from analogRead */
-  float _pinVoltage;  /*!< Pin's calculated voltage, in volts. */
+  analogInputPin *_analog_input_pins; /*!< Array of analog pin objects */
 };
 extern Wippersnapper WS; /*!< Wippersnapper variable. */
 

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -21,6 +21,7 @@
 /** Data about an analog input pin */
 struct analogInputPin {
   int pinName; ///< Pin name
+  bool enabled; ///< Pin is enabled for sampling
   wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode
       readMode;    ///< Which type of read to perform
   long period;     ///< Pin timer interval, in millis, -1 if disabled.
@@ -62,7 +63,7 @@ public:
   int getADCresolution();
   int getNativeResolution();
 
-  void processAnalogInputs();
+  void update();
 
   bool
   encodePinEvent(wippersnapper_signal_v1_CreateSignalRequest *outgoingSignalMsg,

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -25,7 +25,7 @@ struct analogInputPin {
   int pinName;  ///< Pin name
   bool enabled; ///< Pin is enabled for sampling
   wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode
-      readMode;    ///< Which type of read to perform
+      readMode;    ///< Which type of analog read to perform
   long period;     ///< Pin timer interval, in millis, -1 if disabled.
   long prvPeriod;  ///< When Pin's timer was previously serviced, in millis
   float prvPinVal; ///< Previous pin value
@@ -64,6 +64,7 @@ public:
   void setADCResolution(int resolution);
   int getADCresolution();
   int getNativeResolution();
+  bool timerExpired(long currentTime, analogInputPin pin);
 
   void update();
   bool encodePinEvent(

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -66,7 +66,10 @@ public:
   bool timerExpired(long currentTime, analogInputPin pin);
 
   void update();
-  bool encodePinEvent(uint8_t pinName, wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode readMode, uint16_t pinValRaw = 0, float pinValVolts = 0.0);
+  bool encodePinEvent(
+      uint8_t pinName,
+      wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode readMode,
+      uint16_t pinValRaw = 0, float pinValVolts = 0.0);
 
 private:
   float _aRef;           /*!< Hardware's reported voltage reference */
@@ -74,7 +77,7 @@ private:
   int _nativeResolution; /*!< Hardware's native ADC resolution. */
   bool scaleAnalogRead = false; /*!< True if we need to manually scale the value
                                    returned by analogRead(). */
-  int32_t _totalAnalogInputPins; /*!< Total number of analog input pins */
+  int32_t _totalAnalogInputPins;      /*!< Total number of analog input pins */
   analogInputPin *_analog_input_pins; /*!< Array of analog pin objects */
 };
 extern Wippersnapper WS; /*!< Wippersnapper variable. */

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -18,9 +18,11 @@
 
 #include "Wippersnapper.h"
 
+#define HYSTERISIS 0.2 ///< Default hysterisis of 2%
+
 /** Data about an analog input pin */
 struct analogInputPin {
-  int pinName; ///< Pin name
+  int pinName;  ///< Pin name
   bool enabled; ///< Pin is enabled for sampling
   wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode
       readMode;    ///< Which type of read to perform
@@ -56,21 +58,17 @@ public:
                   int pin);
   void deinitAnalogInputPinObj(int pin);
 
-  uint16_t readAnalogPinRaw(int pin);
-  float getAnalogPinVoltage(uint16_t rawValue);
+  uint16_t getPinValue(int pin);
+  float getPinValueVolts(int pin);
 
   void setADCResolution(int resolution);
   int getADCresolution();
   int getNativeResolution();
 
   void update();
-
-  bool
-  encodePinEvent(wippersnapper_signal_v1_CreateSignalRequest *outgoingSignalMsg,
-                 uint8_t pinName, float pinVal);
-  bool
-  encodePinEvent(wippersnapper_signal_v1_CreateSignalRequest *outgoingSignalMsg,
-                 uint8_t pinName, uint16_t pinVal);
+  bool encodePinEvent(
+      wippersnapper_signal_v1_CreateSignalRequest *outgoingSignalMsg,
+      uint8_t pinName, wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode readMode, uint16_t pinValRaw = 0, float pinValVolts = 0.0);
 
   analogInputPin *_analog_input_pins; /*!< Array of analog pin objects */
 private:
@@ -80,10 +78,6 @@ private:
   bool scaleAnalogRead = false; /*!< True if we need to manually scale the value
                                    returned by analogRead(). */
   int32_t _totalAnalogInputPins; /*!< Total number of analog input pins */
-
-  float _hysterisis;         /*!< Hysterisis factor. */
-  uint16_t _pinValThreshLow; /*!< Calculated low threshold. */
-  uint16_t _pinValThreshHi;  /*!< Calculated high threshold. */
 
   uint16_t _pinValue; /*!< Pin's raw value from analogRead */
   float _pinVoltage;  /*!< Pin's calculated voltage, in volts. */

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -55,7 +55,7 @@ public:
   void
   deinitAnalogPin(wippersnapper_pin_v1_ConfigurePinRequest_Direction direction,
                   int pin);
-  void deinitAnalogInputPinObj(int pin);
+  void disableAnalogInPin(int pin);
 
   uint16_t getPinValue(int pin);
   float getPinValueVolts(int pin);

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -48,7 +48,6 @@ public:
   void setAref(float refVoltage);
   float getAref();
 
-  void initAnalogOutputPin(int pin);
   void initAnalogInputPin(
       int pin, float period,
       wippersnapper_pin_v1_ConfigurePinRequest_Pull pullMode,

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -67,9 +67,7 @@ public:
   bool timerExpired(long currentTime, analogInputPin pin);
 
   void update();
-  bool encodePinEvent(
-      wippersnapper_signal_v1_CreateSignalRequest *outgoingSignalMsg,
-      uint8_t pinName, wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode readMode, uint16_t pinValRaw = 0, float pinValVolts = 0.0);
+  bool encodePinEvent(uint8_t pinName, wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode readMode, uint16_t pinValRaw = 0, float pinValVolts = 0.0);
 
   analogInputPin *_analog_input_pins; /*!< Array of analog pin objects */
 private:
@@ -82,9 +80,6 @@ private:
 
   uint16_t _pinValue; /*!< Pin's raw value from analogRead */
   float _pinVoltage;  /*!< Pin's calculated voltage, in volts. */
-
-  wippersnapper_signal_v1_CreateSignalRequest
-      _outgoingSignalMsg; /*!< Signal message to send to broker on pin event. */
 };
 extern Wippersnapper WS; /*!< Wippersnapper variable. */
 


### PR DESCRIPTION
This pull request:
* Resolves #406  
* Refactors `Wippersnapper_AnalogIO` class:
  * Changes `processAnalogInputs()` to `update()` to match other, newer, component class APIs. **Large** refactoring for readability and maintainability around this new method
  * Added `encodePinEvent` func to encode and publish signal message to IO
  * **Removes** unused `initAnalogOutputPin`, superseded by PWM class
* Refactors `configurePinRequest()` into `configAnalogInPinReq()` and `configureDigitalPinReq()`
* Note: this is not a complete refactoring of the class, only what I was confused about/thought needed immediate attention for maintainability and compatibility with other component APIs.

Resolves:
https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/406
https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/403 (needs testing!)

Required tests prior to merging:
- [x] Test LED component toggle (digital class since decoder func. was touched
- [x] Test Pot. component: Periodic polling, raw adc
- [x] Test Pot. component: Periodic polling, voltage
- [x] Test Pot. component: "on change" polling, raw adc
- [x] Test Pot. component: "on change" polling, voltage
- [x] Test Pot. with PicoW