### PR TITLE
Refactor: Altitude from data[0] to Event.Altitude

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -994,11 +994,11 @@ void WipperSnapper_Component_I2C::update() {
         WS_DEBUG_PRINTHEX((*iter)->getI2CAddress());
         WS_DEBUG_PRINTLN("");
         WS_DEBUG_PRINT("\tAltitude: ");
-        WS_DEBUG_PRINT(event.data[0]);
+        WS_DEBUG_PRINT(event.altitude);
         WS_DEBUG_PRINTLN(" m");
 
         // pack event data into msg
-        fillEventMessage(&msgi2cResponse, event.data[0],
+        fillEventMessage(&msgi2cResponse, event.altitude,
                          wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_ALTITUDE);
 
         (*iter)->setSensorAltitudePeriodPrv(curTime);

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
@@ -129,8 +129,6 @@ public:
   */
   /*******************************************************************************/
   bool getEventAltitude(sensors_event_t *altitudeEvent) {
-    // TODO: Note, this is a hack into Adafruit_Sensor, we should really add an
-    // altitude sensor type
     altitudeEvent->altitude = _bme->readAltitude(SEALEVELPRESSURE_HPA);
     return true;
   }

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME280.h
@@ -131,7 +131,7 @@ public:
   bool getEventAltitude(sensors_event_t *altitudeEvent) {
     // TODO: Note, this is a hack into Adafruit_Sensor, we should really add an
     // altitude sensor type
-    altitudeEvent->data[0] = _bme->readAltitude(SEALEVELPRESSURE_HPA);
+    altitudeEvent->altitude = _bme->readAltitude(SEALEVELPRESSURE_HPA);
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME680.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME680.h
@@ -148,7 +148,7 @@ public:
       return false;
     // NOTE: This is hacked onto Adafruit_Sensor and should eventually be
     // removed
-    altitudeEvent->data[0] = (float)_bme->readAltitude(SEALEVELPRESSURE_HPA);
+    altitudeEvent->altitude = (float)_bme->readAltitude(SEALEVELPRESSURE_HPA);
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME680.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME680.h
@@ -146,8 +146,6 @@ public:
   bool getEventAltitude(sensors_event_t *altitudeEvent) {
     if (!bmePerformReading())
       return false;
-    // NOTE: This is hacked onto Adafruit_Sensor and should eventually be
-    // removed
     altitudeEvent->altitude = (float)_bme->readAltitude(SEALEVELPRESSURE_HPA);
     return true;
   }

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BMP280.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BMP280.h
@@ -120,8 +120,6 @@ public:
   */
   /*******************************************************************************/
   bool getEventAltitude(sensors_event_t *altitudeEvent) {
-    // TODO: Note, this is a hack into Adafruit_Sensor, we should really add an
-    // altitude sensor type
     altitudeEvent->altitude = _bmp->readAltitude(SEALEVELPRESSURE_HPA);
     return true;
   }

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BMP280.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BMP280.h
@@ -122,7 +122,7 @@ public:
   bool getEventAltitude(sensors_event_t *altitudeEvent) {
     // TODO: Note, this is a hack into Adafruit_Sensor, we should really add an
     // altitude sensor type
-    altitudeEvent->data[0] = _bmp->readAltitude(SEALEVELPRESSURE_HPA);
+    altitudeEvent->altitude = _bmp->readAltitude(SEALEVELPRESSURE_HPA);
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BMP3XX.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BMP3XX.h
@@ -120,7 +120,7 @@ public:
       return false;
     // TODO: update once we add an altitude sensor type
     // see https://github.com/adafruit/Adafruit_Sensor/issues/52
-    altitudeEvent->data[0] = _bmp3xx->readAltitude(SEALEVELPRESSURE_HPA);
+    altitudeEvent->altitude = _bmp3xx->readAltitude(SEALEVELPRESSURE_HPA);
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BMP3XX.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BMP3XX.h
@@ -118,8 +118,6 @@ public:
   bool getEventAltitude(sensors_event_t *altitudeEvent) {
     if (!_bmp3xx->performReading())
       return false;
-    // TODO: update once we add an altitude sensor type
-    // see https://github.com/adafruit/Adafruit_Sensor/issues/52
     altitudeEvent->altitude = _bmp3xx->readAltitude(SEALEVELPRESSURE_HPA);
     return true;
   }


### PR DESCRIPTION
Refactor main event for altitude. Updates all mentions of the altitude event. 
Not manually checked each driver but used find on "altitude" and `->/.data[0]`, the only data[0] remaining is for Raw and Proximity (and PM<4.0 used by the sen5x).

Resolves the discussions in https://github.com/adafruit/Wippersnapper_Protobuf/pull/130 and https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/pull/459#discussion_r1280718353

Tested with BMP280, BMP388 on same bus