### PR TITLE
Update Platformio.ini file to include more platforms and boards

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -3,47 +3,167 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+; PlatformIO Defaults
 [platformio]
 description = "Adafruit.IO WipperSnapper"
-default_envs = featheresp32v2, featheresp32s2
+default_envs = adafruit_feather_esp32s3_tft, adafruit_magtag29_esp32s2, adafruit_feather_esp32s3, featheresp32s2, adafruit_feather_esp32s2_reversetft, adafruit_metro_esp32s2, adafruit_qtpy_esp32s2, adafruit_feather_esp32s3_reversetft, adafruit_feather_esp32s3_nopsram, adafruit_feather_esp32s2_tft, adafruit_qtpy_esp32, adafruit_qtpy_esp32c3, featheresp32, adafruit_qtpy_esp32s3_nopsram, featheresp32v2
 
-; Common WipperSnapper Build Environment
+
+; Common Build Environment
 ; https://docs.platformio.org/en/latest/projectconf/section_env.html
 [env]
 framework = arduino
 monitor_speed = 115200
 lib_compat_mode = strict
-lib_extra_dirs = ~/Documents/Arduino/libraries
+lib_deps =
+    adafruit/Adafruit TinyUSB Library
+    adafruit/Adafruit NeoPixel
+    adafruit/Adafruit SPIFlash
+    adafruit/Adafruit DotStar
+    adafruit/Adafruit SleepyDog Library
+    adafruit/Adafruit AHTX0
+    adafruit/Adafruit BME280 Library
+    adafruit/Adafruit DPS310
+    adafruit/Adafruit SCD30
+    adafruit/Adafruit Si7021 Library
+    adafruit/Adafruit MCP9808 Library
+    adafruit/Adafruit MCP9600 Library
+    adafruit/Adafruit TSL2591 Library
+    adafruit/Adafruit_VL53L0X
+    adafruit/Adafruit PM25 AQI Sensor
+    adafruit/Adafruit VEML7700 Library
+    adafruit/Adafruit LC709203F
+    adafruit/Adafruit seesaw Library
+    adafruit/Adafruit BME680 Library
+    adafruit/Adafruit MAX1704X
+    adafruit/Adafruit ADT7410 Library
+    adafruit/Adafruit GFX Library
+    adafruit/Adafruit STMPE610
+    adafruit/Adafruit TouchScreen
+    bblanchon/ArduinoJson
+    PaulStoffregen/OneWire
+    https://github.com/milesburton/Arduino-Temperature-Control-Library.git
+    https://github.com/brentru/Adafruit_MQTT_Library.git
+    https://github.com/Sensirion/arduino-sht.git
+    https://github.com/Sensirion/arduino-i2c-scd4x.git
+    https://github.com/Sensirion/arduino-i2c-sen5x.git
 
+; Common build environment for ESP32 platform
+[common:esp32]
+platform = espressif32 @ ^6.3.2
+monitor_filters = esp32_exception_decoder, time
 
-; WipperSnapper local build environment for Adafruit Feather ESP32 v2
+; ESP32-x Boards ;
+
+; Adafruit ESP32 Feather
+[env:featheresp32]
+extends = common:esp32
+board = featheresp32
+build_flags = -DARDUINO_FEATHER_ESP32
+
+; Adafruit ESP32 Feather V2
 [env:featheresp32v2]
-platform = https://github.com/platformio/platform-espressif32.git
-monitor_filters = time, esp32_exception_decoder, colorize
+extends = common:esp32
 board = adafruit_feather_esp32_v2
-build_flags = -D ARDUINO_ADAFRUIT_FEATHER_ESP32_V2
-upload_port = /dev/cu.usbserial-11330
-monitor_port = /dev/cu.usbserial-11330
-lib_deps = adafruit/Adafruit TinyUSB Library@^1.10.3
+board_build.partitions = default_8MB.csv
+build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32_V2
 
-; WipperSnapper local build environment for Adafruit Feather ESP32-S2
+; Adafruit Feather ESP32-S2
 [env:featheresp32s2]
-platform = espressif32
+extends = common:esp32
 board = featheresp32-s2
-upload_port = /dev/cu.usbmodem01
-monitor_port = /dev/cu.usbmodem1330
-build_flags = -D ARDUINO_ADAFRUIT_FEATHER_ESP32S2
-monitor_filters = time, esp32_exception_decoder, colorize
+build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S2
 extra_scripts = 
     pre:rename_usb_config.py
-lib_deps = adafruit/Adafruit TinyUSB Library@^1.10.3
 
-; WipperSnapper local build environment for Adafruit Feather ESP8266
-[env:featheresp8266]
-platform = https://github.com/platformio/platform-espressif8266.git
-board = huzzah
-build_flags = -D ARDUINO_ESP8266_ADAFRUIT_HUZZAH
-lib_ignore = Adafruit TinyUSB Library
-build_src_filter = +<*> -<../.pio/libdeps/featheresp8266/Adafruit TinyUSB Library>
-upload_port = /dev/cu.usbserial-11330
-monitor_port = /dev/cu.usbserial-11330
+; Adafruit Feather ESP32-S2 TFT
+[env:adafruit_feather_esp32s2_tft]
+extends = common:esp32
+board = adafruit_feather_esp32s2_tft
+build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S2_TFT
+extra_scripts = 
+    pre:rename_usb_config.py
+
+; Adafruit Feather ESP32-S2 Reverse TFT
+[env:adafruit_feather_esp32s2_reversetft]
+extends = common:esp32
+board = adafruit_feather_esp32s2_reversetft
+build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S2_REVTFT
+extra_scripts = 
+    pre:rename_usb_config.py
+
+; Adafruit Feather ESP32-S3 2MB PSRAM
+[env:adafruit_feather_esp32s3]
+extends = common:esp32
+board = adafruit_feather_esp32s3
+build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S3
+extra_scripts = 
+    pre:rename_usb_config.py
+
+; Adafruit Feather ESP32-S3 NO PSRAM
+[env:adafruit_feather_esp32s3_nopsram]
+extends = common:esp32
+board = adafruit_feather_esp32s3_nopsram
+build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S3_NOPSRAM
+extra_scripts = 
+    pre:rename_usb_config.py
+
+; Adafruit Feather ESP32-S3 TFT
+[env:adafruit_feather_esp32s3_tft]
+extends = common:esp32
+board = adafruit_feather_esp32s3_tft
+build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S3_TFT
+extra_scripts = 
+    pre:rename_usb_config.py
+
+; Adafruit Feather ESP32-S3 Reverse TFT
+[env:adafruit_feather_esp32s3_reversetft]
+extends = common:esp32
+board = adafruit_feather_esp32s3_reversetft
+build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S3_REVTFT
+extra_scripts = 
+    pre:rename_usb_config.py
+
+; Adafruit Magtag ESP32-S2
+[env:adafruit_magtag29_esp32s2]
+extends = common:esp32
+board = adafruit_magtag29_esp32s2
+build_flags = -DARDUINO_MAGTAG29_ESP32S2
+extra_scripts = 
+    pre:rename_usb_config.py
+
+; Adafruit Metro ESP32-S2
+[env:adafruit_metro_esp32s2]
+extends = common:esp32
+board = adafruit_metro_esp32s2
+build_flags = -DARDUINO_METRO_ESP32S2
+extra_scripts = 
+    pre:rename_usb_config.py
+
+; Adafruit QT Py ESP32 Pico
+[env:adafruit_qtpy_esp32]
+extends = common:esp32
+board = adafruit_qtpy_esp32
+build_flags = -DARDUINO_ADAFRUIT_QTPY_ESP32
+
+; Adafruit QT Py ESP32-C3
+[env:adafruit_qtpy_esp32c3]
+extends = common:esp32
+board = adafruit_qtpy_esp32c3
+build_flags = -DARDUINO_ADAFRUIT_QTPY_ESP32C3
+
+; Adafruit QT Py ESP32-S2
+[env:adafruit_qtpy_esp32s2]
+extends = common:esp32
+board = adafruit_qtpy_esp32s2
+build_flags = -DARDUINO_ADAFRUIT_QTPY_ESP32S2
+extra_scripts = 
+    pre:rename_usb_config.py
+
+; Adafruit QT Py ESP32-S3 NO PSRAM
+[env:adafruit_qtpy_esp32s3_nopsram]
+platform = espressif32
+board = adafruit_qtpy_esp32s3_nopsram
+build_flags = -DARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM
+extra_scripts = 
+    pre:rename_usb_config.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,12 +1,12 @@
-; PlatformIO Project Configuration File for Adafruit.IO WipperSnapper
+; PlatformIO Project Configuration File for Adafruit.IO WipperSnapper Firmware
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
 ; PlatformIO Defaults
 [platformio]
-description = "Adafruit.IO WipperSnapper"
-default_envs = adafruit_feather_esp32s3_tft, adafruit_magtag29_esp32s2, adafruit_feather_esp32s3, featheresp32s2, adafruit_feather_esp32s2_reversetft, adafruit_metro_esp32s2, adafruit_qtpy_esp32s2, adafruit_feather_esp32s3_reversetft, adafruit_feather_esp32s3_nopsram, adafruit_feather_esp32s2_tft, adafruit_qtpy_esp32, adafruit_qtpy_esp32c3, featheresp32, adafruit_qtpy_esp32s3_nopsram, featheresp32v2
+description = "Adafruit.IO WipperSnapper Firmware"
+default_envs = adafruit_feather_esp32s3_tft, adafruit_magtag29_esp32s2, adafruit_feather_esp32s3, featheresp32s2, adafruit_feather_esp32s2_reversetft, adafruit_metro_esp32s2, adafruit_qtpy_esp32s2, adafruit_feather_esp32s3_reversetft, adafruit_feather_esp32s3_nopsram, adafruit_feather_esp32s2_tft, adafruit_qtpy_esp32, adafruit_qtpy_esp32c3, featheresp32, adafruit_qtpy_esp32s3_nopsram, featheresp32v2, huzzah, adafruit_pyportal_m4, adafruit_pyportal_m4_titano
 
 
 ; Common Build Environment
@@ -18,6 +18,7 @@ lib_compat_mode = strict
 lib_deps =
     adafruit/Adafruit TinyUSB Library
     adafruit/Adafruit NeoPixel
+    adafruit/Adafruit Zero DMA Library
     adafruit/Adafruit SPIFlash
     adafruit/Adafruit DotStar
     adafruit/Adafruit SleepyDog Library
@@ -47,11 +48,17 @@ lib_deps =
     https://github.com/Sensirion/arduino-sht.git
     https://github.com/Sensirion/arduino-i2c-scd4x.git
     https://github.com/Sensirion/arduino-i2c-sen5x.git
+    https://github.com/adafruit/WiFiNINA.git
 
 ; Common build environment for ESP32 platform
 [common:esp32]
 platform = espressif32 @ ^6.3.2
+lib_ignore = WiFiNINA
 monitor_filters = esp32_exception_decoder, time
+
+[common:esp8266]
+platform = espressif8266
+lib_ignore = WiFiNINA, Adafruit TinyUSB Library
 
 ; ESP32-x Boards ;
 
@@ -73,72 +80,63 @@ build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32_V2
 extends = common:esp32
 board = featheresp32-s2
 build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S2
-extra_scripts = 
-    pre:rename_usb_config.py
+extra_scripts = pre:rename_usb_config.py
 
 ; Adafruit Feather ESP32-S2 TFT
 [env:adafruit_feather_esp32s2_tft]
 extends = common:esp32
 board = adafruit_feather_esp32s2_tft
 build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S2_TFT
-extra_scripts = 
-    pre:rename_usb_config.py
+extra_scripts = pre:rename_usb_config.py
 
 ; Adafruit Feather ESP32-S2 Reverse TFT
 [env:adafruit_feather_esp32s2_reversetft]
 extends = common:esp32
 board = adafruit_feather_esp32s2_reversetft
 build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S2_REVTFT
-extra_scripts = 
-    pre:rename_usb_config.py
+extra_scripts = pre:rename_usb_config.py
 
 ; Adafruit Feather ESP32-S3 2MB PSRAM
 [env:adafruit_feather_esp32s3]
 extends = common:esp32
 board = adafruit_feather_esp32s3
 build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S3
-extra_scripts = 
-    pre:rename_usb_config.py
+extra_scripts = pre:rename_usb_config.py
 
 ; Adafruit Feather ESP32-S3 NO PSRAM
 [env:adafruit_feather_esp32s3_nopsram]
 extends = common:esp32
 board = adafruit_feather_esp32s3_nopsram
 build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S3_NOPSRAM
-extra_scripts = 
-    pre:rename_usb_config.py
+extra_scripts = pre:rename_usb_config.py
 
 ; Adafruit Feather ESP32-S3 TFT
 [env:adafruit_feather_esp32s3_tft]
 extends = common:esp32
 board = adafruit_feather_esp32s3_tft
 build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S3_TFT
-extra_scripts = 
-    pre:rename_usb_config.py
+extra_scripts = pre:rename_usb_config.py
 
 ; Adafruit Feather ESP32-S3 Reverse TFT
 [env:adafruit_feather_esp32s3_reversetft]
 extends = common:esp32
 board = adafruit_feather_esp32s3_reversetft
 build_flags = -DARDUINO_ADAFRUIT_FEATHER_ESP32S3_REVTFT
-extra_scripts = 
-    pre:rename_usb_config.py
+extra_scripts = pre:rename_usb_config.py
 
 ; Adafruit Magtag ESP32-S2
 [env:adafruit_magtag29_esp32s2]
 extends = common:esp32
 board = adafruit_magtag29_esp32s2
 build_flags = -DARDUINO_MAGTAG29_ESP32S2
-extra_scripts = 
-    pre:rename_usb_config.py
+extra_scripts = pre:rename_usb_config.py
 
 ; Adafruit Metro ESP32-S2
 [env:adafruit_metro_esp32s2]
 extends = common:esp32
 board = adafruit_metro_esp32s2
 build_flags = -DARDUINO_METRO_ESP32S2
-extra_scripts = 
-    pre:rename_usb_config.py
+extra_scripts =  pre:rename_usb_config.py
 
 ; Adafruit QT Py ESP32 Pico
 [env:adafruit_qtpy_esp32]
@@ -157,13 +155,39 @@ build_flags = -DARDUINO_ADAFRUIT_QTPY_ESP32C3
 extends = common:esp32
 board = adafruit_qtpy_esp32s2
 build_flags = -DARDUINO_ADAFRUIT_QTPY_ESP32S2
-extra_scripts = 
-    pre:rename_usb_config.py
+extra_scripts =  pre:rename_usb_config.py
 
 ; Adafruit QT Py ESP32-S3 NO PSRAM
 [env:adafruit_qtpy_esp32s3_nopsram]
-platform = espressif32
+extends = common:esp32
 board = adafruit_qtpy_esp32s3_nopsram
 build_flags = -DARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM
-extra_scripts = 
-    pre:rename_usb_config.py
+extra_scripts = pre:rename_usb_config.py
+
+; ESP8266 Boards
+
+; Adafruit Feather HUZZAH ESP8266
+[env:huzzah]
+extends=common:esp8266
+board = huzzah
+build_flags = -DARDUINO_ESP8266_ADAFRUIT_HUZZAH
+
+; SAMD51 Boards ;
+
+; Adafruit PyPortal M4
+[env:adafruit_pyportal_m4]
+platform = atmelsam
+board = adafruit_pyportal_m4
+lib_ldf_mode = deep+ ; Required for the inclusion of ZeroDMA for some reason
+build_flags = -DUSE_TINYUSB=1
+              -DADAFRUIT_PYPORTAL
+;upload_port=/dev/cu./dev/cu.usbmodem13301
+
+; Adafruit PyPortal M4 Titano
+[env:adafruit_pyportal_m4_titano]
+platform = atmelsam
+board = adafruit_pyportal_m4_titano
+lib_ldf_mode = deep+ ; Required for the inclusion of ZeroDMA for some reason
+build_flags = -DUSE_TINYUSB=1
+              -DADAFRUIT_PYPORTAL_M4_TITANO
+;upload_port=/dev/cu./dev/cu.usbmodem13301


### PR DESCRIPTION
This pull request:
* Adds a new `platformio.ini` file
  * Adds support for ESP8266 platform
  * Adds support for ATMELSAM platform
  * Adds a user-reproducible build environment with `lib_deps` listed rather than sourced from a user's Arduino library installations
  * Adds common build environment for ESP32-X platform

TODO: 
- [x] Update readme.md documentation to reflect this addition
- [ ] Add build steps to learn guide

Future TODO:
- [ ] Add FunHouse (w/LVGL)

NOTE: Due to a disagreement between Raspberry Pi and PlatformIO, we are unable to support the PicoW platform via PlatformIO at this time. PicoW and RP2040 boards will need to be built using Arduino-CLI and the earlephilhower BSP.

Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/337