### PR TITLE
Add IKEA VINDRIKTNING AQI Sensor

### DIFF
--- a/src/components/uart/drivers/ws_uart_drv.h
+++ b/src/components/uart/drivers/ws_uart_drv.h
@@ -89,16 +89,16 @@ public:
       @returns The UART device's unique identifier.
   */
   /*******************************************************************************/
-  const char *getDeviceID() { return _deviceID; }
+  const char *getDriverID() { return _driverID; }
 
   /*******************************************************************************/
   /*!
-      @brief   Sets the UART device's unique identifier.
+      @brief   Sets the UART driver's identifer.
       @param   id
                The UART device's unique identifier.
   */
   /*******************************************************************************/
-  void setDriverID(const char *id) { _deviceID = id; }
+  void setDriverID(const char *id) { _driverID = strdup(id); }
 
   /*******************************************************************************/
   /*!
@@ -169,7 +169,7 @@ public:
 private:
   unsigned long
       _prvPoll; ///< Last time the UART device was polled, in milliseconds
-  const char *_deviceID = nullptr; ///< UART device's ID
+  const char *_driverID = nullptr; ///< UART device's ID
 };
 
 #endif // WS_UART_DRV_H

--- a/src/components/uart/drivers/ws_uart_drv_pm25aqi.h
+++ b/src/components/uart/drivers/ws_uart_drv_pm25aqi.h
@@ -144,21 +144,18 @@ public:
         wippersnapper_signal_v1_UARTResponse_init_zero;
     msgUARTResponse.which_payload =
         wippersnapper_signal_v1_UARTResponse_resp_uart_device_event_tag;
-    // We'll be sending back six sensor_events: pm10_standard, pm25_standard,
-    // pm100_standard, pm10_env, pm25_env, and pm100_env
-    msgUARTResponse.payload.resp_uart_device_event.sensor_event_count = 6;
-    Serial.print("Device ID: ");
-    Serial.println(getDriverID());
     strcpy(msgUARTResponse.payload.resp_uart_device_event.device_id,
-           "pm1006"); // TODO: Change to non-fixed value
+           getDriverID());
 
     // check if driverID is pm1006
     if (strcmp(getDriverID(), "pm1006") == 0) {
       // PM1006 returns only PM2.5_ENV readings
-      packUARTResponse(&msgUARTResponse, 4,
+      msgUARTResponse.payload.resp_uart_device_event.sensor_event_count = 1;
+      packUARTResponse(&msgUARTResponse, 0,
                        wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM25_ENV,
                        (float)_data.pm25_env);
     } else {
+      msgUARTResponse.payload.resp_uart_device_event.sensor_event_count = 6;
       packUARTResponse(&msgUARTResponse, 0,
                        wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM10_STD,
                        (float)_data.pm10_standard);

--- a/src/components/uart/ws_uart.cpp
+++ b/src/components/uart/ws_uart.cpp
@@ -67,11 +67,13 @@ void ws_uart::initUARTBus(
 #ifdef USE_SW_UART
 /*******************************************************************************/
 /*!
-    @brief    Initializes the pms5003 device driver using SoftwareSerial.
+    @brief    Initializes the PM25AQI device driver using SoftwareSerial.
     @param    swSerial
               Pointer to a SoftwareSerial instance.
     @param    pollingInterval
               Polling interval for the pms5003 device.
+    @param    device_id
+              Which PM25 device are we communicating with?
     @returns  True if pms5003 driver was successfully initialized, False
    otherwise.
 */
@@ -105,6 +107,8 @@ bool ws_uart::initUARTDevicePM25AQI(SoftwareSerial *swSerial,
               Pointer to a HardwareSerial instance.
     @param    pollingInterval
               Polling interval for the pms5003 device.
+    @param    device_id
+              Which PM25 device are we communicating with?
     @returns  True if pms5003 driver was successfully initialized, False
    otherwise.
 */

--- a/src/components/uart/ws_uart.h
+++ b/src/components/uart/ws_uart.h
@@ -44,9 +44,11 @@ public:
   void update(); ///< Updates the UART device at every polling interval, must be
                  ///< called by main app.
 #ifdef USE_SW_UART
-  bool initUARTDevicePM25AQI(SoftwareSerial *swSerial, int32_t pollingInterval);
+  bool initUARTDevicePM25AQI(SoftwareSerial *swSerial, int32_t pollingInterval,
+                             const char *device_id);
 #else
-  bool initUARTDevicePM25AQI(HardwareSerial *hwSerial, int32_t pollingInterval);
+  bool initUARTDevicePM25AQI(HardwareSerial *hwSerial, int32_t pollingInterval,
+                             const char *device_id);
 #endif
 private:
 #ifdef USE_SW_UART


### PR DESCRIPTION
This pull request adds the [Ikea Vindriktning Air Quality Sensor](https://www.ikea.com/us/en/p/vindriktning-air-quality-sensor-60515911/) to WipperSnapper.

* Since the Adafruit_PM25 AQ library is now shared between adafruit AQ sensors and the Cubic PM1006 (present in the ikea vindriktning), `ws_uart_drv_pm25` has been modified to support sending data from either the PM1006 or PMS5003 AQ sensors