### PR TITLE
Patch workflow warnings

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -130,7 +130,7 @@ jobs:
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
-          echo "{boardJson}={content} >> $GITHUB_OUTPUT"
+          echo "{boardJson}=${content} >> $GITHUB_OUTPUT"
 
     - name: Create combined binary using Esptool merge_bin
       run: |

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -133,7 +133,7 @@ jobs:
           echo "{boardJson}={content} >> $GITHUB_OUTPUT"
     - name: Create combined binary using Esptool merge_bin
       run: |
-          python3 -m esptool --chip ${{fromJson($GITHUB_OUTPUT).esptool.chip}} merge_bin \
+          python3 -m esptool --chip ${{$GITHUB_OUTPUT.esptool.chip}} merge_bin \
             --flash_mode ${{fromJson($GITHUB_OUTPUT).esptool.flashMode}} \
             --flash_freq ${{fromJson($GITHUB_OUTPUT).esptool.flashFreq}} \
             --flash_size ${{fromJson($GITHUB_OUTPUT).esptool.flashSize}} \

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -134,10 +134,10 @@ jobs:
 
     - name: Create combined binary using Esptool merge_bin
       run: |
-          python3 -m esptool --chip ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.chip}} merge_bin \
-            --flash_mode ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashMode}} \
-            --flash_freq ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashFreq}} \
-            --flash_size ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashSize}} \
+          python3 -m esptool --chip ${{fromJson(env.boardJson).esptool.chip}} merge_bin \
+            --flash_mode ${{fromJson(env.boardJson).esptool.flashMode}} \
+            --flash_freq ${{fromJson(env.boardJson).esptool.flashFreq}} \
+            --flash_size ${{fromJson(env.boardJson).esptool.flashSize}} \
             -o wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.combined.bin \
             ${{ matrix.offset }} wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
             0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -27,13 +27,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
       with:
          repository: brentru/ci-arduino
          path: ci
@@ -55,7 +55,7 @@ jobs:
             mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
             mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
     - name: upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v2
       with:
         name: build-files
         path: |
@@ -77,18 +77,18 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
       with:
         repository: adafruit/ci-arduino
         path: ci
     - name: Checkout Board Definitions
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
       with:
         repository: adafruit/Wippersnapper_Boards
         path: ws-boards
@@ -131,12 +131,13 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           echo "{boardJson}={content} >> $GITHUB_OUTPUT"
+
     - name: Create combined binary using Esptool merge_bin
       run: |
-          python3 -m esptool --chip ${{$GITHUB_OUTPUT.esptool.chip}} merge_bin \
-            --flash_mode ${{fromJson($GITHUB_OUTPUT).esptool.flashMode}} \
-            --flash_freq ${{fromJson($GITHUB_OUTPUT).esptool.flashFreq}} \
-            --flash_size ${{fromJson($GITHUB_OUTPUT).esptool.flashSize}} \
+          python3 -m esptool --chip ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.chip}} merge_bin \
+            --flash_mode ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashMode}} \
+            --flash_freq ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashFreq}} \
+            --flash_size ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashSize}} \
             -o wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.combined.bin \
             ${{ matrix.offset }} wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
             0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \
@@ -146,7 +147,7 @@ jobs:
       run: |
             zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*
     - name: upload build artifacts zip
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v2
       with:
         name: build-files
         path: |
@@ -163,13 +164,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
       with:
          repository: adafruit/ci-arduino
          path: ci
@@ -189,7 +190,7 @@ jobs:
             mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
             mv examples/*/build/*/Wippersnapper_demo.ino.hex wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.hex
     - name: upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v2
       with:
         name: build-files
         path: |
@@ -207,13 +208,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
       with:
          repository: brentru/ci-arduino
          path: ci
@@ -231,7 +232,7 @@ jobs:
       run: |
             mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
     - name: upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v2
       with:
         name: build-files
         path: |
@@ -250,13 +251,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
       with:
          repository: adafruit/ci-arduino
          path: ci
@@ -283,13 +284,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
       with:
          repository: adafruit/ci-arduino
          path: ci
@@ -315,7 +316,7 @@ jobs:
       run: |
             zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*
     - name: upload build artifacts zip
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v2
       with:
         name: build-files
         path: |
@@ -329,9 +330,9 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
       with:
          repository: adafruit/ci-arduino
          path: ci

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -27,13 +27,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          repository: brentru/ci-arduino
          path: ci
@@ -55,7 +55,7 @@ jobs:
             mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
             mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
     - name: upload build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-files
         path: |
@@ -77,18 +77,18 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: adafruit/ci-arduino
         path: ci
     - name: Checkout Board Definitions
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: adafruit/Wippersnapper_Boards
         path: ws-boards
@@ -148,7 +148,7 @@ jobs:
       run: |
             zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*
     - name: upload build artifacts zip
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-files
         path: |
@@ -165,13 +165,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          repository: adafruit/ci-arduino
          path: ci
@@ -191,7 +191,7 @@ jobs:
             mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
             mv examples/*/build/*/Wippersnapper_demo.ino.hex wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.hex
     - name: upload build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-files
         path: |
@@ -209,13 +209,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          repository: brentru/ci-arduino
          path: ci
@@ -233,7 +233,7 @@ jobs:
       run: |
             mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
     - name: upload build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-files
         path: |
@@ -252,13 +252,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          repository: adafruit/ci-arduino
          path: ci
@@ -285,13 +285,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get WipperSnapper version
       run: |
         git fetch --prune --unshallow --tags
         git describe --dirty --tags
         echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          repository: adafruit/ci-arduino
          path: ci
@@ -317,7 +317,7 @@ jobs:
       run: |
             zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*
     - name: upload build artifacts zip
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-files
         path: |
@@ -331,9 +331,9 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
          repository: adafruit/ci-arduino
          path: ci

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -113,7 +113,7 @@ jobs:
             mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.partitions.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin
     - name: Check boot_app0 file existence (esp32 built from core, not-source)
       id: check_files
-      uses: andstor/file-existence-action@v1
+      uses: andstor/file-existence-action@v2
       with:
         files: "/home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin"
     - name: boot_app0 file from arduino-cli core
@@ -130,7 +130,6 @@ jobs:
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
-          echo "::set-output name=boardJson::$content"
           echo "{boardJson}=${content} >> $GITHUB_OUTPUT"
 
     - name: Create combined binary using Esptool merge_bin

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -130,7 +130,9 @@ jobs:
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
-          echo "{boardJson}={$content} >> $GITHUB_OUTPUT"
+          echo "::set-output name=boardJson::$content"
+          echo "{boardJson}=${content} >> $GITHUB_OUTPUT"
+
     - name: Create combined binary using Esptool merge_bin
       run: |
           python3 -m esptool --chip ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.chip}} merge_bin \

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -130,14 +130,13 @@ jobs:
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
-          echo "{boardJson}=${content} >> $GITHUB_OUTPUT"
-
+          echo "{boardJson}={content} >> $GITHUB_OUTPUT"
     - name: Create combined binary using Esptool merge_bin
       run: |
-          python3 -m esptool --chip ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.chip}} merge_bin \
-            --flash_mode ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashMode}} \
-            --flash_freq ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashFreq}} \
-            --flash_size ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashSize}} \
+          python3 -m esptool --chip ${{fromJson($GITHUB_OUTPUT).esptool.chip}} merge_bin \
+            --flash_mode ${{fromJson($GITHUB_OUTPUT).esptool.flashMode}} \
+            --flash_freq ${{fromJson($GITHUB_OUTPUT).esptool.flashFreq}} \
+            --flash_size ${{fromJson($GITHUB_OUTPUT).esptool.flashSize}} \
             -o wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.combined.bin \
             ${{ matrix.offset }} wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
             0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -24,7 +24,7 @@ jobs:
                            "feather_esp32s3_tft",
                            "qtpy_esp32s3", "qtpy_esp32s2"]
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
           - offset: "0x0"
             arduino-platform: "qtpy_esp32c3"
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - uses: actions/checkout@v2
@@ -130,7 +130,7 @@ jobs:
           content="${content//'%'/'%25'}"
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
-          echo "::set-output name=boardJson::$content"
+          echo "{boardJson}={$content} >> $GITHUB_OUTPUT"
     - name: Create combined binary using Esptool merge_bin
       run: |
           python3 -m esptool --chip ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.chip}} merge_bin \
@@ -160,7 +160,7 @@ jobs:
       matrix:
         arduino-platform: ["pyportal_tinyusb", "metro_m4_airliftlite_tinyusb"]
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - uses: actions/checkout@v2
@@ -204,7 +204,7 @@ jobs:
       matrix:
         arduino-platform: ["rpi_pico_w"]
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - uses: actions/checkout@v2
@@ -247,7 +247,7 @@ jobs:
       matrix:
         arduino-platform: ["mkrwifi1010", "nano_33_iot"]
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - uses: actions/checkout@v2
@@ -280,7 +280,7 @@ jobs:
       matrix:
         arduino-platform: ["feather_esp8266"]
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - uses: actions/checkout@v2
@@ -326,7 +326,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-samd, build-esp32, build-esp32sx, build-esp8266, build-samd-non-fs, build-rp2040]
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - uses: actions/checkout@v2


### PR DESCRIPTION
This pull request patches the workflows to remove the following annotations/warnings:
* Deprecating save-state and set-output commands (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
* Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-python@v1, actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.