### PR TITLE
Add DHT20 as alias of AHTx0

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -216,7 +216,8 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
   WS_DEBUG_PRINTLN(msgDeviceInitReq->i2c_device_name);
 
   uint16_t i2cAddress = (uint16_t)msgDeviceInitReq->i2c_device_address;
-  if (strcmp("aht20", msgDeviceInitReq->i2c_device_name) == 0) {
+  if ((strcmp("aht20", msgDeviceInitReq->i2c_device_name) == 0) ||
+      (strcmp("dht20", msgDeviceInitReq->i2c_device_name) == 0)) {
     _ahtx0 = new WipperSnapper_I2C_Driver_AHTX0(this->_i2c, i2cAddress);
     if (!_ahtx0->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize AHTX0 chip!");


### PR DESCRIPTION
Adds the Pin version of the AHT20, aka the DHT20.
https://www.adafruit.com/product/5183

This depends on https://github.com/adafruit/Wippersnapper_Components/pull/145