### PR TITLE
Add driver for MAX17048

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.60
+version=1.0.0-beta.61
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper
@@ -7,4 +7,4 @@ paragraph=Arduino client for Adafruit.io WipperSnapper
 category=Communication
 url=https://github.com/adafruit/Adafruit_IO_Arduino
 architectures=*
-depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, Sensirion I2C SEN5X, arduino-sht, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit_VL53L0X, Adafruit PM25 AQI Sensor, Adafruit VEML7700 Library, Adafruit LC709203F, Adafruit seesaw Library, Adafruit BME680 Library
+depends=Adafruit NeoPixel, Adafruit SPIFlash, ArduinoJson, Adafruit DotStar, Adafruit SleepyDog Library, Adafruit TinyUSB Library, Adafruit AHTX0, Adafruit BME280 Library, Adafruit DPS310, Adafruit SCD30, Sensirion I2C SCD4x, Sensirion I2C SEN5X, arduino-sht, Adafruit Si7021 Library, Adafruit MQTT Library, Adafruit MCP9808 Library, Adafruit MCP9600 Library, Adafruit TSL2591 Library, Adafruit_VL53L0X, Adafruit PM25 AQI Sensor, Adafruit VEML7700 Library, Adafruit LC709203F, Adafruit seesaw Library, Adafruit BME680 Library, Adafruit MAX1704X

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -90,7 +90,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.60" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.61" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -416,7 +416,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     drivers.push_back(_vl53l0x);
     WS_DEBUG_PRINTLN("VL53L0X Initialized Successfully!");
   } else if (strcmp("max17048", msgDeviceInitReq->i2c_device_name) == 0) {
-    _vl53l0x = new WipperSnapper_I2C_Driver_MAX17048(this->_i2c, i2cAddress);
+    _max17048 = new WipperSnapper_I2C_Driver_MAX17048(this->_i2c, i2cAddress);
     if (!_max17048->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize MAX17048/MAX17049!");
       _busStatusResponse =

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -415,6 +415,17 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _vl53l0x->configureDriver(msgDeviceInitReq);
     drivers.push_back(_vl53l0x);
     WS_DEBUG_PRINTLN("VL53L0X Initialized Successfully!");
+  } else if (strcmp("max17048", msgDeviceInitReq->i2c_device_name) == 0) {
+    _vl53l0x = new WipperSnapper_I2C_Driver_MAX17048(this->_i2c, i2cAddress);
+    if (!_max17048->begin()) {
+      WS_DEBUG_PRINTLN("ERROR: Failed to initialize MAX17048/MAX17049!");
+      _busStatusResponse =
+          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
+      return false;
+    }
+    _max17048->configureDriver(msgDeviceInitReq);
+    drivers.push_back(_max17048);
+    WS_DEBUG_PRINTLN("MAX17048/MAX17049 Initialized Successfully!");
   } else {
     WS_DEBUG_PRINTLN("ERROR: I2C device type not found!")
     _busStatusResponse =

--- a/src/components/i2c/WipperSnapper_I2C.h
+++ b/src/components/i2c/WipperSnapper_I2C.h
@@ -25,6 +25,7 @@
 #include "drivers/WipperSnapper_I2C_Driver_BME680.h"
 #include "drivers/WipperSnapper_I2C_Driver_DPS310.h"
 #include "drivers/WipperSnapper_I2C_Driver_LC709203F.h"
+#include "drivers/WipperSnapper_I2C_Driver_MAX17048.h"
 #include "drivers/WipperSnapper_I2C_Driver_MCP9808.h"
 #include "drivers/WipperSnapper_I2C_Driver_PM25.h"
 #include "drivers/WipperSnapper_I2C_Driver_SCD30.h"
@@ -100,6 +101,7 @@ private:
   WipperSnapper_I2C_Driver_LC709203F *_lc = nullptr;
   WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor *_ss = nullptr;
   WipperSnapper_I2C_Driver_VL53L0X *_vl53l0x = nullptr;
+  WipperSnapper_I2C_Driver_MAX17048 *_max17048 = nullptr;
 };
 extern Wippersnapper WS;
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
@@ -72,7 +72,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventVoltage(sensors_event_t *voltageEvent) {
-    voltageEvent->voltage = _maxlipo.cellVoltage();
+    voltageEvent->voltage = _maxlipo->cellVoltage();
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
@@ -1,0 +1,98 @@
+/*!
+ * @file WipperSnapper_I2C_Driver_MAX17048.h
+ *
+ * Device driver for the MAX17048/MAX17049 LiPoly / LiIon Fuel Gauge and Battery
+ * Monitor
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) Brent Rubell 2023 for Adafruit Industries.
+ *
+ * MIT license, all text here must be included in any redistribution.
+ *
+ */
+#ifndef WipperSnapper_I2C_Driver_MAX17048_H
+#define WipperSnapper_I2C_Driver_MAX17048_H
+
+#include "WipperSnapper_I2C_Driver.h"
+#include <Adafruit_MAX1704X.h>
+
+/**************************************************************************/
+/*!
+    @brief  Class that provides a driver interface for a MAX17048 sensor.
+*/
+/**************************************************************************/
+class WipperSnapper_I2C_Driver_MAX17048 : public WipperSnapper_I2C_Driver {
+public:
+  /*******************************************************************************/
+  /*!
+      @brief    Constructor for a MAX17048 sensor.
+      @param    i2c
+                The I2C interface.
+      @param    sensorAddress
+                The 7-bit I2C address of the sensor.
+  */
+  /*******************************************************************************/
+  WipperSnapper_I2C_Driver_MAX17048(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Destructor for an MAX17048 sensor.
+  */
+  /*******************************************************************************/
+  ~WipperSnapper_I2C_Driver_MAX17048() { delete _maxlipo; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the MAX17048 sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _maxlipo = new Adafruit_MAX17048();
+    if (!_maxlipo->begin(_i2c))
+      return false;
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Reads a voltage sensor and converts the
+                reading into the expected SI unit.
+      @param    voltageEvent
+                voltage sensor reading, in volts.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventVoltage(sensors_event_t *voltageEvent) {
+    voltageEvent->voltage = _maxlipo.cellVoltage();
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Reads a sensor's unitless % reading and
+                converts the reading into the expected SI unit.
+      @param    unitlessPercentEvent
+                unitless % sensor reading.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventUnitlessPercent(sensors_event_t *unitlessPercentEvent) {
+    unitlessPercentEvent->data[0] = _maxlipo->cellPercent();
+    return true;
+  }
+
+protected:
+  Adafruit_MAX17048 *_maxlipo; ///< Pointer to MAX17048 sensor object
+};
+
+#endif // WipperSnapper_I2C_Driver_MAX17048


### PR DESCRIPTION
Adds a driver for MAX17048 / MAX17049 lipo charge monitor fuel gauges.

Related component PR: https://github.com/adafruit/Wippersnapper_Components/pull/120

