### PR TITLE
Fix ESP8266 Compiler Warnings

### DIFF
--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -46,7 +46,7 @@ public:
       @brief    Destructor for an I2C sensor.
   */
   /*******************************************************************************/
-  ~WipperSnapper_I2C_Driver() { _sensorAddress = 0; }
+  virtual ~WipperSnapper_I2C_Driver() {}
 
   /*******************************************************************************/
   /*!
@@ -206,7 +206,11 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventCO2(sensors_event_t *co2Event) { return false; }
+  virtual bool getEventCO2(sensors_event_t *co2Event) {
+    (void)
+        co2Event; // Parameter is intentionally unused in this virtual function.
+    return false;
+  }
 
   /****************************** SENSOR_TYPE: ECO2
    * *******************************/
@@ -248,7 +252,11 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventECO2(sensors_event_t *eco2Event) { return false; }
+  virtual bool getEventECO2(sensors_event_t *eco2Event) {
+    (void)eco2Event; // Parameter is intentionally unused in this virtual
+                     // function.
+    return false;
+  }
 
   /****************************** SENSOR_TYPE: TVOC
    * *******************************/
@@ -290,7 +298,11 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventTVOC(sensors_event_t *tvocEvent) { return false; }
+  virtual bool getEventTVOC(sensors_event_t *tvocEvent) {
+    (void)tvocEvent; // Parameter is intentionally unused in this virtual
+                     // function.
+    return false;
+  }
 
   /********************** SENSOR_TYPE: AMBIENT TEMPERATURE (°C)
    * ***********************/
@@ -336,7 +348,11 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventAmbientTemp(sensors_event_t *tempEvent) { return false; }
+  virtual bool getEventAmbientTemp(sensors_event_t *tempEvent) {
+    (void)tempEvent; // Parameter is intentionally unused in this virtual
+                     // function.
+    return false;
+  }
 
   /************************* SENSOR_TYPE: RELATIVE_HUMIDITY
    * ***********************/
@@ -382,6 +398,8 @@ public:
   */
   /*******************************************************************************/
   virtual bool getEventRelativeHumidity(sensors_event_t *humidEvent) {
+    (void)humidEvent; // Parameter is intentionally unused in this virtual
+                      // function.
     return false;
   }
 
@@ -427,6 +445,8 @@ public:
   */
   /*******************************************************************************/
   virtual bool getEventPressure(sensors_event_t *pressureEvent) {
+    (void)pressureEvent; // Parameter is intentionally unused in this virtual
+                         // function.
     return false;
   }
 
@@ -472,6 +492,8 @@ public:
   */
   /*******************************************************************************/
   virtual bool getEventAltitude(sensors_event_t *altitudeEvent) {
+    (void)altitudeEvent; // Parameter is intentionally unused in this virtual
+                         // function.
     return false;
   }
 
@@ -522,6 +544,8 @@ public:
   */
   /*******************************************************************************/
   virtual bool getEventObjectTemp(sensors_event_t *objectTempEvent) {
+    (void)objectTempEvent; // Parameter is intentionally unused in this virtual
+                           // function.
     return false;
   }
 
@@ -569,7 +593,11 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventLight(sensors_event_t *lightEvent) { return false; }
+  virtual bool getEventLight(sensors_event_t *lightEvent) {
+    (void)lightEvent; // Parameter is intentionally unused in this virtual
+                      // function.
+    return false;
+  }
 
   /**************************** SENSOR_TYPE: PM10_STD
    * ****************************/
@@ -615,7 +643,11 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventPM10_STD(sensors_event_t *pm10StdEvent) { return false; }
+  virtual bool getEventPM10_STD(sensors_event_t *pm10StdEvent) {
+    (void)pm10StdEvent; // Parameter is intentionally unused in this virtual
+                        // function.
+    return false;
+  }
 
   /**************************** SENSOR_TYPE: PM25_STD
    * ****************************/
@@ -661,7 +693,11 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventPM25_STD(sensors_event_t *pm25StdEvent) { return false; }
+  virtual bool getEventPM25_STD(sensors_event_t *pm25StdEvent) {
+    (void)pm25StdEvent; // Parameter is intentionally unused in this virtual
+                        // function.
+    return false;
+  }
 
   /**************************** SENSOR_TYPE: PM100_STD
    * ****************************/
@@ -708,6 +744,8 @@ public:
   */
   /*******************************************************************************/
   virtual bool getEventPM100_STD(sensors_event_t *pm100StdEvent) {
+    (void)pm100StdEvent; // Parameter is intentionally unused in this virtual
+                         // function.
     return false;
   }
 
@@ -760,6 +798,8 @@ public:
   */
   /*******************************************************************************/
   virtual bool getEventUnitlessPercent(sensors_event_t *unitlessPercentEvent) {
+    (void)unitlessPercentEvent; // Parameter is intentionally unused in this
+                                // virtual function.
     return false;
   }
 
@@ -804,7 +844,11 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventVoltage(sensors_event_t *voltageEvent) { return false; }
+  virtual bool getEventVoltage(sensors_event_t *voltageEvent) {
+    (void)voltageEvent; // Parameter is intentionally unused in this virtual
+                        // function.
+    return false;
+  }
 
   /****************************** SENSOR_TYPE: Raw
    * *******************************/
@@ -846,7 +890,11 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventRaw(sensors_event_t *rawEvent) { return false; }
+  virtual bool getEventRaw(sensors_event_t *rawEvent) {
+    (void)
+        rawEvent; // Parameter is intentionally unused in this virtual function.
+    return false;
+  }
 
   /****************************** SENSOR_TYPE: Ambient Temp (°F)
    * *******************************/
@@ -1019,6 +1067,8 @@ public:
   */
   /*******************************************************************************/
   virtual bool getEventGasResistance(sensors_event_t *gasEvent) {
+    (void)
+        gasEvent; // Parameter is intentionally unused in this virtual function.
     return false;
   }
 
@@ -1067,7 +1117,11 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventNOxIndex(sensors_event_t *gasEvent) { return false; }
+  virtual bool getEventNOxIndex(sensors_event_t *gasEvent) {
+    (void)
+        gasEvent; // Parameter is intentionally unused in this virtual function.
+    return false;
+  }
 
   /****************************** SENSOR_TYPE: VOC Index (index)
    * *******************************/
@@ -1114,7 +1168,11 @@ public:
                 otherwise.
   */
   /*******************************************************************************/
-  virtual bool getEventVOCIndex(sensors_event_t *gasEvent) { return false; }
+  virtual bool getEventVOCIndex(sensors_event_t *gasEvent) {
+    (void)
+        gasEvent; // Parameter is intentionally unused in this virtual function.
+    return false;
+  }
 
   /**************************** SENSOR_TYPE: PROXIMITY
    * ****************************/
@@ -1189,6 +1247,8 @@ public:
   */
   /*******************************************************************************/
   virtual bool getEventProximity(sensors_event_t *proximityEvent) {
+    (void)proximityEvent; // Parameter is intentionally unused in this virtual
+                          // function.
     return false;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor.h
@@ -49,7 +49,7 @@ public:
       @brief    Destructor for a STEMMA soil sensor.
   */
   /*******************************************************************************/
-  ~WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor() { delete _seesaw; }
+  ~WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor() { _seesaw = nullptr; }
 
   /*******************************************************************************/
   /*!
@@ -99,7 +99,7 @@ public:
   }
 
 protected:
-  Adafruit_seesaw *_seesaw; ///< Seesaw object
+  Adafruit_seesaw *_seesaw = nullptr; ///< Seesaw object
 };
 
 #endif // WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor_H

--- a/src/components/pixels/ws_pixels.cpp
+++ b/src/components/pixels/ws_pixels.cpp
@@ -46,7 +46,7 @@ ws_pixels::~ws_pixels() {
 */
 /******************************************************************************/
 int16_t ws_pixels::allocateStrand() {
-  for (int16_t strandIdx = 0; strandIdx < sizeof(strands) / sizeof(strands[0]);
+  for (size_t strandIdx = 0; strandIdx < sizeof(strands) / sizeof(strands[0]);
        strandIdx++) {
     if (strands[strandIdx].type ==
         wippersnapper_pixels_v1_PixelsType_PIXELS_TYPE_UNSPECIFIED) {

--- a/src/components/servo/ws_servo.cpp
+++ b/src/components/servo/ws_servo.cpp
@@ -36,7 +36,7 @@ ws_servo::~ws_servo() {
 */
 /**************************************************************************/
 servoComponent *ws_servo::getServoComponent(uint8_t pin) {
-  for (int i = 0; i < sizeof(_servos) / sizeof(_servos[0]); i++) {
+  for (size_t i = 0; i < sizeof(_servos) / sizeof(_servos[0]); i++) {
     WS_DEBUG_PRINTLN(_servos[i].pin);
     if (_servos[i].pin == pin)
       return &_servos[i];
@@ -72,6 +72,7 @@ bool ws_servo::servo_attach(int pin, int minPulseWidth, int maxPulseWidth,
 #ifdef ARDUINO_ARCH_ESP32
   rc = servo->attach(pin, minPulseWidth, maxPulseWidth, freq);
 #else
+  (void)freq; // supress warning when we don't use the frequency parameter
   rc = servo->attach(pin, minPulseWidth, maxPulseWidth);
 #endif
   if (rc == ERR_SERVO_ATTACH)


### PR DESCRIPTION
This PR seeks to reduce ESP8266 builds failing by reducing the amount of compiler warnings produced such as:

- Unused parameter
- Virtual destructor
- Comparison of integer expressions of different signedness