### PR TITLE
Add AM2301B and AM2315C as AHT20

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -217,6 +217,8 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
 
   uint16_t i2cAddress = (uint16_t)msgDeviceInitReq->i2c_device_address;
   if ((strcmp("aht20", msgDeviceInitReq->i2c_device_name) == 0) ||
+      (strcmp("am2301b", msgDeviceInitReq->i2c_device_name) == 0) ||
+      (strcmp("am2315c", msgDeviceInitReq->i2c_device_name) == 0) ||
       (strcmp("dht20", msgDeviceInitReq->i2c_device_name) == 0)) {
     _ahtx0 = new WipperSnapper_I2C_Driver_AHTX0(this->_i2c, i2cAddress);
     if (!_ahtx0->begin()) {


### PR DESCRIPTION
Adds both as aliases of AHT20, using the Adafruit AHTx0 driver
https://www.adafruit.com/product/5181
https://www.adafruit.com/product/5182