### PR TITLE
Add-BME688

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -269,7 +269,8 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _bmp3xx->configureDriver(msgDeviceInitReq);
     drivers.push_back(_bmp3xx);
     WS_DEBUG_PRINTLN("BMP388 Initialized Successfully!");
-  } else if (strcmp("bme680", msgDeviceInitReq->i2c_device_name) == 0) {
+  } else if ((strcmp("bme680", msgDeviceInitReq->i2c_device_name) == 0) ||
+             (strcmp("bme688", msgDeviceInitReq->i2c_device_name) == 0)) {
     _bme680 = new WipperSnapper_I2C_Driver_BME680(this->_i2c, i2cAddress);
     if (!_bme680->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize BME680!");


### PR DESCRIPTION
Adds BME688 as an alias of BME680, tested with two on the bus (QTPY-ESP32s2)
![image](https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/assets/6692083/2042ae52-f763-4192-8071-7c09b3240c4f)
