### PR TITLE
Update SCD4x driver and sensor types

### DIFF
--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -90,7 +90,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.63" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.64" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -819,11 +819,11 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
         WS_DEBUG_PRINTLN("");
         WS_DEBUG_PRINT("\tPM1.0: ");
-        WS_DEBUG_PRINT(event.data[0]);
+        WS_DEBUG_PRINT(event.pm10_std);
         WS_DEBUG_PRINTLN(" ppm");
 
         // pack event data into msg
-        fillEventMessage(&msgi2cResponse, event.data[0],
+        fillEventMessage(&msgi2cResponse, event.pm10_std,
                          wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM10_STD);
       } else {
         WS_DEBUG_PRINTLN("ERROR: Failed to get PM1.0 sensor reading!");
@@ -842,11 +842,11 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
         WS_DEBUG_PRINTLN("");
         WS_DEBUG_PRINT("\tPM2.5: ");
-        WS_DEBUG_PRINT(event.data[0]);
+        WS_DEBUG_PRINT(event.pm25_std);
         WS_DEBUG_PRINTLN(" ppm");
 
         // pack event data into msg
-        fillEventMessage(&msgi2cResponse, event.data[0],
+        fillEventMessage(&msgi2cResponse, event.pm25_std,
                          wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM25_STD);
       } else {
         WS_DEBUG_PRINTLN("ERROR: Failed to get PM2.5 sensor reading!");
@@ -864,12 +864,12 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINT("Sensor 0x");
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
         WS_DEBUG_PRINTLN("");
-        WS_DEBUG_PRINT("\tPM100: ");
-        WS_DEBUG_PRINT(event.data[0]);
+        WS_DEBUG_PRINT("\tPM10.0: ");
+        WS_DEBUG_PRINT(event.pm25_std);
         WS_DEBUG_PRINTLN(" ppm");
 
         // pack event data into msg
-        fillEventMessage(&msgi2cResponse, event.data[0],
+        fillEventMessage(&msgi2cResponse, event.pm25_std,
                          wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM100_STD);
       } else {
         WS_DEBUG_PRINTLN("ERROR: Failed to get PM10.0 sensor reading!");
@@ -920,7 +920,7 @@ void WipperSnapper_Component_I2C::update() {
             wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_UNITLESS_PERCENT);
       } else {
         WS_DEBUG_PRINTLN(
-            "ERROR: Failed to get unitless percentage sensor reading!");
+            "ERROR: Failed to get unitless percent sensor reading!");
       }
       // try again in curTime seconds
       (*iter)->setSensorUnitlessPercentPeriodPrv(curTime);
@@ -956,11 +956,11 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
         WS_DEBUG_PRINTLN("");
         WS_DEBUG_PRINT("\tGas Resistance: ");
-        WS_DEBUG_PRINT(event.data[0]);
+        WS_DEBUG_PRINT(event.gas_resistance);
         WS_DEBUG_PRINT(" ohms");
 
         fillEventMessage(
-            &msgi2cResponse, event.data[0],
+            &msgi2cResponse, event.gas_resistance,
             wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_GAS_RESISTANCE);
       } else {
         WS_DEBUG_PRINTLN(

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -318,14 +318,14 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
   } else if (strcmp("scd40", msgDeviceInitReq->i2c_device_name) == 0) {
     _scd40 = new WipperSnapper_I2C_Driver_SCD4X(this->_i2c, i2cAddress);
     if (!_scd40->begin()) {
-      WS_DEBUG_PRINTLN("ERROR: Failed to initialize SCD40!");
+      WS_DEBUG_PRINTLN("ERROR: Failed to initialize SCD4x!");
       _busStatusResponse =
           wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
       return false;
     }
     _scd40->configureDriver(msgDeviceInitReq);
     drivers.push_back(_scd40);
-    WS_DEBUG_PRINTLN("SCD40 Initialized Successfully!");
+    WS_DEBUG_PRINTLN("SCD4x Initialized Successfully!");
   } else if (strcmp("sen5x", msgDeviceInitReq->i2c_device_name) == 0) {
     _sen5x = new WipperSnapper_I2C_Driver_SEN5X(this->_i2c, i2cAddress);
     if (!_sen5x->begin()) {

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -316,7 +316,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     drivers.push_back(_veml7700);
     WS_DEBUG_PRINTLN("VEML7700 Initialized Successfully!");
   } else if (strcmp("scd40", msgDeviceInitReq->i2c_device_name) == 0) {
-    _scd40 = new WipperSnapper_I2C_Driver_SCD40(this->_i2c, i2cAddress);
+    _scd40 = new WipperSnapper_I2C_Driver_SCD4X(this->_i2c, i2cAddress);
     if (!_scd40->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize SCD40!");
       _busStatusResponse =
@@ -752,10 +752,10 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
         WS_DEBUG_PRINTLN("");
         WS_DEBUG_PRINT("\tCO2: ");
-        WS_DEBUG_PRINT(event.data[0]);
+        WS_DEBUG_PRINT(event.CO2);
         WS_DEBUG_PRINTLN(" ppm");
 
-        fillEventMessage(&msgi2cResponse, event.data[0],
+        fillEventMessage(&msgi2cResponse, event.CO2,
                          wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_CO2);
         (*iter)->setSensorCO2PeriodPrv(curTime);
       } else {
@@ -911,12 +911,12 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
         WS_DEBUG_PRINTLN("");
         WS_DEBUG_PRINT("\tRead: ");
-        WS_DEBUG_PRINT(event.data[0]);
+        WS_DEBUG_PRINT(event.unitless_percent);
         WS_DEBUG_PRINTLN(" %");
 
         // pack event data into msg
         fillEventMessage(
-            &msgi2cResponse, event.voltage,
+            &msgi2cResponse, event.unitless_percent,
             wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_UNITLESS_PERCENT);
       } else {
         WS_DEBUG_PRINTLN(

--- a/src/components/i2c/WipperSnapper_I2C.h
+++ b/src/components/i2c/WipperSnapper_I2C.h
@@ -30,7 +30,7 @@
 #include "drivers/WipperSnapper_I2C_Driver_MCP9808.h"
 #include "drivers/WipperSnapper_I2C_Driver_PM25.h"
 #include "drivers/WipperSnapper_I2C_Driver_SCD30.h"
-#include "drivers/WipperSnapper_I2C_Driver_SCD40.h"
+#include "drivers/WipperSnapper_I2C_Driver_SCD4X.h"
 #include "drivers/WipperSnapper_I2C_Driver_SEN5X.h"
 #include "drivers/WipperSnapper_I2C_Driver_SHT3X.h"
 #include "drivers/WipperSnapper_I2C_Driver_SHT4X.h"
@@ -92,7 +92,7 @@ private:
   WipperSnapper_I2C_Driver_MCP9808 *_mcp9808 = nullptr;
   WipperSnapper_I2C_Driver_TSL2591 *_tsl2591 = nullptr;
   WipperSnapper_I2C_Driver_VEML7700 *_veml7700 = nullptr;
-  WipperSnapper_I2C_Driver_SCD40 *_scd40 = nullptr;
+  WipperSnapper_I2C_Driver_SCD4X *_scd40 = nullptr;
   WipperSnapper_I2C_Driver_SEN5X *_sen5x = nullptr;
   WipperSnapper_I2C_Driver_PM25 *_pm25 = nullptr;
   WipperSnapper_I2C_Driver_SI7021 *_si7021 = nullptr;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME680.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME680.h
@@ -165,9 +165,8 @@ public:
   virtual bool getEventGasResistance(sensors_event_t *gasEvent) {
     if (!bmePerformReading())
       return false;
-    // NOTE: This is hacked onto Adafruit_Sensor and should eventually be
-    // removed
-    gasEvent->data[0] = (float)_bme->gas_resistance;
+
+    gasEvent->gas_resistance = (float)_bme->gas_resistance;
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_LC709203F.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_LC709203F.h
@@ -94,7 +94,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventUnitlessPercent(sensors_event_t *unitlessPercentEvent) {
-    unitlessPercentEvent->data[0] = _lc->cellPercent();
+    unitlessPercentEvent->unitless_percent = _lc->cellPercent();
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
@@ -87,7 +87,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventUnitlessPercent(sensors_event_t *unitlessPercentEvent) {
-    unitlessPercentEvent->data[0] = _maxlipo->cellPercent();
+    unitlessPercentEvent->unitless_percent = _maxlipo->cellPercent();
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_PM25.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_PM25.h
@@ -75,7 +75,7 @@ public:
     if (!_pm25->read(&data))
       return false; // couldn't read data
 
-    pm10StdEvent->data[0] = (float)data.pm10_standard;
+    pm10StdEvent->pm10_std = (float)data.pm10_standard;
     return true;
   }
 
@@ -93,7 +93,7 @@ public:
     if (!_pm25->read(&data))
       return false; // couldn't read data
 
-    pm25StdEvent->data[0] = (float)data.pm25_standard;
+    pm25StdEvent->pm25_std = (float)data.pm25_standard;
     return true;
   }
 
@@ -111,7 +111,7 @@ public:
     if (!_pm25->read(&data))
       return false; // couldn't read data
 
-    pm100StdEvent->data[0] = (float)data.pm100_standard;
+    pm100StdEvent->pm100_std = (float)data.pm100_standard;
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD30.h
@@ -110,9 +110,8 @@ public:
     // check if sensor is enabled and data is available
     if (_CO2SensorPeriod != 0 && (!_scd->dataReady()))
       return false;
-    // TODO: This is a TEMPORARY HACK, we need to add CO2 type to
-    // adafruit_sensor
-    co2Event->data[0] = _scd->CO2;
+
+    co2Event->CO2 = _scd->CO2;
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
@@ -55,18 +55,11 @@ public:
     _scd->begin(*_i2c);
 
     // stop previously started measurement
-    if (!_scd->stopPeriodicMeasurement())
-      return false;
-
-    // attempt to grab SCD4x's serial number
-    uint16_t serial0;
-    uint16_t serial1;
-    uint16_t serial2;
-    if (!_scd->getSerialNumber(serial0, serial1, serial2))
+    if (_scd->stopPeriodicMeasurement())
       return false;
 
     // start measurements
-    if (!_scd->startPeriodicMeasurement())
+    if (_scd->startPeriodicMeasurement())
       return false;
 
     return true;
@@ -142,7 +135,7 @@ public:
     if (!readSensorMeasurements())
       return false;
 
-    co2Event->CO2 = _co2;
+    co2Event->CO2 = (float)_co2;
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
@@ -67,21 +67,26 @@ public:
 
   /********************************************************************************/
   /*!
-      @brief    Reads the SCD4x's sensors
+      @brief    Attempts to read the SCD4x's sensor measurements
       @returns  True if the measurements were read without errors, False
-     otherwise.
+                if read errors occured or if sensor did not have data ready.
   */
   /********************************************************************************/
   bool readSensorMeasurements() {
-    // TODO: We should also have a func. to check if data is ready
-    // prior to calling this func but sensiron does not yet
-    // have this released:
-    // https://github.com/Sensirion/arduino-i2c-scd4x/commit/4ec07965f30f32f4320960a04aadb7a19e6499c7
+    uint16_t error;
+    bool isDataReady = false;
+    delay(100);
 
-    int16_t error;
+    // Check if data is ready
+    error = _scd->getDataReadyFlag(isDataReady);
+    if (error || !isDataReady)
+      return false;
+
+    // Read SCD4x measurement
     error = _scd->readMeasurement(_co2, _temperature, _humidity);
     if (error || _co2 == 0)
       return false;
+
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
@@ -1,8 +1,7 @@
 /*!
- * @file WipperSnapper_I2C_Driver_scd40.h
+ * @file WipperSnapper_I2C_Driver_SCD4x.h
  *
- * Device driver for the SCD40 CO2, Temperature, and Humidity sensor.
- * TEMPORARY HACK
+ * Device driver for the SCD4X CO2, Temperature, and Humidity sensor.
  *
  * Adafruit invests time and resources providing this open source code,
  * please support Adafruit and open-source hardware by purchasing
@@ -21,7 +20,6 @@
 #include "WipperSnapper_I2C_Driver.h"
 #include <SensirionI2CScd4x.h>
 #include <Wire.h>
-
 
 /**************************************************************************/
 /*!
@@ -74,6 +72,13 @@ public:
     return true;
   }
 
+  /********************************************************************************/
+  /*!
+      @brief    Reads the SCD4x's sensors
+      @returns  True if the measurements were read without errors, False
+     otherwise.
+  */
+  /********************************************************************************/
   bool readSensorMeasurements() {
     // TODO: We should also have a func. to check if data is ready
     // prior to calling this func but sensiron does not yet

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
@@ -8,27 +8,27 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Copyright (c) Marni Brewster 2022 for Adafruit Industries.
+ * Copyright (c) Marni Brewster 2022
+ * Copyright (c) Brent Rubell 2023 for Adafruit Industries
  *
  * MIT license, all text here must be included in any redistribution.
  *
  */
 
-#ifndef WipperSnapper_I2C_Driver_scd40_H
-#define WipperSnapper_I2C_Driver_scd40_H
+#ifndef WipperSnapper_I2C_Driver_SCD4X_H
+#define WipperSnapper_I2C_Driver_SCD4X_H
 
 #include "WipperSnapper_I2C_Driver.h"
 #include <SensirionI2CScd4x.h>
 #include <Wire.h>
 
-// TODO: Change title to SCD4X.h
 
 /**************************************************************************/
 /*!
     @brief  Class that provides a driver interface for the SCD40 sensor.
 */
 /**************************************************************************/
-class WipperSnapper_I2C_Driver_SCD40 : public WipperSnapper_I2C_Driver {
+class WipperSnapper_I2C_Driver_SCD4X : public WipperSnapper_I2C_Driver {
 
 public:
   /*******************************************************************************/
@@ -40,7 +40,7 @@ public:
                 7-bit device address.
   */
   /*******************************************************************************/
-  WipperSnapper_I2C_Driver_SCD40(TwoWire *i2c, uint16_t sensorAddress)
+  WipperSnapper_I2C_Driver_SCD4X(TwoWire *i2c, uint16_t sensorAddress)
       : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
     _i2c = i2c;
     _sensorAddress = sensorAddress;
@@ -137,9 +137,7 @@ public:
     if (!readSensorMeasurements())
       return false;
 
-    // TODO: This is a TEMPORARY HACK, we need to add CO2 type to
-    // adafruit_sensor
-    co2Event->data[0] = _co2;
+    co2Event->CO2 = _co2;
     return true;
   }
 
@@ -150,4 +148,4 @@ protected:
   float _humidity;         ///< SCD4x humidity reading
 };
 
-#endif // WipperSnapper_I2C_Driver_SCD40
+#endif // WipperSnapper_I2C_Driver_SCD4X

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SEN5X.h
@@ -205,7 +205,7 @@ public:
       return false;
     }
 
-    pm10StdEvent->data[0] = massConcentrationPm1p0;
+    pm10StdEvent->pm10_std = massConcentrationPm1p0;
     return true;
   }
 
@@ -234,7 +234,7 @@ public:
       return false;
     }
 
-    pm25StdEvent->data[0] = massConcentrationPm2p5;
+    pm25StdEvent->pm25_std = massConcentrationPm2p5;
     return true;
   }
 
@@ -292,7 +292,7 @@ public:
       return false;
     }
 
-    pm100StdEvent->data[0] = massConcentrationPm10p0;
+    pm100StdEvent->pm100_std = massConcentrationPm10p0;
     return true;
   }
 


### PR DESCRIPTION
Note: This PR is a draft until we figure out why SCD40 is writing CO2 as an integer to the feed but the firmware sends a float and the device page displays a float.

This pull request:
- Refactoring around SCD40 (now SCD4X) driver's `getEvent()` calls
  - Note: In the future we will want to check if the sensor is ready to be read, currently blocking via https://github.com/Sensirion/arduino-i2c-scd4x/commit/4ec07965f30f32f4320960a04aadb7a19e6499c7
- Updates existing I2C drivers to use CO2, eCO2 sensor types (https://github.com/adafruit/Adafruit_Sensor/pull/45)
- Updates existing I2C drivers to use particle sensor types (https://github.com/adafruit/Adafruit_Sensor/pull/46)
- Updates existing I2C drivers to use sensor types for gas resistance and unitless percentage (https://github.com/adafruit/Adafruit_Sensor/pull/50)