### PR TITLE
Build for Arduino Release v2.0.9 based on ESP-IDF v4.4.4

### DIFF
--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -90,7 +90,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.62" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.63" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic


### PR DESCRIPTION
Builds WipperSnapper for [Build for Arduino Release v2.0.9 based on ESP-IDF v4.4.4](https://github.com/espressif/arduino-esp32/releases/tag/2.0.9)