### PR TITLE
Bugfix - Added the hp_bh1750 library to the lib_deps list

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -49,6 +49,7 @@ lib_deps =
     https://github.com/Sensirion/arduino-i2c-scd4x.git
     https://github.com/Sensirion/arduino-i2c-sen5x.git
     https://github.com/adafruit/WiFiNINA.git
+    https://github.com/Starmbi/hp_BH1750.git
 
 ; Common build environment for ESP32 platform
 [common:esp32]


### PR DESCRIPTION
This PR Resolves #447.

The dependency for the BH1750 light sensor was missing, causing the builds to fail. It looks like I forgot to add the hp_bh1750 library to the list of lib_deps in the platformio.ini file when I added the BH1750 sensor earlier this week. My apologies. Adding the library to the lib_deps list seems to resolve the issue. 