### PR TITLE
Workflow - Remove Adafruit_MQTT_Library brentru fork, use adafruit upstream instead

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Brent Rubell for Adafruit Industries, 2022
+# SPDX-FileCopyrightText: Brent Rubell for Adafruit Industries, 2023
 #
 # SPDX-License-Identifier: MIT
 name: WipperSnapper Build CI
@@ -42,7 +42,6 @@ jobs:
       run: bash ci/actions_install.sh
     - name: Install extra Arduino libraries
       run: |
-        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
         git clone --quiet https://github.com/adafruit/Adafruit_HX8357_Library.git /home/runner/Arduino/libraries/Adafruit_HX8357_Library
@@ -110,7 +109,6 @@ jobs:
       run: bash ci/actions_install.sh
     - name: Install extra Arduino libraries
       run: |
-        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
     - name: Install Dependencies
@@ -193,7 +191,6 @@ jobs:
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/adafruit/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
-        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
     - name: build platforms
@@ -236,7 +233,6 @@ jobs:
       # manually install OneWireNG/TempControlLib for OneWireNg (RP2040 Supported OneWire w/backwards compat.)
     - name: Install extra Arduino libraries
       run: |
-        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
         git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
         git clone --quiet https://github.com/pstolarz/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
     - name: build platforms
@@ -279,7 +275,6 @@ jobs:
     - name: Install extra Arduino libraries
       run: |
         git clone --quiet https://github.com/arduino-libraries/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
-        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
         git clone --quiet https://github.com/arduino-libraries/Servo.git /home/runner/Arduino/libraries/Servo
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
@@ -311,7 +306,6 @@ jobs:
       run: bash ci/actions_install.sh
     - name: Install extra Arduino library
       run: |
-        git clone --quiet https://github.com/brentru/Adafruit_MQTT_Library.git /home/runner/Arduino/libraries/Adafruit_MQTT_Library
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
     - name: build platforms

--- a/platformio.ini
+++ b/platformio.ini
@@ -50,10 +50,10 @@ lib_deps =
     adafruit/Adafruit GFX Library
     adafruit/Adafruit STMPE610
     adafruit/Adafruit TouchScreen
+    adafruit/Adafruit MQTT Library
     bblanchon/ArduinoJson
     PaulStoffregen/OneWire
     https://github.com/milesburton/Arduino-Temperature-Control-Library.git
-    https://github.com/brentru/Adafruit_MQTT_Library.git
     https://github.com/Sensirion/arduino-sht.git
     https://github.com/Sensirion/arduino-i2c-scd4x.git
     https://github.com/Sensirion/arduino-i2c-sen5x.git


### PR DESCRIPTION
PR https://github.com/adafruit/Adafruit_MQTT_Library/pull/227 brought the changes from the `brentru/` fork of AMQTT upstream to the origin repository. This PR also includes changes for resolving the "I2C Packet Decode Error" persistent in WipperSnapper release builds.

This pull request removes the manual installation of the Adafruit MQTT Library (brentru fork) within the git workflow and instead 