### PR TITLE
Add TC74A0 as alias of PCT2075

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -437,7 +437,8 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _shtc3->configureDriver(msgDeviceInitReq);
     drivers.push_back(_shtc3);
     WS_DEBUG_PRINTLN("SHTC3 Initialized Successfully!");
-  } else if (strcmp("pct2075", msgDeviceInitReq->i2c_device_name) == 0) {
+  } else if ((strcmp("pct2075", msgDeviceInitReq->i2c_device_name) == 0) ||
+             (strcmp("tc74a0", msgDeviceInitReq->i2c_device_name) == 0)) {
     _pct2075 = new WipperSnapper_I2C_Driver_PCT2075(this->_i2c, i2cAddress);
     if (!_pct2075->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize PCT2075 Temp Sensor!");


### PR DESCRIPTION
This adds the TC74A0
https://www.adafruit.com/product/4375

Tested on feather huzzah32 v2
![image](https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/assets/6692083/937ad604-3316-4377-98ee-380d78cb5b4a)
