### PR TITLE
Upgrade ArduinoJSON v6 to v7

### DIFF
--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -64,6 +64,8 @@ void WipperSnapper_LittleFS::parseSecrets() {
     fsHalt();
   }
 
+  //JsonDocument doc;
+
   // check if we can deserialize the secrets.json file
   DeserializationError err = deserializeJson(_doc, secretsFile);
   if (err) {

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -64,18 +64,19 @@ void WipperSnapper_LittleFS::parseSecrets() {
     fsHalt();
   }
 
-  //JsonDocument doc;
-
+  JsonDocument doc;
   // check if we can deserialize the secrets.json file
-  DeserializationError err = deserializeJson(_doc, secretsFile);
-  if (err) {
+  DeserializationError error = deserializeJson(doc, secretsFile);
+  if (error) {
     WS_DEBUG_PRINT("ERROR: deserializeJson() failed with code ");
-    WS_DEBUG_PRINTLN(err.c_str());
+    WS_DEBUG_PRINTLN(error.c_str());
     fsHalt();
   }
+  // close the file
+  secretsFile.close();
 
   // Get IO username from JSON
-  const char *io_username = _doc["io_username"];
+  const char *io_username = doc["io_username"]; // "YOUR_IO_USERNAME_HERE"
   // error check against default values [ArduinoJSON, 3.3.3]
   if (io_username == nullptr) {
     WS_DEBUG_PRINTLN("ERROR: io_username not set!");
@@ -85,7 +86,7 @@ void WipperSnapper_LittleFS::parseSecrets() {
   WS._username = io_username;
 
   // Get IO key from JSON
-  const char *io_key = _doc["io_key"];
+  const char *io_key = doc["io_key"]; // "YOUR_IO_KEY_HERE"
   // error check against default values [ArduinoJSON, 3.3.3]
   if (io_key == nullptr) {
     WS_DEBUG_PRINTLN("ERROR: io_key not set!");
@@ -96,10 +97,10 @@ void WipperSnapper_LittleFS::parseSecrets() {
 
   // Parse SSID
   // Check if network type is WiFi
-  const char *network_type_wifi_ssid =
-      _doc["network_type_wifi"]["network_ssid"];
-  if (network_type_wifi_ssid != nullptr) {
-    WS._network_ssid = network_type_wifi_ssid;
+  const char *network_type_wifi_network_ssid =
+      doc["network_type_wifi"]["network_ssid"];
+  if (network_type_wifi_network_ssid != nullptr) {
+    WS._network_ssid = network_type_wifi_network_ssid;
   }
 
   if (WS._network_ssid == nullptr) {
@@ -108,10 +109,10 @@ void WipperSnapper_LittleFS::parseSecrets() {
   }
 
   // Parse WiFi network password
-  const char *network_type_wifi_password =
-      _doc["network_type_wifi"]["network_password"];
-  if (network_type_wifi_password != nullptr) {
-    WS._network_pass = network_type_wifi_password;
+  const char *network_type_wifi_network_password =
+      doc["network_type_wifi"]["network_password"];
+  if (network_type_wifi_network_password != nullptr) {
+    WS._network_pass = network_type_wifi_network_password;
   }
 
   // error check WiFi network password
@@ -121,18 +122,12 @@ void WipperSnapper_LittleFS::parseSecrets() {
   }
 
   // Optionally set the Adafruit.io URL
-  WS._mqttBrokerURL = _doc["io_url"];
+  WS._mqttBrokerURL = doc["io_url"];
 
   // Get (optional) setting for the status pixel brightness
-  float status_pixel_brightness = _doc["status_pixel_brightness"];
+  float status_pixel_brightness = doc["status_pixel_brightness"];
   // Note: ArduinoJSON's default value on failure to find is 0.0
   setStatusLEDBrightness(status_pixel_brightness);
-
-  // close the file
-  secretsFile.close();
-
-  // clear the document and release all memory from the memory pool
-  _doc.clear();
 
   // stop LittleFS, we no longer need it
   LittleFS.end();

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.h
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.h
@@ -16,6 +16,8 @@
 #define WIPPERSNAPPER_LITTLEFS_H
 
 #include "Wippersnapper.h"
+#define ARDUINOJSON_USE_DOUBLE 0
+#define ARDUINOJSON_USE_LONG_LONG 1
 #include <ArduinoJson.h>
 #include <FS.h>
 #include <LittleFS.h>
@@ -32,15 +34,8 @@ class WipperSnapper_LittleFS {
 public:
   WipperSnapper_LittleFS();
   ~WipperSnapper_LittleFS();
-
   void parseSecrets();
   void fsHalt();
-
-private:
-  // NOTE: calculated capacity with maximum
-  // length of usernames/passwords/tokens
-  // is 382 bytes, rounded to nearest power of 2.
-  StaticJsonDocument<512> _doc; /*!< Json configuration file */
 };
 
 extern Wippersnapper WS;

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -529,7 +529,7 @@ void Wippersnapper_FS::parseDisplayConfig(displayConfig &displayFile) {
   JsonObject spi = doc["spi"];
   if (spi != nullptr) {
     displayFile.isSPI = true;             // indicate that we're using SPI bus
-    int spi_spiMode = spi["spiMode"];     // 1
+    displayFile.spiMode= spi["spiMode"];  // 1
     displayFile.pinCS = spi["pinCs"];     // 40
     displayFile.pinDC = spi["pinDc"];     // 39
     displayFile.pinMOSI = spi["pinMosi"]; // 0

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -345,7 +345,7 @@ void Wippersnapper_FS::parseSecrets() {
   DeserializationError error = deserializeJson(doc, secretsFile);
   if (error) {
     WS_DEBUG_PRINT("ERROR: deserializeJson() failed with code ");
-    WS_DEBUG_PRINTLN(err.c_str());
+    WS_DEBUG_PRINTLN(error.c_str());
     fsHalt();
   }
 
@@ -384,8 +384,8 @@ void Wippersnapper_FS::parseSecrets() {
   // Parse WiFi SSID
   const char *network_type_wifi_network_ssid =
       doc["network_type_wifi"]["network_ssid"];
-  if (network_type_wifi_ssid == nullptr ||
-      strcmp(network_type_wifi_ssid, "YOUR_WIFI_SSID_HERE") == 0) {
+  if (network_type_wifi_network_ssid == nullptr ||
+      strcmp(network_type_wifi_network_ssid, "YOUR_WIFI_SSID_HERE") == 0) {
     WS_DEBUG_PRINTLN("ERROR: invalid network_ssid value in secrets.json!");
     writeToBootOut("ERROR: invalid network_ssid value in secrets.json!\n");
 #ifdef USE_DISPLAY
@@ -397,13 +397,13 @@ void Wippersnapper_FS::parseSecrets() {
     fsHalt();
   }
   // Set network SSID
-  WS._network_ssid = network_type_wifi_ssid;
+  WS._network_ssid = network_type_wifi_network_ssid;
 
   // Parse WiFi Network Password
   const char *network_type_wifi_network_password =
       doc["network_type_wifi"]["network_password"];
-  if (network_type_wifi_password == nullptr ||
-      strcmp(network_type_wifi_password, "YOUR_WIFI_PASS_HERE") == 0) {
+  if (network_type_wifi_network_password == nullptr ||
+      strcmp(network_type_wifi_network_password, "YOUR_WIFI_PASS_HERE") == 0) {
     WS_DEBUG_PRINTLN("ERROR: invalid network_type_wifi_password value in "
                      "secrets.json!");
     writeToBootOut("ERROR: invalid network_type_wifi_password value in "
@@ -416,15 +416,14 @@ void Wippersnapper_FS::parseSecrets() {
 #endif
     fsHalt();
   }
-  WS._network_pass = network_type_wifi_password;
+  WS._network_pass = network_type_wifi_network_password;
 
   // Optionally set the MQTT broker url (used to switch btween prod. and
   // staging)
   WS._mqttBrokerURL = doc["io_url"];
 
   // Get (optional) setting for the status pixel brightness
-  const char *status_pixel_brightness =
-      doc["status_pixel_brightness"]; // default is "0.2"
+  float status_pixel_brightness = doc["status_pixel_brightness"]; // default is "0.2"
   // Note: ArduinoJSON's default value on failure to find is 0.0
   setStatusLEDBrightness(status_pixel_brightness);
 

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -480,7 +480,6 @@ void Wippersnapper_FS::createDisplayConfig() {
   doc["height"] = 240;
   doc["rotation"] = 0;
   JsonObject spi = doc["spi"].to<JsonObject>();
-  spi["spiMode"] = 1;
   spi["pinCs"] = 40;
   spi["pinDc"] = 39;
   spi["pinMosi"] = 0;
@@ -529,7 +528,6 @@ void Wippersnapper_FS::parseDisplayConfig(displayConfig &displayFile) {
   JsonObject spi = doc["spi"];
   if (spi != nullptr) {
     displayFile.isSPI = true;             // indicate that we're using SPI bus
-    displayFile.spiMode= spi["spiMode"];  // 1
     displayFile.pinCS = spi["pinCs"];     // 40
     displayFile.pinDC = spi["pinDc"];     // 39
     displayFile.pinMOSI = spi["pinMosi"]; // 0

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -400,8 +400,7 @@ void Wippersnapper_FS::parseSecrets() {
   WS._network_ssid = network_type_wifi_network_ssid;
 
   // Parse WiFi Network Password
-  const char *network_type_wifi_network_password =
-      doc["network_type_wifi"]["network_password"];
+  const char *network_type_wifi_network_password = doc["network_type_wifi"]["network_password"];
   if (network_type_wifi_network_password == nullptr ||
       strcmp(network_type_wifi_network_password, "YOUR_WIFI_PASS_HERE") == 0) {
     WS_DEBUG_PRINTLN("ERROR: invalid network_type_wifi_password value in "
@@ -426,9 +425,6 @@ void Wippersnapper_FS::parseSecrets() {
   float status_pixel_brightness = doc["status_pixel_brightness"]; // default is "0.2"
   // Note: ArduinoJSON's default value on failure to find is 0.0
   setStatusLEDBrightness(status_pixel_brightness);
-
-  // clear the document and release all memory from the memory pool
-  doc.clear();
 
   // Write configuration out to boot_out file
   writeToBootOut("Adafruit.io Username: ");

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -17,13 +17,13 @@
 
 #include "Adafruit_SPIFlash.h"
 #include "Adafruit_TinyUSB.h"
+#include "SdFat.h"
 #define ARDUINOJSON_USE_DOUBLE 0
 #define ARDUINOJSON_USE_LONG_LONG 1
 #include "ArduinoJson.h"
-#include "SdFat.h"
 // using f_mkfs() for formatting
-#include "fatfs/diskio.h"
 #include "fatfs/ff.h" // NOTE: This should be #included before fatfs/diskio.h!!!
+#include "fatfs/diskio.h"
 
 #include "Wippersnapper.h"
 

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -17,11 +17,13 @@
 
 #include "Adafruit_SPIFlash.h"
 #include "Adafruit_TinyUSB.h"
+#define ARDUINOJSON_USE_DOUBLE 0
+#define ARDUINOJSON_USE_LONG_LONG 1
 #include "ArduinoJson.h"
 #include "SdFat.h"
 // using f_mkfs() for formatting
-#include "fatfs/ff.h" // NOTE: This should be #included before fatfs/diskio.h!!!
 #include "fatfs/diskio.h"
+#include "fatfs/ff.h" // NOTE: This should be #included before fatfs/diskio.h!!!
 
 #include "Wippersnapper.h"
 
@@ -59,15 +61,10 @@ public:
 
   void parseSecrets();
 
-  #ifdef ARDUINO_FUNHOUSE_ESP32S2
-  void parseDisplayConfig(displayConfig& displayFile);
+#ifdef ARDUINO_FUNHOUSE_ESP32S2
+  void parseDisplayConfig(displayConfig &displayFile);
   void createDisplayConfig();
-  #endif
-
-  // NOTE: calculated capacity with maximum
-  // length of usernames/passwords/tokens
-  // is 382 bytes, rounded to nearest power of 2.
-  StaticJsonDocument<512> doc; /*!< Json configuration file */
+#endif
 private:
   bool _freshFS = false; /*!< True if filesystem was initialized by
                             WipperSnapper, False otherwise. */


### PR DESCRIPTION
Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/533 by updating existing API calls [using the migration guide](https://arduinojson.org/v7/how-to/upgrade-from-v6/).