### PR TITLE
Migrate from Arduino ESP32 Core 2.x to 3.x, IDF 5.1

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.73
+version=1.0.0-beta.74
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino client for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -9,7 +9,7 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Copyright (c) Brent Rubell 2020-2022 for Adafruit Industries.
+ * Copyright (c) Brent Rubell 2020-2023 for Adafruit Industries.
  *
  * BSD license, all text here must be included in any redistribution.
  *
@@ -71,7 +71,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.73" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.74" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/ledc/drivers/servo/ws_ledc_servo.cpp
+++ b/src/components/ledc/drivers/servo/ws_ledc_servo.cpp
@@ -62,16 +62,14 @@ void ws_ledc_servo::setLEDCDriver(ws_ledc *ledcManager) {
 uint8_t ws_ledc_servo::attach(int pin, int minPulseWidth, int maxPulseWidth,
                               int servoFreq) {
   // Attempt to attach a pin to ledc channel
-  uint8_t chan =
-      _ledcMgr->attachPin((uint8_t)pin, (double)servoFreq, LEDC_TIMER_WIDTH);
-  if (chan == LEDC_CH_ERR) // error!
-    return chan;
+  if (!_ledcMgr->attachPin((uint8_t)pin, (uint32_t)servoFreq, LEDC_TIMER_WIDTH))
+    return 255;
   // configure the servo object and assign it to a pin
   _servo.Pin.nbr = pin;
   _servo.Pin.isActive = true;
   _minPulseWidth = minPulseWidth;
   _maxPulseWidth = maxPulseWidth;
-  return chan;
+  return 1;
 }
 
 /**************************************************************************/

--- a/src/components/ledc/ws_ledc.cpp
+++ b/src/components/ledc/ws_ledc.cpp
@@ -23,10 +23,7 @@
 */
 /**************************************************************************/
 ws_ledc::ws_ledc() {
-  // reset active pins
-  for (int i = 0; i < MAX_LEDC_PWMS; i++) {
-    _ledcPins[i].isActive = false;
-  }
+  // TODO
 }
 
 /**************************************************************************/
@@ -35,170 +32,62 @@ ws_ledc::ws_ledc() {
 */
 /**************************************************************************/
 ws_ledc::~ws_ledc() {
-  // detach all active pins and de-allocate them
-  for (int i = 0; i < MAX_LEDC_PWMS; i++) {
-    detachPin(_ledcPins[i].pin);
-    _ledcPins[i].isActive = false;
-  }
+  // TODO
 }
 
 /**************************************************************************/
 /*!
-    @brief  Checks if a channel has already been allocated for a pin.
-    @param  pin  Desired GPIO pin number.
-    @return The channel number if the pin was successfully or already
-            attached, otherwise LEDC_CH_ERR.
-*/
-/**************************************************************************/
-uint8_t ws_ledc::_getChannel(uint8_t pin) {
-  // have we already attached this pin?
-  for (int i = 0; i < MAX_LEDC_PWMS; i++) {
-    if (_ledcPins[i].pin == pin)
-      return _ledcPins[i].chan;
-  }
-  return LEDC_CH_ERR;
-}
-
-/**************************************************************************/
-/*!
-    @brief  Allocates a timer + channel for a pin and attaches it.
+    @brief  Sets up a LEDC pin with given frequency and resolution.
     @param  pin  Desired GPIO pin number.
     @param  freq Desired timer frequency, in Hz.
     @param  resolution Desired timer resolution, in bits.
-    @return The channel number if the pin was successfully or already
-            attached, otherwise 255.
+    @return True if configuration is successful. False is returned if error
+   occurs and LEDC channel was not configured.
 */
 /**************************************************************************/
-uint8_t ws_ledc::attachPin(uint8_t pin, double freq, uint8_t resolution) {
-  // have we already attached this pin?
-  for (int i = 0; i < MAX_LEDC_PWMS; i++) {
-    if (_ledcPins[i].pin == pin)
-      return _ledcPins[i].chan;
-  }
-
-  // allocate chanel
-  uint8_t chanNum = _allocateChannel(freq, resolution);
-  if (chanNum == LEDC_CH_ERR)
-    return chanNum;
-
-  // attach pin to channel
-  ledcAttachPin(pin, chanNum);
-
-  // allocate pin in pool
-  _ledcPins[chanNum].pin = pin;
-  _ledcPins[chanNum].chan = chanNum;
-
-  return chanNum;
+bool ws_ledc::attachPin(uint8_t pin, uint32_t freq, uint8_t resolution) {
+  return ledcAttach(pin, freq, resolution);
 }
 
 /**************************************************************************/
 /*!
-    @brief  Detaches a pin and de-allocates it from the manager.
+    @brief  Detaches a pin from LEDC.
     @param  pin  Desired GPIO pin number.
+    @return True if successfully detached, False otherwise.
 */
 /**************************************************************************/
-void ws_ledc::detachPin(uint8_t pin) {
-  // de-allocate the pin and the channel
-  for (int i = 0; i < sizeof(_ledcPins); i++) {
-    if (_ledcPins[i].pin == pin) {
-      _ledcPins[i].pin = 0;
-      _ledcPins[i].chan = 255;
-      _ledcPins[i].isActive = false;
-      break;
-    }
-  }
-
-  // detach the pin
-  ledcDetachPin(pin);
-}
-
-/**************************************************************************/
-/*!
-    @brief  Allocates a channel and timer.
-    @param  freq       Timer frequency, in Hz.
-    @param  resolution Timer resolution, in bits.
-    @return The channel number if the timer was successfully initialized,
-            otherwise 255.
-*/
-/**************************************************************************/
-uint8_t ws_ledc::_allocateChannel(double freq, uint8_t resolution = 16) {
-  // obtain an inactive channel number
-  uint8_t chanNum = _getInactiveChannel();
-  if (chanNum == LEDC_CH_ERR)
-    return LEDC_CH_ERR; // failed to obtain inactive channel #
-
-  // attempt to set up a ledc_timer on the free channel
-  double rc = ledcSetup(uint8_t(chanNum), freq, resolution);
-  if (rc == 0)
-    return 255;
-
-  // Assign
-  _ledcPins[chanNum].chan = chanNum;
-  _ledcPins[chanNum].isActive = true;
-
-  return chanNum;
-}
-
-/**************************************************************************/
-/*!
-    @brief    Returns an inactive LEDC channel number.
-    @returns  Inactive channel number if free, otherwise LEDC_CH_ERR.
-*/
-/**************************************************************************/
-uint8_t ws_ledc::_getInactiveChannel() {
-  for (int ch = 0; ch < sizeof(_ledcPins); ch++) {
-    if (_ledcPins[ch].isActive == false) {
-      return ch;
-    }
-  }
-  return LEDC_CH_ERR;
-}
+bool ws_ledc::detachPin(uint8_t pin) { return ledcDetach(pin); }
 
 /**************************************************************************/
 /*!
     @brief  Arduino AnalogWrite function, but for ESP32's LEDC.
     @param  pin  The desired pin to write to.
     @param  value The duty cycle.
+    @return True if PWM value written to LEDC pin, False otherwise.
 */
 /**************************************************************************/
-void ws_ledc::analogWrite(uint8_t pin, int value) {
+bool ws_ledc::analogWrite(uint8_t pin, int value) {
   if (value > 255 || value < 0)
-    return;
+    return false;
 
-  uint8_t ch;
-  ch = _getChannel(pin);
-  if (ch == LEDC_CH_ERR) {
-    Serial.println("ERROR: Pin not attached to channel");
-    return;
-  }
-
-  // perform duty cycle calculation provided value
+  // Calculate duty cycle for the `value` passed in
   // (assumes 12-bit resolution, 2^12)
   uint32_t dutyCycle = (4095 / 255) * min(value, 255);
 
-  // set the duty cycle of the pin
-  setDuty(pin, dutyCycle);
+  // Call duty cycle write
+  return setDuty(pin, dutyCycle);
 }
 
 /**************************************************************************/
 /*!
-    @brief  Sets the duty cycle of a pin
+    @brief  Sets the duty cycle of a LEDC pin.
     @param  pin  Desired GPIO pin to write to.
     @param  duty  Desired duty cycle.
+    @return True if duty cycle was set, False otherwise.
 */
 /**************************************************************************/
-void ws_ledc::setDuty(uint8_t pin, uint32_t duty) {
-  // find the channel corresponding to the pin
-  uint8_t chan = 0;
-  for (int i = 0; i < sizeof(_ledcPins); i++) {
-    if (_ledcPins[i].pin == pin) {
-      chan = _ledcPins[i].chan;
-      break;
-    }
-  }
-
-  // set the channel's duty cycle
-  ledcWrite(chan, duty);
+bool ws_ledc::setDuty(uint8_t pin, uint32_t duty) {
+  return ledcWrite(pin, duty);
 }
 
 /**************************************************************************/
@@ -207,15 +96,12 @@ void ws_ledc::setDuty(uint8_t pin, uint32_t duty) {
             frequency to a pin. Used by piezo buzzers and speakers.
     @param  pin  The desired pin to write to.
     @param  freq The frequency of the tone, in Hz.
+    @return The frequency of the LEDC pin. 0 if error occurs and LEDC pin was
+   not configured.
 */
 /**************************************************************************/
-void ws_ledc::tone(uint8_t pin, uint32_t freq) {
-  uint8_t ch;
-  ch = _getChannel(pin);
-  if (ch == LEDC_CH_ERR) {
-    // Serial.println("ERROR: Pin not previously attached!");
-  }
-  ledcWriteTone(ch, freq);
+uint32_t ws_ledc::tone(uint8_t pin, uint32_t freq) {
+  return ledcWriteTone(pin, freq);
 }
 
 #endif // ARDUINO_ARCH_ESP32

--- a/src/components/ledc/ws_ledc.cpp
+++ b/src/components/ledc/ws_ledc.cpp
@@ -8,7 +8,7 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Written by Brent Rubell for Adafruit Industries, 2022.
+ * Written by Brent Rubell for Adafruit Industries, 2022-2023
  *
  * MIT license, all text here must be included in any redistribution.
  *
@@ -22,18 +22,14 @@
     @brief  Constructor
 */
 /**************************************************************************/
-ws_ledc::ws_ledc() {
-  // TODO
-}
+ws_ledc::ws_ledc() {}
 
 /**************************************************************************/
 /*!
     @brief  Destructor
 */
 /**************************************************************************/
-ws_ledc::~ws_ledc() {
-  // TODO
-}
+ws_ledc::~ws_ledc() {}
 
 /**************************************************************************/
 /*!

--- a/src/components/ledc/ws_ledc.h
+++ b/src/components/ledc/ws_ledc.h
@@ -8,7 +8,7 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Copyright (c) Brent Rubell 2022 for Adafruit Industries.
+ * Copyright (c) Brent Rubell 2022-2023 for Adafruit Industries.
  *
  * BSD license, all text here must be included in any redistribution.
  *
@@ -20,18 +20,6 @@
 
 #include "esp32-hal-ledc.h"
 #include "esp_err.h"
-
-#define LEDC_CH_ERR 255 ///< LEDC channel error
-#define MAX_LEDC_PWMS                                                          \
-  16 ///< maximum # of LEDC channels (see: LEDC Chan to Group/Channel/Timer
-     ///< Mapping)
-
-/** Defines a pin attached to an active LEDC timer group */
-typedef struct {
-  uint8_t pin;   ///< GPIO pin number
-  uint8_t chan;  ///< Channel allocated to the pin
-  bool isActive; ///< True if the ledcPin's timer has been initialized
-} ledcPin_t;
 
 // forward decl.
 class Wippersnapper;
@@ -50,18 +38,12 @@ class ws_ledc {
 public:
   ws_ledc();
   ~ws_ledc();
-  uint8_t attachPin(uint8_t pin, double freq, uint8_t resolution);
-  void detachPin(uint8_t pin);
-
-  void setDuty(uint8_t pin, uint32_t duty);
-  void analogWrite(uint8_t pin, int value);
-  void tone(uint8_t pin, uint32_t freq);
-
-private:
-  uint8_t _allocateChannel(double freq, uint8_t resolution);
-  uint8_t _getChannel(uint8_t pin);
-  uint8_t _getInactiveChannel();
-  ledcPin_t _ledcPins[MAX_LEDC_PWMS]; ///< Pool of usable LEDC pins
+  bool attachPin(uint8_t pin, uint32_t freq, uint8_t resolution);
+  bool detachPin(uint8_t pin);
+  // LEDC-API
+  bool setDuty(uint8_t pin, uint32_t duty);
+  bool analogWrite(uint8_t pin, int value);
+  uint32_t tone(uint8_t pin, uint32_t freq);
 };
 extern Wippersnapper WS;
 

--- a/src/components/ledc/ws_ledc.h
+++ b/src/components/ledc/ws_ledc.h
@@ -36,8 +36,8 @@ class Wippersnapper;
 /**************************************************************************/
 class ws_ledc {
 public:
-  ws_ledc();
-  ~ws_ledc();
+  ws_ledc(){};
+  ~ws_ledc(){};
   bool attachPin(uint8_t pin, uint32_t freq, uint8_t resolution);
   bool detachPin(uint8_t pin);
   // LEDC-API

--- a/src/components/pwm/ws_pwm.cpp
+++ b/src/components/pwm/ws_pwm.cpp
@@ -51,9 +51,9 @@ bool ws_pwm::attach(uint8_t pin, double freq, uint8_t resolution) {
   // Future TODO: Maybe this function should be within #ifdef for ARCH_ESP32
   bool is_attached = true;
 #if defined(ARDUINO_ARCH_ESP32)
-  uint8_t rc = _ledcMgr->attachPin(pin, freq, resolution);
-  if (rc == LEDC_CH_ERR)
-    is_attached = false;
+  bool rc = _ledcMgr->attachPin(pin, (uint32_t)freq, resolution);
+  if (!rc)
+    return false;
 #else
   (void)pin;        // marking as unused parameter to avoid compiler warning
   (void)freq;       // marking as unused parameter to avoid compiler warning

--- a/src/components/uart/ws_uart.cpp
+++ b/src/components/uart/ws_uart.cpp
@@ -43,13 +43,6 @@ void ws_uart::initUARTBus(
   int32_t tx = atoi(msgUARTRequest->bus_info.pin_tx + 1);
   bool invert = msgUARTRequest->bus_info.is_invert;
 
-  // Print bus_info
-  WS_DEBUG_PRINTLN("[INFO, UART]: Initializing SW UART bus...");
-  WS_DEBUG_PRINTLN("[INFO, UART]: Baud Rate: " + String(baud));
-  WS_DEBUG_PRINTLN("[INFO, UART]: RX Pin: " + String(rx));
-  WS_DEBUG_PRINTLN("[INFO, UART]: TX Pin: " + String(tx));
-  WS_DEBUG_PRINTLN("[INFO, UART]: Invert? " + String(invert));
-
 // Initialize and begin UART bus depending if the platform supports either HW
 // UART or SW UART
 #ifdef USE_SW_UART
@@ -150,18 +143,14 @@ bool ws_uart::initUARTDevice(
     wippersnapper_uart_v1_UARTDeviceAttachRequest *msgUARTRequest) {
   // Ensure the protobuf contains a device identifier
   if (strlen(msgUARTRequest->device_id) == 0) {
-    WS_DEBUG_PRINTLN("[ERROR, UART]: Device ID is empty!");
     return false;
   }
 
   // Do we already have a device with this ID?
   for (ws_uart_drv *ptrUARTDriver : uartDrivers) {
     if (strcmp(ptrUARTDriver->getDeviceID(), msgUARTRequest->device_id) == 0) {
-      WS_DEBUG_PRINTLN("[INFO, UART]: Device ID already exists on the bus, "
-                       "disconnecting...");
       deinitUARTDevice(
           msgUARTRequest->device_id); // Deinit the device and free resources
-      WS_DEBUG_PRINT("Disconnected!");
     }
   }
 
@@ -229,11 +218,9 @@ void ws_uart::detachUARTDevice(
 void ws_uart::update() {
   for (ws_uart_drv *ptrUARTDriver : uartDrivers) {
     if (ptrUARTDriver->isReady()) {
-      WS_DEBUG_PRINTLN("[INFO, UART]: UART driver is ready.");
       // Attempt to poll the UART driver for new data
       if (ptrUARTDriver->read_data()) {
         // Send UART driver's data to IO
-        WS_DEBUG_PRINTLN("[INFO, UART]: UART driver has new data.");
         ptrUARTDriver->send_data();
       }
     }


### PR DESCRIPTION
Migration of WipperSnapper's ESP32 builds from 2.X (based on ESP-IDF 4.4) to version 3.0 (based on ESP-IDF 5.1) of the Arduino ESP32 core.

Changes:
* Migrated to new LEDC API
* Updated dependencies 
  * SleepyDog
  * OneWireNG

Needs physical testing before release:
- [ ] PWM Component on any ESP32 board
- [ ] Servo Component on any ESP32 board