### PR TITLE
Fix NeoPixels not working on Adafruit MagTag

### DIFF
--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -41,7 +41,12 @@ void initStatusLED() {
     digitalWrite(NEOPIXEL_I2C_POWER, HIGH);
 #elif defined(NEOPIXEL_POWER)
     pinMode(NEOPIXEL_POWER, OUTPUT);
+// turn NeoPixel power pin on
+#ifndef ARDUINO_MAGTAG29_ESP32S2
     digitalWrite(NEOPIXEL_POWER, HIGH);
+#else
+    digitalWrite(NEOPIXEL_POWER, LOW);
+#endif
 #endif
     statusPixel = new Adafruit_NeoPixel(
         STATUS_NEOPIXEL_NUM, STATUS_NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);


### PR DESCRIPTION
MagTag requires "pin 21 to be an output and LOW". This PR sets `NEOPIXEL_POWER` to `LOW` for the MagTag board within StatusLED.

Tested with both StatusLED and Pixels modules