### PR TITLE
Upgrade ArduinoJSON to V7 and refactored JSON handling

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -390,8 +390,7 @@ jobs:
       fail-fast: false
       matrix:
         arduino-platform: ["feather_esp32s2_debug", "feather_esp32s2_tft_debug",
-                           "feather_esp32s3_debug", "feather_esp32s3_4mbflash_2mbpsram_debug", "feather_esp32s3_tft_debug",
-                           "feather_esp32s3_tft_debug"]
+                           "feather_esp32s3_debug", "feather_esp32s3_4mbflash_2mbpsram_debug", "feather_esp32s3_tft_debug"]
     steps:
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -49,7 +49,6 @@ jobs:
         git clone --quiet https://github.com/adafruit/Adafruit_STMPE610.git /home/runner/Arduino/libraries/Adafruit_STMPE610
         git clone --quiet https://github.com/adafruit/Adafruit-ST7735-Library.git /home/runner/Arduino/libraries/Adafruit-ST7735-Library
         git clone --quiet https://github.com/adafruit/Adafruit_TouchScreen.git /home/runner/Arduino/libraries/Adafruit_TouchScreen
-        git clone --depth 1 --branch 6.x https://github.com/bblanchon/ArduinoJson.git /home/runner/Arduino/libraries/ArduinoJson
         git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
         git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
     - name: Download and install stable Nanopb
@@ -118,7 +117,6 @@ jobs:
       run: bash ci/actions_install.sh
     - name: Install extra Arduino libraries
       run: |
-        git clone --depth 1 --branch 6.x https://github.com/bblanchon/ArduinoJson.git /home/runner/Arduino/libraries/ArduinoJson
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
     - name: Download and install stable Nanopb
@@ -214,7 +212,6 @@ jobs:
       # manually install Adafruit WiFiNINA library fork
     - name: Install extra Arduino libraries
       run: |
-        git clone --depth 1 --branch 6.x https://github.com/bblanchon/ArduinoJson.git /home/runner/Arduino/libraries/ArduinoJson
         git clone --quiet https://github.com/adafruit/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
@@ -266,7 +263,6 @@ jobs:
       # manually install OneWireNG/TempControlLib for OneWireNg (RP2040 Supported OneWire w/backwards compat.)
     - name: Install extra Arduino libraries
       run: |
-        git clone --depth 1 --branch 6.x https://github.com/bblanchon/ArduinoJson.git /home/runner/Arduino/libraries/ArduinoJson
         git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
         git clone --quiet https://github.com/pstolarz/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
     - name: Download and install stable Nanopb
@@ -316,7 +312,6 @@ jobs:
       run: bash ci/actions_install.sh
     - name: Install extra Arduino libraries
       run: |
-        git clone --depth 1 --branch 6.x https://github.com/bblanchon/ArduinoJson.git /home/runner/Arduino/libraries/ArduinoJson
         git clone --quiet https://github.com/arduino-libraries/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
         git clone --quiet https://github.com/arduino-libraries/Servo.git /home/runner/Arduino/libraries/Servo
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
@@ -357,7 +352,6 @@ jobs:
       run: bash ci/actions_install.sh
     - name: Install extra Arduino library
       run: |
-        git clone --depth 1 --branch 6.x https://github.com/bblanchon/ArduinoJson.git /home/runner/Arduino/libraries/ArduinoJson
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
     - name: Download and install stable Nanopb
@@ -415,7 +409,6 @@ jobs:
       run: bash ci/actions_install.sh
     - name: Install extra Arduino libraries
       run: |
-        git clone --depth 1 --branch 6.x https://github.com/bblanchon/ArduinoJson.git /home/runner/Arduino/libraries/ArduinoJson
         git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
         git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
         git clone --quiet https://github.com/adafruit/Adafruit_HX8357_Library.git /home/runner/Arduino/libraries/Adafruit_HX8357_Library

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.74
+version=1.0.0-beta.75
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino application for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -2404,6 +2404,12 @@ void Wippersnapper::runNetFSM() {
         WS._ui_helper->set_label_status("Connecting to IO...");
 #endif
       WS._mqtt->setKeepAliveInterval(WS_KEEPALIVE_INTERVAL_MS / 1000);
+      // print mqtt config
+      // WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port, clientID, WS._config.aio_user, WS._config.aio_key);
+      WS_DEBUG_PRINTLN(WS._config.aio_url);
+      WS_DEBUG_PRINTLN(WS._mqtt_port);
+      WS_DEBUG_PRINTLN(WS._config.aio_user);
+      WS_DEBUG_PRINTLN(WS._config.aio_key);
       // Attempt to connect
       maxAttempts = 5;
       while (maxAttempts > 0) {
@@ -2425,7 +2431,7 @@ void Wippersnapper::runNetFSM() {
         }
         WS_DEBUG_PRINTLN(
             "Unable to connect to Adafruit IO MQTT, retrying in 3 seconds...");
-        statusLEDBlink(WS_LED_STATUS_MQTT_CONNECTING);
+        delay(3000);
         maxAttempts--;
       }
       if (fsmNetwork != FSM_NET_CHECK_MQTT) {

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -2688,9 +2688,9 @@ void printDeviceInfo() {
   WS_DEBUG_PRINT("Board ID: ");
   WS_DEBUG_PRINTLN(BOARD_ID);
   WS_DEBUG_PRINT("Adafruit.io User: ");
-  WS_DEBUG_PRINTLN(WS._username);
+  WS_DEBUG_PRINTLN(WS._config.mqtt.aio_user);
   WS_DEBUG_PRINT("WiFi Network: ");
-  WS_DEBUG_PRINTLN(WS._network_ssid);
+  WS_DEBUG_PRINTLN(WS._config.network.ssid);
 
   char sMAC[18] = {0};
   sprintf(sMAC, "%02X:%02X:%02X:%02X:%02X:%02X", WS._macAddr[0], WS._macAddr[1],

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -2404,12 +2404,6 @@ void Wippersnapper::runNetFSM() {
         WS._ui_helper->set_label_status("Connecting to IO...");
 #endif
       WS._mqtt->setKeepAliveInterval(WS_KEEPALIVE_INTERVAL_MS / 1000);
-      // print mqtt config
-      // WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port, clientID, WS._config.aio_user, WS._config.aio_key);
-      WS_DEBUG_PRINTLN(WS._config.aio_url);
-      WS_DEBUG_PRINTLN(WS._mqtt_port);
-      WS_DEBUG_PRINTLN(WS._config.aio_user);
-      WS_DEBUG_PRINTLN(WS._config.aio_key);
       // Attempt to connect
       maxAttempts = 5;
       while (maxAttempts > 0) {

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -2688,7 +2688,7 @@ void printDeviceInfo() {
   WS_DEBUG_PRINT("Board ID: ");
   WS_DEBUG_PRINTLN(BOARD_ID);
   WS_DEBUG_PRINT("Adafruit.io User: ");
-  WS_DEBUG_PRINTLN(WS._config.mqtt.aio_user);
+  WS_DEBUG_PRINTLN(WS._config.aio_user);
   WS_DEBUG_PRINT("WiFi Network: ");
   WS_DEBUG_PRINTLN(WS._config.network.ssid);
 

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -1746,11 +1746,12 @@ void cbThrottleTopic(char *throttleData, uint16_t len) {
 bool Wippersnapper::generateWSErrorTopics() {
 // dynamically allocate memory for err topic
 #ifdef USE_PSRAM
-  WS._err_topic = (char *)ps_malloc(
-      sizeof(char) * (strlen(WS._config.aio_user) + strlen(TOPIC_IO_ERRORS) + 1));
+  WS._err_topic =
+      (char *)ps_malloc(sizeof(char) * (strlen(WS._config.aio_user) +
+                                        strlen(TOPIC_IO_ERRORS) + 1));
 #else
-  WS._err_topic = (char *)malloc(
-      sizeof(char) * (strlen(WS._config.aio_user) + strlen(TOPIC_IO_ERRORS) + 1));
+  WS._err_topic = (char *)malloc(sizeof(char) * (strlen(WS._config.aio_user) +
+                                                 strlen(TOPIC_IO_ERRORS) + 1));
 #endif
 
   if (WS._err_topic) { // build error topic
@@ -1768,11 +1769,13 @@ bool Wippersnapper::generateWSErrorTopics() {
 
 // dynamically allocate memory for throttle topic
 #ifdef USE_PSRAM
-  WS._throttle_topic = (char *)ps_malloc(
-      sizeof(char) * (strlen(WS._config.aio_user) + strlen(TOPIC_IO_THROTTLE) + 1));
+  WS._throttle_topic =
+      (char *)ps_malloc(sizeof(char) * (strlen(WS._config.aio_user) +
+                                        strlen(TOPIC_IO_THROTTLE) + 1));
 #else
-  WS._throttle_topic = (char *)malloc(
-      sizeof(char) * (strlen(WS._config.aio_user) + strlen(TOPIC_IO_THROTTLE) + 1));
+  WS._throttle_topic =
+      (char *)malloc(sizeof(char) * (strlen(WS._config.aio_user) +
+                                     strlen(TOPIC_IO_THROTTLE) + 1));
 #endif
 
   if (WS._throttle_topic) { // build throttle topic
@@ -1846,9 +1849,9 @@ bool Wippersnapper::generateWSTopics() {
       sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr") +
       strlen(TOPIC_INFO) + strlen("status") + 1);
 #else
-  WS._topic_description =
-      (char *)malloc(sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr") +
-                     strlen(TOPIC_INFO) + strlen("status") + 1);
+  WS._topic_description = (char *)malloc(
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr") +
+      strlen(TOPIC_INFO) + strlen("status") + 1);
 #endif
   if (WS._topic_description != NULL) {
     strcpy(WS._topic_description, WS._config.aio_user);
@@ -1867,10 +1870,10 @@ bool Wippersnapper::generateWSTopics() {
       strlen(_device_uid) + strlen(TOPIC_INFO) + strlen("status/") +
       strlen("broker") + 1);
 #else
-  WS._topic_description_status =
-      (char *)malloc(sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
-                     strlen(_device_uid) + strlen(TOPIC_INFO) +
-                     strlen("status/") + strlen("broker") + 1);
+  WS._topic_description_status = (char *)malloc(
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
+      strlen(_device_uid) + strlen(TOPIC_INFO) + strlen("status/") +
+      strlen("broker") + 1);
 #endif
   if (WS._topic_description_status != NULL) {
     strcpy(WS._topic_description_status, WS._config.aio_user);
@@ -1897,10 +1900,10 @@ bool Wippersnapper::generateWSTopics() {
       strlen(_device_uid) + strlen(TOPIC_INFO) + strlen("status") +
       strlen("/device/complete") + 1);
 #else
-  WS._topic_description_status_complete =
-      (char *)malloc(sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
-                     strlen(_device_uid) + strlen(TOPIC_INFO) +
-                     strlen("status") + strlen("/device/complete") + 1);
+  WS._topic_description_status_complete = (char *)malloc(
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
+      strlen(_device_uid) + strlen(TOPIC_INFO) + strlen("status") +
+      strlen("/device/complete") + 1);
 #endif
   if (WS._topic_description_status_complete != NULL) {
     strcpy(WS._topic_description_status_complete, WS._config.aio_user);
@@ -1942,10 +1945,10 @@ bool Wippersnapper::generateWSTopics() {
       strlen(_device_uid) + strlen(TOPIC_SIGNALS) +
       strlen("device/pinConfigComplete") + 1);
 #else
-  WS._topic_device_pin_config_complete =
-      (char *)malloc(sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
-                     strlen(_device_uid) + strlen(TOPIC_SIGNALS) +
-                     strlen("device/pinConfigComplete") + 1);
+  WS._topic_device_pin_config_complete = (char *)malloc(
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
+      strlen(_device_uid) + strlen(TOPIC_SIGNALS) +
+      strlen("device/pinConfigComplete") + 1);
 #endif
   if (WS._topic_device_pin_config_complete != NULL) {
     strcpy(WS._topic_device_pin_config_complete, WS._config.aio_user);
@@ -1989,14 +1992,14 @@ bool Wippersnapper::generateWSTopics() {
 // Create device-to-broker i2c signal topic
 #ifdef USE_PSRAM
   WS._topic_signal_i2c_brkr = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("broker") +
-      strlen(TOPIC_I2C) + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) +
+      strlen("broker") + strlen(TOPIC_I2C) + 1);
 #else
   WS._topic_signal_i2c_brkr = (char *)malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("broker") +
-      strlen(TOPIC_I2C) + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) +
+      strlen("broker") + strlen(TOPIC_I2C) + 1);
 #endif
   if (WS._topic_signal_i2c_brkr != NULL) {
     strcpy(WS._topic_signal_i2c_brkr, WS._config.aio_user);
@@ -2019,14 +2022,14 @@ bool Wippersnapper::generateWSTopics() {
 // Create broker-to-device i2c signal topic
 #ifdef USE_PSRAM
   WS._topic_signal_i2c_device = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("device") +
-      strlen(TOPIC_I2C) + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) +
+      strlen("device") + strlen(TOPIC_I2C) + 1);
 #else
   WS._topic_signal_i2c_device = (char *)malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("device") +
-      strlen(TOPIC_I2C) + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) +
+      strlen("device") + strlen(TOPIC_I2C) + 1);
 #endif
   if (WS._topic_signal_i2c_device != NULL) {
     strcpy(WS._topic_signal_i2c_device, WS._config.aio_user);
@@ -2043,14 +2046,14 @@ bool Wippersnapper::generateWSTopics() {
 // Create device-to-broker ds18x20 topic
 #ifdef USE_PSRAM
   WS._topic_signal_ds18_brkr = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("broker/") +
-      strlen("ds18x20") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) +
+      strlen("broker/") + strlen("ds18x20") + 1);
 #else
   WS._topic_signal_ds18_brkr = (char *)malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("broker/") +
-      strlen("ds18x20") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) +
+      strlen("broker/") + strlen("ds18x20") + 1);
 #endif
   if (WS._topic_signal_ds18_brkr != NULL) {
     strcpy(WS._topic_signal_ds18_brkr, WS._config.aio_user);
@@ -2072,14 +2075,14 @@ bool Wippersnapper::generateWSTopics() {
 // Create broker-to-device ds18x20 topic
 #ifdef USE_PSRAM
   WS._topic_signal_ds18_device = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("device/") +
-      strlen("ds18x20") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) +
+      strlen("device/") + strlen("ds18x20") + 1);
 #else
   WS._topic_signal_ds18_device = (char *)malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("device/") +
-      strlen("ds18x20") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) +
+      strlen("device/") + strlen("ds18x20") + 1);
 #endif
   if (WS._topic_signal_ds18_device != NULL) {
     strcpy(WS._topic_signal_ds18_device, WS._config.aio_user);
@@ -2095,12 +2098,12 @@ bool Wippersnapper::generateWSTopics() {
 // Create device-to-broker servo signal topic
 #ifdef USE_PSRAM
   WS._topic_signal_servo_brkr = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/broker/servo") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/broker/servo") + 1);
 #else
   WS._topic_signal_servo_brkr = (char *)malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/broker/servo") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/broker/servo") + 1);
 #endif
   if (WS._topic_signal_servo_brkr != NULL) {
     strcpy(WS._topic_signal_servo_brkr, WS._config.aio_user);
@@ -2122,12 +2125,12 @@ bool Wippersnapper::generateWSTopics() {
 // Create broker-to-device servo signal topic
 #ifdef USE_PSRAM
   WS._topic_signal_servo_device = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/device/servo") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/device/servo") + 1);
 #else
   WS._topic_signal_servo_device = (char *)malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/device/servo") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/device/servo") + 1);
 #endif
   if (WS._topic_signal_servo_device != NULL) {
     strcpy(WS._topic_signal_servo_device, WS._config.aio_user);
@@ -2143,12 +2146,12 @@ bool Wippersnapper::generateWSTopics() {
 // Topic for pwm messages from broker->device
 #ifdef USE_PSRAM
   WS._topic_signal_pwm_brkr = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/broker/pwm") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/broker/pwm") + 1);
 #else
   WS._topic_signal_pwm_brkr = (char *)malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/broker/pwm") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/broker/pwm") + 1);
 #endif
   // Create device-to-broker pwm signal topic
   if (WS._topic_signal_pwm_brkr != NULL) {
@@ -2171,12 +2174,12 @@ bool Wippersnapper::generateWSTopics() {
 // Topic for pwm messages from device->broker
 #ifdef USE_PSRAM
   WS._topic_signal_pwm_device = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/device/pwm") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/device/pwm") + 1);
 #else
   WS._topic_signal_pwm_device = (char *)malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/device/pwm") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/device/pwm") + 1);
 #endif
   if (WS._topic_signal_pwm_device != NULL) {
     strcpy(WS._topic_signal_pwm_device, WS._config.aio_user);
@@ -2192,12 +2195,12 @@ bool Wippersnapper::generateWSTopics() {
 // Topic for pixel messages from broker->device
 #ifdef USE_PSRAM
   WS._topic_signal_pixels_brkr = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/broker/pixels") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/broker/pixels") + 1);
 #else
   WS._topic_signal_pixels_brkr = (char *)malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/broker/pixels") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/broker/pixels") + 1);
 #endif
   if (WS._topic_signal_pixels_brkr != NULL) {
     strcpy(WS._topic_signal_pixels_brkr, WS._config.aio_user);
@@ -2218,12 +2221,12 @@ bool Wippersnapper::generateWSTopics() {
 // Topic for pixel messages from device->broker
 #ifdef USE_PSRAM
   WS._topic_signal_pixels_device = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/device/pixels") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/device/pixels") + 1);
 #else
   WS._topic_signal_pixels_device = (char *)malloc(
-      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-      strlen("/wprsnpr/signals/device/pixels") + 1);
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") +
+      strlen(_device_uid) + strlen("/wprsnpr/signals/device/pixels") + 1);
 #endif
   if (WS._topic_signal_pixels_device != NULL) {
     strcpy(WS._topic_signal_pixels_device, WS._config.aio_user);
@@ -2238,9 +2241,9 @@ bool Wippersnapper::generateWSTopics() {
   // Create device-to-broker UART topic
 
   // Calculate size for dynamic MQTT topic
-  size_t topicLen = strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
-                    strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) +
-                    strlen("broker/uart") + 1;
+  size_t topicLen = strlen(WS._config.aio_user) + strlen("/") +
+                    strlen(_device_uid) + strlen("/wprsnpr/") +
+                    strlen(TOPIC_SIGNALS) + strlen("broker/uart") + 1;
 
 // Allocate memory for dynamic MQTT topic
 #ifdef USE_PSRAM

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -38,10 +38,6 @@ Wippersnapper WS;
 Wippersnapper::Wippersnapper() {
   _mqtt = 0; // MQTT Client object
 
-  // IO creds
-  _username = 0;
-  _key = 0;
-
   // Reserved MQTT Topics
   _topic_description = 0;
   _topic_description_status = 0;
@@ -1749,14 +1745,14 @@ bool Wippersnapper::generateWSErrorTopics() {
 // dynamically allocate memory for err topic
 #ifdef USE_PSRAM
   WS._err_topic = (char *)ps_malloc(
-      sizeof(char) * (strlen(WS._username) + strlen(TOPIC_IO_ERRORS) + 1));
+      sizeof(char) * (strlen(WS._config.aio_user) + strlen(TOPIC_IO_ERRORS) + 1));
 #else
   WS._err_topic = (char *)malloc(
-      sizeof(char) * (strlen(WS._username) + strlen(TOPIC_IO_ERRORS) + 1));
+      sizeof(char) * (strlen(WS._config.aio_user) + strlen(TOPIC_IO_ERRORS) + 1));
 #endif
 
   if (WS._err_topic) { // build error topic
-    strcpy(WS._err_topic, WS._username);
+    strcpy(WS._err_topic, WS._config.aio_user);
     strcat(WS._err_topic, TOPIC_IO_ERRORS);
   } else { // malloc failed
     WS_DEBUG_PRINTLN("ERROR: Failed to allocate global error topic!");
@@ -1771,14 +1767,14 @@ bool Wippersnapper::generateWSErrorTopics() {
 // dynamically allocate memory for throttle topic
 #ifdef USE_PSRAM
   WS._throttle_topic = (char *)ps_malloc(
-      sizeof(char) * (strlen(WS._username) + strlen(TOPIC_IO_THROTTLE) + 1));
+      sizeof(char) * (strlen(WS._config.aio_user) + strlen(TOPIC_IO_THROTTLE) + 1));
 #else
   WS._throttle_topic = (char *)malloc(
-      sizeof(char) * (strlen(WS._username) + strlen(TOPIC_IO_THROTTLE) + 1));
+      sizeof(char) * (strlen(WS._config.aio_user) + strlen(TOPIC_IO_THROTTLE) + 1));
 #endif
 
   if (WS._throttle_topic) { // build throttle topic
-    strcpy(WS._throttle_topic, WS._username);
+    strcpy(WS._throttle_topic, WS._config.aio_user);
     strcat(WS._throttle_topic, TOPIC_IO_THROTTLE);
   } else { // malloc failed
     WS_DEBUG_PRINTLN("ERROR: Failed to allocate global throttle topic!");
@@ -1801,19 +1797,6 @@ bool Wippersnapper::generateWSErrorTopics() {
 */
 /**************************************************************************/
 bool Wippersnapper::generateDeviceUID() {
-  // Validate IO configuration from flash
-  if (WS._username == NULL || WS._key == NULL) {
-    WS_DEBUG_PRINTLN("FATAL ERROR: IO Config not detected on device!");
-    return false;
-  }
-
-  // Validate network configuration from flash
-  if (WS._username == NULL || WS._key == NULL || WS._network_ssid == NULL ||
-      WS._network_pass == NULL) {
-    WS_DEBUG_PRINTLN("FATAL ERROR: Network Config not detected on device!");
-    return false;
-  }
-
   // Generate device unique identifier
   // Set machine_name
   WS._boardId = BOARD_ID;
@@ -1858,15 +1841,15 @@ bool Wippersnapper::generateWSTopics() {
 // Create global registration topic
 #ifdef USE_PSRAM
   WS._topic_description = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/wprsnpr") +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr") +
       strlen(TOPIC_INFO) + strlen("status") + 1);
 #else
   WS._topic_description =
-      (char *)malloc(sizeof(char) * strlen(WS._username) + strlen("/wprsnpr") +
+      (char *)malloc(sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr") +
                      strlen(TOPIC_INFO) + strlen("status") + 1);
 #endif
   if (WS._topic_description != NULL) {
-    strcpy(WS._topic_description, WS._username);
+    strcpy(WS._topic_description, WS._config.aio_user);
     strcat(WS._topic_description, "/wprsnpr");
     strcat(WS._topic_description, TOPIC_INFO);
     strcat(WS._topic_description, "status");
@@ -1878,17 +1861,17 @@ bool Wippersnapper::generateWSTopics() {
 // Create registration status topic
 #ifdef USE_PSRAM
   WS._topic_description_status = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/wprsnpr/") +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
       strlen(_device_uid) + strlen(TOPIC_INFO) + strlen("status/") +
       strlen("broker") + 1);
 #else
   WS._topic_description_status =
-      (char *)malloc(sizeof(char) * strlen(WS._username) + strlen("/wprsnpr/") +
+      (char *)malloc(sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
                      strlen(_device_uid) + strlen(TOPIC_INFO) +
                      strlen("status/") + strlen("broker") + 1);
 #endif
   if (WS._topic_description_status != NULL) {
-    strcpy(WS._topic_description_status, WS._username);
+    strcpy(WS._topic_description_status, WS._config.aio_user);
     strcat(WS._topic_description_status, "/wprsnpr/");
     strcat(WS._topic_description_status, _device_uid);
     strcat(WS._topic_description_status, TOPIC_INFO);
@@ -1908,17 +1891,17 @@ bool Wippersnapper::generateWSTopics() {
 // Create registration status complete topic
 #ifdef USE_PSRAM
   WS._topic_description_status_complete = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/wprsnpr/") +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
       strlen(_device_uid) + strlen(TOPIC_INFO) + strlen("status") +
       strlen("/device/complete") + 1);
 #else
   WS._topic_description_status_complete =
-      (char *)malloc(sizeof(char) * strlen(WS._username) + strlen("/wprsnpr/") +
+      (char *)malloc(sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
                      strlen(_device_uid) + strlen(TOPIC_INFO) +
                      strlen("status") + strlen("/device/complete") + 1);
 #endif
   if (WS._topic_description_status_complete != NULL) {
-    strcpy(WS._topic_description_status_complete, WS._username);
+    strcpy(WS._topic_description_status_complete, WS._config.aio_user);
     strcat(WS._topic_description_status_complete, "/wprsnpr/");
     strcat(WS._topic_description_status_complete, _device_uid);
     strcat(WS._topic_description_status_complete, TOPIC_INFO);
@@ -1932,15 +1915,15 @@ bool Wippersnapper::generateWSTopics() {
 // Create device-to-broker signal topic
 #ifdef USE_PSRAM
   WS._topic_signal_device = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/wprsnpr/") +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
       strlen(_device_uid) + strlen(TOPIC_SIGNALS) + strlen("device") + 1);
 #else
   WS._topic_signal_device = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/wprsnpr/") +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
       strlen(_device_uid) + strlen(TOPIC_SIGNALS) + strlen("device") + 1);
 #endif
   if (WS._topic_signal_device != NULL) {
-    strcpy(WS._topic_signal_device, WS._username);
+    strcpy(WS._topic_signal_device, WS._config.aio_user);
     strcat(WS._topic_signal_device, "/wprsnpr/");
     strcat(WS._topic_signal_device, _device_uid);
     strcat(WS._topic_signal_device, TOPIC_SIGNALS);
@@ -1953,17 +1936,17 @@ bool Wippersnapper::generateWSTopics() {
 // Create pin configuration complete topic
 #ifdef USE_PSRAM
   WS._topic_device_pin_config_complete = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/wprsnpr/") +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
       strlen(_device_uid) + strlen(TOPIC_SIGNALS) +
       strlen("device/pinConfigComplete") + 1);
 #else
   WS._topic_device_pin_config_complete =
-      (char *)malloc(sizeof(char) * strlen(WS._username) + strlen("/wprsnpr/") +
+      (char *)malloc(sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
                      strlen(_device_uid) + strlen(TOPIC_SIGNALS) +
                      strlen("device/pinConfigComplete") + 1);
 #endif
   if (WS._topic_device_pin_config_complete != NULL) {
-    strcpy(WS._topic_device_pin_config_complete, WS._username);
+    strcpy(WS._topic_device_pin_config_complete, WS._config.aio_user);
     strcat(WS._topic_device_pin_config_complete, "/wprsnpr/");
     strcat(WS._topic_device_pin_config_complete, _device_uid);
     strcat(WS._topic_device_pin_config_complete, TOPIC_SIGNALS);
@@ -1977,15 +1960,15 @@ bool Wippersnapper::generateWSTopics() {
 // Create broker-to-device signal topic
 #ifdef USE_PSRAM
   WS._topic_signal_brkr = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/wprsnpr/") +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
       strlen(_device_uid) + strlen(TOPIC_SIGNALS) + strlen("broker") + 1);
 #else
   WS._topic_signal_brkr = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/wprsnpr/") +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/wprsnpr/") +
       strlen(_device_uid) + strlen(TOPIC_SIGNALS) + strlen("broker") + 1);
 #endif
   if (WS._topic_signal_brkr != NULL) {
-    strcpy(WS._topic_signal_brkr, WS._username);
+    strcpy(WS._topic_signal_brkr, WS._config.aio_user);
     strcat(WS._topic_signal_brkr, "/wprsnpr/");
     strcat(WS._topic_signal_brkr, _device_uid);
     strcat(WS._topic_signal_brkr, TOPIC_SIGNALS);
@@ -2004,17 +1987,17 @@ bool Wippersnapper::generateWSTopics() {
 // Create device-to-broker i2c signal topic
 #ifdef USE_PSRAM
   WS._topic_signal_i2c_brkr = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + +strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("broker") +
       strlen(TOPIC_I2C) + 1);
 #else
   WS._topic_signal_i2c_brkr = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + +strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("broker") +
       strlen(TOPIC_I2C) + 1);
 #endif
   if (WS._topic_signal_i2c_brkr != NULL) {
-    strcpy(WS._topic_signal_i2c_brkr, WS._username);
+    strcpy(WS._topic_signal_i2c_brkr, WS._config.aio_user);
     strcat(WS._topic_signal_i2c_brkr, TOPIC_WS);
     strcat(WS._topic_signal_i2c_brkr, _device_uid);
     strcat(WS._topic_signal_i2c_brkr, TOPIC_SIGNALS);
@@ -2034,17 +2017,17 @@ bool Wippersnapper::generateWSTopics() {
 // Create broker-to-device i2c signal topic
 #ifdef USE_PSRAM
   WS._topic_signal_i2c_device = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + +strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("device") +
       strlen(TOPIC_I2C) + 1);
 #else
   WS._topic_signal_i2c_device = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + +strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("device") +
       strlen(TOPIC_I2C) + 1);
 #endif
   if (WS._topic_signal_i2c_device != NULL) {
-    strcpy(WS._topic_signal_i2c_device, WS._username);
+    strcpy(WS._topic_signal_i2c_device, WS._config.aio_user);
     strcat(WS._topic_signal_i2c_device, TOPIC_WS);
     strcat(WS._topic_signal_i2c_device, _device_uid);
     strcat(WS._topic_signal_i2c_device, TOPIC_SIGNALS);
@@ -2058,17 +2041,17 @@ bool Wippersnapper::generateWSTopics() {
 // Create device-to-broker ds18x20 topic
 #ifdef USE_PSRAM
   WS._topic_signal_ds18_brkr = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + +strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("broker/") +
       strlen("ds18x20") + 1);
 #else
   WS._topic_signal_ds18_brkr = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + +strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("broker/") +
       strlen("ds18x20") + 1);
 #endif
   if (WS._topic_signal_ds18_brkr != NULL) {
-    strcpy(WS._topic_signal_ds18_brkr, WS._username);
+    strcpy(WS._topic_signal_ds18_brkr, WS._config.aio_user);
     strcat(WS._topic_signal_ds18_brkr, TOPIC_WS);
     strcat(WS._topic_signal_ds18_brkr, _device_uid);
     strcat(WS._topic_signal_ds18_brkr, TOPIC_SIGNALS);
@@ -2087,17 +2070,17 @@ bool Wippersnapper::generateWSTopics() {
 // Create broker-to-device ds18x20 topic
 #ifdef USE_PSRAM
   WS._topic_signal_ds18_device = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + +strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("device/") +
       strlen("ds18x20") + 1);
 #else
   WS._topic_signal_ds18_device = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + +strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + +strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) + strlen("device/") +
       strlen("ds18x20") + 1);
 #endif
   if (WS._topic_signal_ds18_device != NULL) {
-    strcpy(WS._topic_signal_ds18_device, WS._username);
+    strcpy(WS._topic_signal_ds18_device, WS._config.aio_user);
     strcat(WS._topic_signal_ds18_device, TOPIC_WS);
     strcat(WS._topic_signal_ds18_device, _device_uid);
     strcat(WS._topic_signal_ds18_device, TOPIC_SIGNALS);
@@ -2110,15 +2093,15 @@ bool Wippersnapper::generateWSTopics() {
 // Create device-to-broker servo signal topic
 #ifdef USE_PSRAM
   WS._topic_signal_servo_brkr = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/broker/servo") + 1);
 #else
   WS._topic_signal_servo_brkr = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/broker/servo") + 1);
 #endif
   if (WS._topic_signal_servo_brkr != NULL) {
-    strcpy(WS._topic_signal_servo_brkr, WS._username);
+    strcpy(WS._topic_signal_servo_brkr, WS._config.aio_user);
     strcat(WS._topic_signal_servo_brkr, TOPIC_WS);
     strcat(WS._topic_signal_servo_brkr, _device_uid);
     strcat(WS._topic_signal_servo_brkr, TOPIC_SIGNALS);
@@ -2137,15 +2120,15 @@ bool Wippersnapper::generateWSTopics() {
 // Create broker-to-device servo signal topic
 #ifdef USE_PSRAM
   WS._topic_signal_servo_device = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/device/servo") + 1);
 #else
   WS._topic_signal_servo_device = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/device/servo") + 1);
 #endif
   if (WS._topic_signal_servo_device != NULL) {
-    strcpy(WS._topic_signal_servo_device, WS._username);
+    strcpy(WS._topic_signal_servo_device, WS._config.aio_user);
     strcat(WS._topic_signal_servo_device, TOPIC_WS);
     strcat(WS._topic_signal_servo_device, _device_uid);
     strcat(WS._topic_signal_servo_device, TOPIC_SIGNALS);
@@ -2158,16 +2141,16 @@ bool Wippersnapper::generateWSTopics() {
 // Topic for pwm messages from broker->device
 #ifdef USE_PSRAM
   WS._topic_signal_pwm_brkr = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/broker/pwm") + 1);
 #else
   WS._topic_signal_pwm_brkr = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/broker/pwm") + 1);
 #endif
   // Create device-to-broker pwm signal topic
   if (WS._topic_signal_pwm_brkr != NULL) {
-    strcpy(WS._topic_signal_pwm_brkr, WS._username);
+    strcpy(WS._topic_signal_pwm_brkr, WS._config.aio_user);
     strcat(WS._topic_signal_pwm_brkr, TOPIC_WS);
     strcat(WS._topic_signal_pwm_brkr, _device_uid);
     strcat(WS._topic_signal_pwm_brkr, TOPIC_SIGNALS);
@@ -2186,15 +2169,15 @@ bool Wippersnapper::generateWSTopics() {
 // Topic for pwm messages from device->broker
 #ifdef USE_PSRAM
   WS._topic_signal_pwm_device = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/device/pwm") + 1);
 #else
   WS._topic_signal_pwm_device = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/device/pwm") + 1);
 #endif
   if (WS._topic_signal_pwm_device != NULL) {
-    strcpy(WS._topic_signal_pwm_device, WS._username);
+    strcpy(WS._topic_signal_pwm_device, WS._config.aio_user);
     strcat(WS._topic_signal_pwm_device, TOPIC_WS);
     strcat(WS._topic_signal_pwm_device, _device_uid);
     strcat(WS._topic_signal_pwm_device, TOPIC_SIGNALS);
@@ -2207,15 +2190,15 @@ bool Wippersnapper::generateWSTopics() {
 // Topic for pixel messages from broker->device
 #ifdef USE_PSRAM
   WS._topic_signal_pixels_brkr = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/broker/pixels") + 1);
 #else
   WS._topic_signal_pixels_brkr = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/broker/pixels") + 1);
 #endif
   if (WS._topic_signal_pixels_brkr != NULL) {
-    strcpy(WS._topic_signal_pixels_brkr, WS._username);
+    strcpy(WS._topic_signal_pixels_brkr, WS._config.aio_user);
     strcat(WS._topic_signal_pixels_brkr, TOPIC_WS);
     strcat(WS._topic_signal_pixels_brkr, _device_uid);
     strcat(WS._topic_signal_pixels_brkr, MQTT_TOPIC_PIXELS_BROKER);
@@ -2233,15 +2216,15 @@ bool Wippersnapper::generateWSTopics() {
 // Topic for pixel messages from device->broker
 #ifdef USE_PSRAM
   WS._topic_signal_pixels_device = (char *)ps_malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/device/pixels") + 1);
 #else
   WS._topic_signal_pixels_device = (char *)malloc(
-      sizeof(char) * strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+      sizeof(char) * strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
       strlen("/wprsnpr/signals/device/pixels") + 1);
 #endif
   if (WS._topic_signal_pixels_device != NULL) {
-    strcpy(WS._topic_signal_pixels_device, WS._username);
+    strcpy(WS._topic_signal_pixels_device, WS._config.aio_user);
     strcat(WS._topic_signal_pixels_device, TOPIC_WS);
     strcat(WS._topic_signal_pixels_device, _device_uid);
     strcat(WS._topic_signal_pixels_device, MQTT_TOPIC_PIXELS_DEVICE);
@@ -2253,7 +2236,7 @@ bool Wippersnapper::generateWSTopics() {
   // Create device-to-broker UART topic
 
   // Calculate size for dynamic MQTT topic
-  size_t topicLen = strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+  size_t topicLen = strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
                     strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) +
                     strlen("broker/uart") + 1;
 
@@ -2267,7 +2250,7 @@ bool Wippersnapper::generateWSTopics() {
   // Generate the topic if memory was allocated successfully
   if (WS._topic_signal_uart_brkr != NULL) {
     snprintf(WS._topic_signal_uart_brkr, topicLen, "%s/wprsnpr/%s%sbroker/uart",
-             WS._username, _device_uid, TOPIC_SIGNALS);
+             WS._config.aio_user, _device_uid, TOPIC_SIGNALS);
   } else {
     WS_DEBUG_PRINTLN("FATAL ERROR: Failed to allocate memory for UART topic!");
     return false;
@@ -2282,7 +2265,7 @@ bool Wippersnapper::generateWSTopics() {
 
   // Create broker-to-device UART topic
   // Calculate size for dynamic MQTT topic
-  topicLen = strlen(WS._username) + strlen("/") + strlen(_device_uid) +
+  topicLen = strlen(WS._config.aio_user) + strlen("/") + strlen(_device_uid) +
              strlen("/wprsnpr/") + strlen(TOPIC_SIGNALS) +
              strlen("device/uart") + 1;
 
@@ -2296,7 +2279,7 @@ bool Wippersnapper::generateWSTopics() {
   // Generate the topic if memory was allocated successfully
   if (WS._topic_signal_uart_device != NULL) {
     snprintf(WS._topic_signal_uart_device, topicLen,
-             "%s/wprsnpr/%s%sdevice/uart", WS._username, _device_uid,
+             "%s/wprsnpr/%s%sdevice/uart", WS._config.aio_user, _device_uid,
              TOPIC_SIGNALS);
   } else {
     WS_DEBUG_PRINTLN("FATAL ERROR: Failed to allocate memory for UART topic!");

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -134,6 +134,8 @@ void Wippersnapper::provision() {
 #else
   set_user_key(); // non-fs-backed, sets global credentials within network iface
 #endif
+  // Set the status pixel's brightness
+  setStatusLEDBrightness(WS._config.status_pixel_brightness);
   // Set device's wireless credentials
   set_ssid_pass();
 

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -320,10 +320,6 @@ public:
   // TODO: Should this be in config, too?
   uint16_t _mqtt_port = 8883;           /*!< MQTT Broker Port */
 
-  // WiFi credentials
-  const char *_network_ssid = NULL; /*!< WiFi network SSID */
-  const char *_network_pass = NULL; /*!< WiFi network password*/
-
   // TODO: Does this need to be within this class?
   int32_t totalDigitalPins; /*!< Total number of digital-input capable pins */
 

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -70,6 +70,8 @@
 #include "provisioning/littlefs/WipperSnapper_LittleFS.h"
 #endif
 
+#include "provisioning/ConfigJson.h"
+
 #define WS_VERSION                                                             \
   "1.0.0-beta.74" ///< WipperSnapper app. version (semver-formatted)
 
@@ -313,6 +315,8 @@ public:
   char sUID[13];        /*!< Unique network iface identifier */
   const char *_boardId; /*!< Adafruit IO+ board string */
   Adafruit_MQTT *_mqtt; /*!< Reference to Adafruit_MQTT, _mqtt. */
+
+  Config _config; /*!< Pointer to Config object */
 
   const char *_mqttBrokerURL = nullptr; /*!< MQTT Broker URL */
   uint16_t _mqtt_port = 8883;           /*!< MQTT Broker Port */

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -9,7 +9,7 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Copyright (c) Brent Rubell 2020-2023 for Adafruit Industries.
+ * Copyright (c) Brent Rubell 2020-2024 for Adafruit Industries.
  *
  * BSD license, all text here must be included in any redistribution.
  *
@@ -73,7 +73,7 @@
 #include "provisioning/ConfigJson.h"
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.74" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.75" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -316,7 +316,7 @@ public:
   const char *_boardId; /*!< Adafruit IO+ board string */
   Adafruit_MQTT *_mqtt; /*!< Reference to Adafruit_MQTT, _mqtt. */
 
-  Config _config; /*!< Wippersnapper secrets.json as a struct. */
+  secretsConfig _config; /*!< Wippersnapper secrets.json as a struct. */
 
   // TODO: Does this need to be within this class?
   int32_t totalDigitalPins; /*!< Total number of digital-input capable pins */

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -317,8 +317,6 @@ public:
   Adafruit_MQTT *_mqtt; /*!< Reference to Adafruit_MQTT, _mqtt. */
 
   Config _config; /*!< Pointer to Config object */
-
-  const char *_mqttBrokerURL = nullptr; /*!< MQTT Broker URL */
   uint16_t _mqtt_port = 8883;           /*!< MQTT Broker Port */
 
   // AIO credentials

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -317,8 +317,6 @@ public:
   Adafruit_MQTT *_mqtt; /*!< Reference to Adafruit_MQTT, _mqtt. */
 
   Config _config; /*!< Wippersnapper secrets.json as a struct. */
-  // TODO: Should this be in config, too?
-  uint16_t _mqtt_port = 8883;           /*!< MQTT Broker Port */
 
   // TODO: Does this need to be within this class?
   int32_t totalDigitalPins; /*!< Total number of digital-input capable pins */

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -316,12 +316,9 @@ public:
   const char *_boardId; /*!< Adafruit IO+ board string */
   Adafruit_MQTT *_mqtt; /*!< Reference to Adafruit_MQTT, _mqtt. */
 
-  Config _config; /*!< Pointer to Config object */
+  Config _config; /*!< Wippersnapper secrets.json as a struct. */
+  // TODO: Should this be in config, too?
   uint16_t _mqtt_port = 8883;           /*!< MQTT Broker Port */
-
-  // AIO credentials
-  const char *_username = NULL; /*!< Adafruit IO username */
-  const char *_key = NULL;      /*!< Adafruit IO key */
 
   // WiFi credentials
   const char *_network_ssid = NULL; /*!< WiFi network SSID */

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -39,6 +39,7 @@
 // Wippersnapper API Helpers
 #include "Wippersnapper_Boards.h"
 #include "components/statusLED/Wippersnapper_StatusLED.h"
+#include "provisioning/ConfigJson.h"
 
 // Wippersnapper components
 #include "components/analogIO/Wippersnapper_AnalogIO.h"
@@ -69,8 +70,6 @@
 #if defined(USE_LITTLEFS)
 #include "provisioning/littlefs/WipperSnapper_LittleFS.h"
 #endif
-
-#include "provisioning/ConfigJson.h"
 
 #define WS_VERSION                                                             \
   "1.0.0-beta.75" ///< WipperSnapper app. version (semver-formatted)

--- a/src/display/ws_display_driver.cpp
+++ b/src/display/ws_display_driver.cpp
@@ -26,13 +26,14 @@
 ws_display_driver::ws_display_driver(displayConfig config) {
   // dynamically create the display driver from the configuration file
   if (strcmp(config.driver, "ST7789") == 0) {
-    Serial.println("Configuring the Adafruit_ST7789 driver");
-    _tft_st7789 =
-        new Adafruit_ST7789(config.pinCS, config.pinDC, config.pinRST);
+    WS_DEBUG_PRINTLN("Creating ST7789 driver");
+    // create a new ST7789 driver
+    _tft_st7789 = new Adafruit_ST7789((uint8_t)config.spiConfig.pinCs, (uint8_t)config.spiConfig.pinDc, (uint8_t)config.spiConfig.pinRst);
   } else {
     Serial.println("ERROR: Display driver type not implemented!");
   }
 
+  // set display resolution and rotation
   setResolution(config.width, config.height);
   setRotation(config.rotation);
 }

--- a/src/display/ws_display_driver.cpp
+++ b/src/display/ws_display_driver.cpp
@@ -28,7 +28,9 @@ ws_display_driver::ws_display_driver(displayConfig config) {
   if (strcmp(config.driver, "ST7789") == 0) {
     WS_DEBUG_PRINTLN("Creating ST7789 driver");
     // create a new ST7789 driver
-    _tft_st7789 = new Adafruit_ST7789((uint8_t)config.spiConfig.pinCs, (uint8_t)config.spiConfig.pinDc, (uint8_t)config.spiConfig.pinRst);
+    _tft_st7789 = new Adafruit_ST7789((uint8_t)config.spiConfig.pinCs,
+                                      (uint8_t)config.spiConfig.pinDc,
+                                      (uint8_t)config.spiConfig.pinRst);
   } else {
     Serial.println("ERROR: Display driver type not implemented!");
   }

--- a/src/display/ws_display_driver.h
+++ b/src/display/ws_display_driver.h
@@ -16,25 +16,10 @@
 #define WIPPERSNAPPER_DISPLAY_H
 
 #include "Wippersnapper.h"
-
+#include "provisioning/Config.h"
 #include <Adafruit_LvGL_Glue.h> // Always include this BEFORE lvgl.h!
 #include <Adafruit_ST7789.h>
 #include <lvgl.h>
-
-/** Display driver configuration */
-struct displayConfig {
-  char driver[10]; ///< Display driver type
-  int width;       ///< Display width
-  int height;      ///< Display height
-  int rotation;    ///< Display rotation
-  bool isSPI;      ///< Is the display SPI?
-  bool isI2C;      ///< Is the display I2C?
-  uint8_t pinCS;   ///< Display CS pin
-  uint8_t pinDC;   ///< Display DC pin
-  uint8_t pinMOSI; ///< Display MOSI pin
-  uint8_t pinSCK;  ///< Display SCK pin
-  uint8_t pinRST;  ///< Display RST pin
-};
 
 LV_FONT_DECLARE(errorTriangle); ///< Error triangle symbol/font
 

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -199,7 +199,7 @@ public:
   */
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
-    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS.WS._config.io_port, clientID, WS._config.aio_user, WS._config.aio_key);
+    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._config.io_port, clientID, WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -199,7 +199,7 @@ public:
   */
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
-    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port, clientID, WS._username, WS._key);
+    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port, clientID, WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -199,12 +199,7 @@ public:
   */
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
-    if (WS._mqttBrokerURL == nullptr)
-      WS._mqttBrokerURL = "io.adafruit.com";
-
-    WS._mqtt =
-        new Adafruit_MQTT_Client(_mqtt_client, WS._mqttBrokerURL, WS._mqtt_port,
-                                 clientID, WS._username, WS._key);
+    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port, clientID, WS._username, WS._key);
   }
 
   /********************************************************/
@@ -237,7 +232,6 @@ public:
 protected:
   const char *_ssid;           /*!< Network SSID. */
   const char *_pass;           /*!< Network password. */
-  const char *_mqttBrokerURL;  /*!< MQTT broker URL. */
   String _fv;                  /*!< nina-fw firmware version. */
   int _ssPin = -1;             /*!< SPI S.S. pin. */
   int _ackPin = -1;            /*!< SPI ACK pin. */

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -91,8 +91,8 @@ public:
   */
   /**********************************************************/
   void set_ssid_pass() {
-    _ssid = WS._network_ssid;
-    _pass = WS._network_pass;
+    _ssid = WS._config.network.ssid;
+    _pass = WS._config.network.pass;
   }
 
   /***********************************************************/

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -199,7 +199,9 @@ public:
   */
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
-    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._config.io_port, clientID, WS._config.aio_user, WS._config.aio_key);
+    WS._mqtt = new Adafruit_MQTT_Client(
+        _mqtt_client, WS._config.aio_url, WS._config.io_port, clientID,
+        WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -199,7 +199,7 @@ public:
   */
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
-    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port, clientID, WS._config.aio_user, WS._config.aio_key);
+    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS.WS._config.io_port, clientID, WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -152,7 +152,9 @@ public:
     }
 
     // Construct MQTT client
-    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, 8883, clientID, WS._config.aio_user, WS._config.aio_key);
+    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, 8883,
+                                        clientID, WS._config.aio_user,
+                                        WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -82,8 +82,8 @@ public:
   */
   /**********************************************************/
   void set_ssid_pass() {
-    _ssid = WS._network_ssid;
-    _pass = WS._network_pass;
+    _ssid = WS._config.network.ssid;
+    _pass = WS._config.network.pass;
   }
 
   /***********************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -152,7 +152,7 @@ public:
     }
 
     // Construct MQTT client
-    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, 8883, clientID, WS._username, WS._key);
+    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, 8883, clientID, WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -145,15 +145,14 @@ public:
   */
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
-    if (WS._mqttBrokerURL == nullptr) {
-      WS._mqttBrokerURL = "io.adafruit.com";
+    if (strcmp(WS._config.aio_url, "io.adafruit.com") == 0) {
       _mqtt_client->setCACert(_aio_root_ca_prod);
     } else {
       _mqtt_client->setCACert(_aio_root_ca_staging);
     }
+
     // Construct MQTT client
-    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._mqttBrokerURL, 8883,
-                                        clientID, WS._username, WS._key);
+    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, 8883, clientID, WS._username, WS._key);
   }
 
   /********************************************************/
@@ -186,7 +185,6 @@ public:
 protected:
   const char *_ssid;              ///< WiFi SSID
   const char *_pass;              ///< WiFi password
-  const char *_mqttBrokerURL;     ///< MQTT broker URL
   WiFiClientSecure *_mqtt_client; ///< Pointer to a WiFi client object (TLS/SSL)
 
   const char *_aio_root_ca_staging =

--- a/src/network_interfaces/Wippersnapper_ESP8266.h
+++ b/src/network_interfaces/Wippersnapper_ESP8266.h
@@ -172,9 +172,9 @@ public:
     // Uncomment the following lines to use MQTT/SSL. You will need to
     // re-compile after. _wifi_client->setFingerprint(fingerprint); WS._mqtt =
     // new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, _mqtt_port,
-    // clientID, WS._username, WS._key);
+    // clientID, WS._config.aio_user, WS._config.aio_key);
 
-    WS._mqtt = new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, 1883, clientID, WS._username, WS._key);
+    WS._mqtt = new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, 1883, clientID, WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP8266.h
+++ b/src/network_interfaces/Wippersnapper_ESP8266.h
@@ -106,8 +106,8 @@ public:
   */
   /**********************************************************/
   void set_ssid_pass() {
-    _ssid = WS._network_ssid;
-    _pass = WS._network_pass;
+    _ssid = WS._config.network.ssid;
+    _pass = WS._config.network.pass;
   }
 
   /***********************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP8266.h
+++ b/src/network_interfaces/Wippersnapper_ESP8266.h
@@ -171,10 +171,12 @@ public:
   void setupMQTTClient(const char *clientID) {
     // Uncomment the following lines to use MQTT/SSL. You will need to
     // re-compile after. _wifi_client->setFingerprint(fingerprint); WS._mqtt =
-    // new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, WS._config.io_port,
-    // clientID, WS._config.aio_user, WS._config.aio_key);
+    // new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url,
+    // WS._config.io_port, clientID, WS._config.aio_user, WS._config.aio_key);
 
-    WS._mqtt = new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, 1883, clientID, WS._config.aio_user, WS._config.aio_key);
+    WS._mqtt = new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, 1883,
+                                        clientID, WS._config.aio_user,
+                                        WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP8266.h
+++ b/src/network_interfaces/Wippersnapper_ESP8266.h
@@ -169,17 +169,12 @@ public:
   */
   /*******************************************************************/
   void setupMQTTClient(const char *clientID) {
-    if (WS._mqttBrokerURL == nullptr) {
-      WS._mqttBrokerURL = "io.adafruit.com";
-    }
-
     // Uncomment the following lines to use MQTT/SSL. You will need to
     // re-compile after. _wifi_client->setFingerprint(fingerprint); WS._mqtt =
-    // new Adafruit_MQTT_Client(_wifi_client, WS._mqttBrokerURL, _mqtt_port,
+    // new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, _mqtt_port,
     // clientID, WS._username, WS._key);
 
-    WS._mqtt = new Adafruit_MQTT_Client(_wifi_client, WS._mqttBrokerURL, 1883,
-                                        clientID, WS._username, WS._key);
+    WS._mqtt = new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, 1883, clientID, WS._username, WS._key);
   }
 
   /********************************************************/
@@ -212,7 +207,6 @@ public:
 protected:
   const char *_ssid = NULL;
   const char *_pass = NULL;
-  const char *_mqttBrokerURL = NULL;
   WiFiClient *_wifi_client;
 
   /**************************************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP8266.h
+++ b/src/network_interfaces/Wippersnapper_ESP8266.h
@@ -171,7 +171,7 @@ public:
   void setupMQTTClient(const char *clientID) {
     // Uncomment the following lines to use MQTT/SSL. You will need to
     // re-compile after. _wifi_client->setFingerprint(fingerprint); WS._mqtt =
-    // new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, _mqtt_port,
+    // new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, WS._config.io_port,
     // clientID, WS._config.aio_user, WS._config.aio_key);
 
     WS._mqtt = new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, 1883, clientID, WS._config.aio_user, WS._config.aio_key);

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -94,7 +94,8 @@ public:
   /**********************************************************/
   void set_ssid_pass(const char *ssid, const char *ssidPassword) {
     strlcpy(WS._config.network.ssid, ssid, sizeof(WS._config.network.ssid));
-    strlcpy(WS._config.network.pass, ssidPassword, sizeof(WS._config.network.pass));
+    strlcpy(WS._config.network.pass, ssidPassword,
+            sizeof(WS._config.network.pass));
   }
 
   /**********************************************************/
@@ -192,8 +193,9 @@ public:
   */
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
-    WS._mqtt =
-        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._config.io_port, clientID, WS._config.aio_user, WS._config.aio_key);
+    WS._mqtt = new Adafruit_MQTT_Client(
+        _mqtt_client, WS._config.aio_url, WS._config.io_port, clientID,
+        WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/
@@ -224,10 +226,10 @@ public:
   const char *connectionType() { return "AIRLIFT"; }
 
 protected:
-  const char *_ssid;         /*!< Network SSID. */
-  const char *_pass;         /*!< Network password. */
-  const char* _username;     /*!< Adafruit IO username. */
-  const char* _key;          /*!< Adafruit IO key. */
+  const char *_ssid;     /*!< Network SSID. */
+  const char *_pass;     /*!< Network password. */
+  const char *_username; /*!< Adafruit IO username. */
+  const char *_key;      /*!< Adafruit IO key. */
 
   WiFiSSLClient *_mqtt_client; /*!< Instance of a secure WiFi client. */
   SPIClass *_wifi; /*!< Instance of the SPI bus used by the ublox. */

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -224,8 +224,10 @@ public:
   const char *connectionType() { return "AIRLIFT"; }
 
 protected:
-  const char *_ssid;          /*!< Network SSID. */
-  const char *_pass;          /*!< Network password. */
+  const char *_ssid;         /*!< Network SSID. */
+  const char *_pass;         /*!< Network password. */
+  const char* _username;     /*!< Adafruit IO username. */
+  const char* _key;          /*!< Adafruit IO key. */
 
   WiFiSSLClient *_mqtt_client; /*!< Instance of a secure WiFi client. */
   SPIClass *_wifi; /*!< Instance of the SPI bus used by the ublox. */

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -79,8 +79,8 @@ public:
   */
   /****************************************************************************/
   void set_user_key() {
-    WS._config.aio_user = _username;
-    WS._config.aio_key = _key;
+    strlcpy(WS._config.aio_user, _username, sizeof(WS._config.aio_user));
+    strlcpy(WS._config.aio_key, _key, sizeof(WS._config.aio_key));
   }
 
   /**********************************************************/

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -79,8 +79,8 @@ public:
   */
   /****************************************************************************/
   void set_user_key() {
-    WS._username = _username;
-    WS._key = _key;
+    WS._config.aio_user = _username;
+    WS._config.aio_key = _key;
   }
 
   /**********************************************************/
@@ -194,7 +194,7 @@ public:
   void setupMQTTClient(const char *clientID) {
     WS._mqtt =
         new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port,
-                                 clientID, WS._username, WS._key);
+                                 clientID, WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -104,8 +104,8 @@ public:
   */
   /**********************************************************/
   void set_ssid_pass() {
-    WS._config.network.ssid = _ssid;
-    WS._config.network.pass = _pass;
+    strlcpy(WS._config.network.ssid, _ssid, sizeof(WS._config.network.ssid));
+    strlcpy(WS._config.network.pass, _pass, sizeof(WS._config.network.pass));
   }
 
   /***********************************************************/

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -193,7 +193,7 @@ public:
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
     WS._mqtt =
-        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port,
+        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS.WS._config.io_port,
                                  clientID, WS._config.aio_user, WS._config.aio_key);
   }
 

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -59,7 +59,6 @@ public:
 
     _wifi = &SPIWIFI;
     _mqtt_client = new WiFiSSLClient;
-    WS._mqttBrokerURL = "io.adafruit.com";
   }
 
   /**************************************************************************/
@@ -194,7 +193,7 @@ public:
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
     WS._mqtt =
-        new Adafruit_MQTT_Client(_mqtt_client, WS._mqttBrokerURL, WS._mqtt_port,
+        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port,
                                  clientID, WS._username, WS._key);
   }
 
@@ -228,7 +227,6 @@ public:
 protected:
   const char *_ssid;          /*!< Network SSID. */
   const char *_pass;          /*!< Network password. */
-  const char *_mqttBrokerURL; /*!< MQTT broker URL. */
 
   WiFiSSLClient *_mqtt_client; /*!< Instance of a secure WiFi client. */
   SPIClass *_wifi; /*!< Instance of the SPI bus used by the ublox. */

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -93,8 +93,8 @@ public:
   */
   /**********************************************************/
   void set_ssid_pass(const char *ssid, const char *ssidPassword) {
-    WS._network_ssid = ssid;
-    WS._network_pass = ssidPassword;
+    WS._config.network.ssid = ssid;
+    WS._config.network.pass = ssidPassword;
   }
 
   /**********************************************************/
@@ -104,8 +104,8 @@ public:
   */
   /**********************************************************/
   void set_ssid_pass() {
-    WS._network_ssid = _ssid;
-    WS._network_pass = _pass;
+    WS._config.network.ssid = _ssid;
+    WS._config.network.pass = _pass;
   }
 
   /***********************************************************/

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -93,8 +93,8 @@ public:
   */
   /**********************************************************/
   void set_ssid_pass(const char *ssid, const char *ssidPassword) {
-    WS._config.network.ssid = ssid;
-    WS._config.network.pass = ssidPassword;
+    strlcpy(WS._config.network.ssid, ssid, sizeof(WS._config.network.ssid));
+    strlcpy(WS._config.network.pass, ssidPassword, sizeof(WS._config.network.pass));
   }
 
   /**********************************************************/
@@ -193,8 +193,7 @@ public:
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
     WS._mqtt =
-        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS.WS._config.io_port,
-                                 clientID, WS._config.aio_user, WS._config.aio_key);
+        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._config.io_port, clientID, WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/ws_networking_pico.h
+++ b/src/network_interfaces/ws_networking_pico.h
@@ -82,8 +82,8 @@ public:
   */
   /**********************************************************/
   void set_ssid_pass() {
-    _ssid = WS._network_ssid;
-    _pass = WS._network_pass;
+    _ssid = WS._config.network.ssid;
+    _pass = WS._config.network.pass;
   }
 
   /***********************************************************/

--- a/src/network_interfaces/ws_networking_pico.h
+++ b/src/network_interfaces/ws_networking_pico.h
@@ -154,7 +154,7 @@ public:
 
     WS._mqtt =
         new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port,
-                                 clientID, WS._username, WS._key);
+                                 clientID, WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/ws_networking_pico.h
+++ b/src/network_interfaces/ws_networking_pico.h
@@ -153,7 +153,7 @@ public:
     }
 
     WS._mqtt =
-        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port,
+        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS.WS._config.io_port,
                                  clientID, WS._config.aio_user, WS._config.aio_key);
   }
 

--- a/src/network_interfaces/ws_networking_pico.h
+++ b/src/network_interfaces/ws_networking_pico.h
@@ -145,15 +145,15 @@ public:
   */
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
-    if (WS._mqttBrokerURL == nullptr) {
-      WS._mqttBrokerURL = "io.adafruit.com";
+    // Set CA cert depending on the server we're connecting to
+    if (WS._config.aio_url= nullptr) {
       _mqtt_client->setCACert(_aio_root_ca_prod);
     } else {
       _mqtt_client->setCACert(_aio_root_ca_staging);
     }
 
     WS._mqtt =
-        new Adafruit_MQTT_Client(_mqtt_client, WS._mqttBrokerURL, WS._mqtt_port,
+        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._mqtt_port,
                                  clientID, WS._username, WS._key);
   }
 
@@ -187,7 +187,6 @@ public:
 protected:
   const char *_ssid;              ///< WiFi SSID
   const char *_pass;              ///< WiFi password
-  const char *_mqttBrokerURL;     ///< MQTT broker URL
   WiFiClientSecure *_mqtt_client; ///< Pointer to a secure MQTT client object
 
   const char *_aio_root_ca_staging =

--- a/src/network_interfaces/ws_networking_pico.h
+++ b/src/network_interfaces/ws_networking_pico.h
@@ -154,7 +154,7 @@ public:
     }
 
     WS._mqtt =
-        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS.WS._config.io_port,
+        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._config.io_port,
                                  clientID, WS._config.aio_user, WS._config.aio_key);
   }
 

--- a/src/network_interfaces/ws_networking_pico.h
+++ b/src/network_interfaces/ws_networking_pico.h
@@ -146,7 +146,8 @@ public:
   /********************************************************/
   void setupMQTTClient(const char *clientID) {
     // Set CA cert depending on the server we're connecting to
-    if (WS._config.aio_url= nullptr) {
+    // compare WS._config.aio_url to "io.adafruit.com"
+    if (strcmp(WS._config.aio_url, "io.adafruit.com") == 0) {
       _mqtt_client->setCACert(_aio_root_ca_prod);
     } else {
       _mqtt_client->setCACert(_aio_root_ca_staging);

--- a/src/network_interfaces/ws_networking_pico.h
+++ b/src/network_interfaces/ws_networking_pico.h
@@ -153,9 +153,9 @@ public:
       _mqtt_client->setCACert(_aio_root_ca_staging);
     }
 
-    WS._mqtt =
-        new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, WS._config.io_port,
-                                 clientID, WS._config.aio_user, WS._config.aio_key);
+    WS._mqtt = new Adafruit_MQTT_Client(
+        _mqtt_client, WS._config.aio_url, WS._config.io_port, clientID,
+        WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/provisioning/Config.h
+++ b/src/provisioning/Config.h
@@ -1,3 +1,17 @@
+/*!
+ * @file Config.h
+ *
+ * Contains user-defined structures for WipperSnapper JSON configuration files.
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) Brent Rubell 2024 for Adafruit Industries.
+ *
+ * BSD license, all text here must be included in any redistribution.
+ *
+*/
 #ifndef CONFIG_H
 #define CONFIG_H
 struct networkConfig {

--- a/src/provisioning/Config.h
+++ b/src/provisioning/Config.h
@@ -11,20 +11,20 @@
  *
  * BSD license, all text here must be included in any redistribution.
  *
-*/
+ */
 #ifndef CONFIG_H
 #define CONFIG_H
 struct networkConfig {
-    char ssid[32];
-    char pass[64];
+  char ssid[32];
+  char pass[64];
 };
 
 struct secretsConfig {
-    networkConfig network;
-    char aio_url[64];
-    char aio_user[31];
-    char aio_key[33];
-    uint16_t io_port;
-    float status_pixel_brightness;
+  networkConfig network;
+  char aio_url[64];
+  char aio_user[31];
+  char aio_key[33];
+  uint16_t io_port;
+  float status_pixel_brightness;
 };
 #endif // CONFIG_H

--- a/src/provisioning/Config.h
+++ b/src/provisioning/Config.h
@@ -29,18 +29,18 @@ struct secretsConfig {
 };
 
 struct displayConfigSPI {
-    int pinCs;
-    int pinDc;
-    int pinMosi;
-    int pinSck;
-    int pinRst;
+  int pinCs;
+  int pinDc;
+  int pinMosi;
+  int pinSck;
+  int pinRst;
 };
 
 struct displayConfig {
-    char driver[10];
-    int width;
-    int height;
-    int rotation;
-    displayConfigSPI spiConfig;
+  char driver[10];
+  int width;
+  int height;
+  int rotation;
+  displayConfigSPI spiConfig;
 };
 #endif // CONFIG_H

--- a/src/provisioning/Config.h
+++ b/src/provisioning/Config.h
@@ -7,9 +7,9 @@ struct networkConfig {
 
 struct Config {
     networkConfig network;
-    char server_url[64];
+    char aio_url[64];
     char aio_user[64];
-    char aio_pass[30];
+    char aio_key[30];
     float status_pixel_brightness;
 };
 #endif // CONFIG_H

--- a/src/provisioning/Config.h
+++ b/src/provisioning/Config.h
@@ -10,6 +10,7 @@ struct Config {
     char aio_url[64];
     char aio_user[31];
     char aio_key[33];
+    uint16_t io_port;
     float status_pixel_brightness;
 };
 #endif // CONFIG_H

--- a/src/provisioning/Config.h
+++ b/src/provisioning/Config.h
@@ -27,4 +27,20 @@ struct secretsConfig {
   int io_port;
   float status_pixel_brightness;
 };
+
+struct displayConfigSPI {
+    int pinCs;
+    int pinDc;
+    int pinMosi;
+    int pinSck;
+    int pinRst;
+};
+
+struct displayConfig {
+    char driver[10];
+    int width;
+    int height;
+    int rotation;
+    displayConfigSPI spiConfig;
+};
 #endif // CONFIG_H

--- a/src/provisioning/Config.h
+++ b/src/provisioning/Config.h
@@ -1,5 +1,5 @@
 /*!
- * @file Config.h
+ * @file secretsConfig.h
  *
  * Contains user-defined structures for WipperSnapper JSON configuration files.
  *
@@ -19,7 +19,7 @@ struct networkConfig {
     char pass[64];
 };
 
-struct Config {
+struct secretsConfig {
     networkConfig network;
     char aio_url[64];
     char aio_user[31];

--- a/src/provisioning/Config.h
+++ b/src/provisioning/Config.h
@@ -24,7 +24,7 @@ struct secretsConfig {
   char aio_url[64];
   char aio_user[31];
   char aio_key[33];
-  uint16_t io_port;
+  int io_port;
   float status_pixel_brightness;
 };
 #endif // CONFIG_H

--- a/src/provisioning/Config.h
+++ b/src/provisioning/Config.h
@@ -1,0 +1,19 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+struct networkConfig {
+    char ssid[32];
+    char pass[64];
+};
+
+struct mqttConfig {
+    char server_url[64];
+    char port[6];
+    char aio_user[64];
+    char aio_pass[30];
+};
+
+struct Config {
+    networkConfig network;
+    mqttConfig mqtt;
+};
+#endif // CONFIG_H

--- a/src/provisioning/Config.h
+++ b/src/provisioning/Config.h
@@ -5,15 +5,11 @@ struct networkConfig {
     char pass[64];
 };
 
-struct mqttConfig {
-    char server_url[64];
-    char port[6];
-    char aio_user[64];
-    char aio_pass[30];
-};
-
 struct Config {
     networkConfig network;
-    mqttConfig mqtt;
+    char server_url[64];
+    char aio_user[64];
+    char aio_pass[30];
+    float status_pixel_brightness;
 };
 #endif // CONFIG_H

--- a/src/provisioning/Config.h
+++ b/src/provisioning/Config.h
@@ -8,8 +8,8 @@ struct networkConfig {
 struct Config {
     networkConfig network;
     char aio_url[64];
-    char aio_user[64];
-    char aio_key[30];
+    char aio_user[31];
+    char aio_key[33];
     float status_pixel_brightness;
 };
 #endif // CONFIG_H

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -14,7 +14,13 @@ void convertFromJson(JsonVariantConst src, networkConfig &dst) {
 
 // Converts a Config structure to a JSON variant
 void convertToJson(const Config &src, JsonVariant dst) {
-  dst["network"] = src.network;
+  dst["network_type_wifi"] = src.network;
+  dst["io_username"] = src.aio_user;
+  dst["io_key"] = src.aio_key;
+  // Parse status pixel brightness from secrets
+  dst["status_pixel_brightness"] = src.status_pixel_brightness;
+  // Parse MQTT port from secrets, if exists
+  dst["io_port"] = src.io_port;
 }
 
 // Extracts a JSON file to a Config structure

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -2,8 +2,8 @@
 
 // Converts a network configuration structure to a JSON variant
 void convertToJson(const networkConfig &src, JsonVariant dst) {
-  dst["network_type_wifi"]["network_ssid"] = src.ssid;
-  dst["network_type_wifi"]["network_password"] = src.pass;
+  dst["network_ssid"] = src.ssid;
+  dst["network_password"] = src.pass;
 }
 
 // Extracts a network configuration structure from a JSON variant
@@ -14,13 +14,10 @@ void convertFromJson(JsonVariantConst src, networkConfig &dst) {
 
 // Converts a Config structure to a JSON variant
 void convertToJson(const Config &src, JsonVariant dst) {
-  dst["network_type_wifi"] = src.network;
   dst["io_username"] = src.aio_user;
   dst["io_key"] = src.aio_key;
-  // Parse status pixel brightness from secrets
+  dst["network_type_wifi"] = src.network;
   dst["status_pixel_brightness"] = src.status_pixel_brightness;
-  // Parse MQTT port from secrets, if exists
-  dst["io_port"] = src.io_port;
 }
 
 // Extracts a JSON file to a Config structure

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -10,8 +10,8 @@ void convertToJson(const networkConfig &src, JsonVariant dst) {
 // Extracts an ApConfig from JSON
 // (automatically called by `dst.accessPoint[dst.accessPoints] = ap`)
 void convertFromJson(JsonVariantConst src, networkConfig &dst) {
-  strlcpy(dst.ssid, src["network_type_wifi"]["network_ssid"] | "testvar", sizeof(dst.ssid));
-  strlcpy(dst.pass, src["network_type_wifi"]["network_password"] | "testvar", sizeof(dst.pass));
+  strlcpy(dst.ssid, src["network_ssid"] | "testvar", sizeof(dst.ssid));
+  strlcpy(dst.pass, src["network_password"] | "testvar", sizeof(dst.pass));
 }
 
 // Extracts a ServerConfig to JSON
@@ -42,6 +42,6 @@ void convertToJson(const Config &src, JsonVariant dst) {
 // Extracts a Config from JSON
 // (automatically called by `doc.set(config)`)
 void convertFromJson(JsonVariantConst src, Config &dst) {
-  dst.network = src["network"];
+  dst.network = src["network_type_wifi"];
   dst.mqtt = src["mqtt"];
 }

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -48,3 +48,38 @@ void convertFromJson(JsonVariantConst src, secretsConfig &dst) {
   // Parse MQTT port from secrets, if exists
   dst.io_port = src["io_port"] | 8883;
 }
+
+// Converts a displayConfigSPI structure to a JSON variant
+void convertToJson(const displayConfigSPI &src, JsonVariant dst) {
+    dst["pin_cs"] = src.pinCs;
+    dst["pin_dc"] = src.pinDc;
+    dst["pin_mosi"] = src.pinMosi;
+    dst["pin_sck"] = src.pinSck;
+    dst["pin_rst"] = src.pinRst;
+}
+
+// Extracts a displayConfigSPI structure from a JSON variant
+void convertFromJson(JsonVariantConst src, displayConfigSPI &dst) {
+    dst.pinCs = src["pin_cs"] | 40;
+    dst.pinDc = src["pin_dc"] | 39;
+    dst.pinMosi = src["pin_mosi"] | 0;
+    dst.pinSck = src["pin_sck"] | 0;
+    dst.pinRst = src["pin_rst"] | 41;
+}
+
+// Converts a displayConfig structure to a JSON variant
+void convertToJson(const displayConfig &src, JsonVariant dst) {
+    dst["driver"] = src.driver;
+    dst["width"] = src.width;
+    dst["height"] = src.height;
+    dst["rotation"] = src.rotation;
+}
+
+// Extracts a displayConfig structure from a JSON variant
+void convertFromJson(JsonVariantConst src, displayConfig &dst) {
+    strlcpy(dst.driver, src["driver"] | "ST7789", sizeof(dst.driver));
+    dst.width = src["width"] | 128;
+    dst.height = src["height"] | 64;
+    dst.rotation = src["rotation"] | 0;
+    dst.spiConfig = src["spi_config"];
+}

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -23,8 +23,8 @@ void convertFromJson(JsonVariantConst src, Config &dst) {
   dst.network = src["network_type_wifi"];
   // Parse IO credentials from secrets
   strlcpy(dst.aio_user, src["io_username"] | "YOUR_IO_USERNAME_HERE", sizeof(dst.aio_user));
-  strlcpy(dst.aio_user, src["io_key"] | "YOUR_IO_KEY_HERE", sizeof(dst.aio_pass));
-  strlcpy(dst.aio_user, src["io_url"] | "io.adafruit.com", sizeof(dst.server_url));
+  strlcpy(dst.aio_key, src["io_key"] | "YOUR_IO_KEY_HERE", sizeof(dst.aio_key));
+  strlcpy(dst.aio_url, src["io_url"] | "io.adafruit.com", sizeof(dst.aio_url));
   // Parse status pixel brightness from secrets
   dst.status_pixel_brightness = src["status_pixel_brightness"] | 0.2;
 }

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -1,47 +1,30 @@
 #include "ConfigJson.h"
 
-// Converts an ApConfig to JSON
-// (automatically called by `aps.add(src.accessPoint[i])`)
+// Converts a network configuration structure to a JSON variant
 void convertToJson(const networkConfig &src, JsonVariant dst) {
   dst["network_type_wifi"]["network_ssid"] = src.ssid;
   dst["network_type_wifi"]["network_password"] = src.pass;
 }
 
-// Extracts an ApConfig from JSON
-// (automatically called by `dst.accessPoint[dst.accessPoints] = ap`)
+// Extracts a network configuration structure from a JSON variant
 void convertFromJson(JsonVariantConst src, networkConfig &dst) {
   strlcpy(dst.ssid, src["network_ssid"] | "testvar", sizeof(dst.ssid));
   strlcpy(dst.pass, src["network_password"] | "testvar", sizeof(dst.pass));
 }
 
-// Extracts a ServerConfig to JSON
-// (automatically called by `dst["server"] = src.server`)
-void convertToJson(const mqttConfig &src, JsonVariant dst) {
-  dst["io_username"] = src.aio_user;
-  dst["io_key"] = src.aio_pass;
-  dst["url"] = src.server_url;
-  dst["port"] = 8883;
-}
-
-// Convert a ServerConfig from JSON
-// (automatically called by `dst.server = src["server"]`)
-void convertFromJson(JsonVariantConst src, mqttConfig &dst) {
-  strlcpy(dst.aio_user, src["io_username"] | "iousertest", sizeof(dst.aio_user));
-  strlcpy(dst.aio_pass, src["io_key"] | "iokeytest", sizeof(dst.aio_pass));
-  strlcpy(dst.server_url, src["io_url"] | "io.adafruit.com", sizeof(dst.server_url));
-  strlcpy(dst.port, src["port"] | "8883", sizeof(dst.port));
-}
-
-// Converts a Config to JSON
-// (automatically called by `config = doc.as<Config>()`)
+// Converts a Config structure to a JSON variant
 void convertToJson(const Config &src, JsonVariant dst) {
   dst["network"] = src.network;
-  dst["mqtt"] = src.mqtt;
 }
 
-// Extracts a Config from JSON
-// (automatically called by `doc.set(config)`)
+// Extracts a JSON file to a Config structure
 void convertFromJson(JsonVariantConst src, Config &dst) {
+  // Parse network credentials from secrets
   dst.network = src["network_type_wifi"];
-  dst.mqtt = src["mqtt"];
+  // Parse IO credentials from secrets
+  strlcpy(dst.aio_user, src["io_username"] | "YOUR_IO_USERNAME_HERE", sizeof(dst.aio_user));
+  strlcpy(dst.aio_user, src["io_key"] | "YOUR_IO_KEY_HERE", sizeof(dst.aio_pass));
+  strlcpy(dst.aio_user, src["io_url"] | "io.adafruit.com", sizeof(dst.server_url));
+  // Parse status pixel brightness from secrets
+  dst.status_pixel_brightness = src["status_pixel_brightness"] | 0.2;
 }

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -27,4 +27,6 @@ void convertFromJson(JsonVariantConst src, Config &dst) {
   strlcpy(dst.aio_url, src["io_url"] | "io.adafruit.com", sizeof(dst.aio_url));
   // Parse status pixel brightness from secrets
   dst.status_pixel_brightness = src["status_pixel_brightness"] | 0.2;
+  // Parse MQTT port from secrets, if exists
+  dst.io_port = src["io_port"] | 8883;
 }

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -26,16 +26,16 @@ void convertFromJson(JsonVariantConst src, networkConfig &dst) {
   strlcpy(dst.pass, src["network_password"] | "testvar", sizeof(dst.pass));
 }
 
-// Converts a Config structure to a JSON variant
-void convertToJson(const Config &src, JsonVariant dst) {
+// Converts a secretsConfig structure to a JSON variant
+void convertToJson(const secretsConfig &src, JsonVariant dst) {
   dst["io_username"] = src.aio_user;
   dst["io_key"] = src.aio_key;
   dst["network_type_wifi"] = src.network;
   dst["status_pixel_brightness"] = src.status_pixel_brightness;
 }
 
-// Extracts a JSON file to a Config structure
-void convertFromJson(JsonVariantConst src, Config &dst) {
+// Extracts a JSON file to a secretsConfig structure
+void convertFromJson(JsonVariantConst src, secretsConfig &dst) {
   // Parse network credentials from secrets
   dst.network = src["network_type_wifi"];
   // Parse IO credentials from secrets

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -51,35 +51,36 @@ void convertFromJson(JsonVariantConst src, secretsConfig &dst) {
 
 // Converts a displayConfigSPI structure to a JSON variant
 void convertToJson(const displayConfigSPI &src, JsonVariant dst) {
-    dst["pin_cs"] = src.pinCs;
-    dst["pin_dc"] = src.pinDc;
-    dst["pin_mosi"] = src.pinMosi;
-    dst["pin_sck"] = src.pinSck;
-    dst["pin_rst"] = src.pinRst;
+  dst["pin_cs"] = src.pinCs;
+  dst["pin_dc"] = src.pinDc;
+  dst["pin_mosi"] = src.pinMosi;
+  dst["pin_sck"] = src.pinSck;
+  dst["pin_rst"] = src.pinRst;
 }
 
 // Extracts a displayConfigSPI structure from a JSON variant
 void convertFromJson(JsonVariantConst src, displayConfigSPI &dst) {
-    dst.pinCs = src["pin_cs"] | 40;
-    dst.pinDc = src["pin_dc"] | 39;
-    dst.pinMosi = src["pin_mosi"] | 0;
-    dst.pinSck = src["pin_sck"] | 0;
-    dst.pinRst = src["pin_rst"] | 41;
+  dst.pinCs = src["pin_cs"] | 40;
+  dst.pinDc = src["pin_dc"] | 39;
+  dst.pinMosi = src["pin_mosi"] | 0;
+  dst.pinSck = src["pin_sck"] | 0;
+  dst.pinRst = src["pin_rst"] | 41;
 }
 
 // Converts a displayConfig structure to a JSON variant
 void convertToJson(const displayConfig &src, JsonVariant dst) {
-    dst["driver"] = src.driver;
-    dst["width"] = src.width;
-    dst["height"] = src.height;
-    dst["rotation"] = src.rotation;
+  dst["driver"] = src.driver;
+  dst["width"] = src.width;
+  dst["height"] = src.height;
+  dst["rotation"] = src.rotation;
+  dst["spi_config"] = src.spiConfig;
 }
 
 // Extracts a displayConfig structure from a JSON variant
 void convertFromJson(JsonVariantConst src, displayConfig &dst) {
-    strlcpy(dst.driver, src["driver"] | "ST7789", sizeof(dst.driver));
-    dst.width = src["width"] | 128;
-    dst.height = src["height"] | 64;
-    dst.rotation = src["rotation"] | 0;
-    dst.spiConfig = src["spi_config"];
+  strlcpy(dst.driver, src["driver"] | "ST7789", sizeof(dst.driver));
+  dst.width = src["width"] | 128;
+  dst.height = src["height"] | 64;
+  dst.rotation = src["rotation"] | 0;
+  dst.spiConfig = src["spi_config"];
 }

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -1,0 +1,47 @@
+#include "ConfigJson.h"
+
+// Converts an ApConfig to JSON
+// (automatically called by `aps.add(src.accessPoint[i])`)
+void convertToJson(const networkConfig &src, JsonVariant dst) {
+  dst["network_type_wifi"]["network_ssid"] = src.ssid;
+  dst["network_type_wifi"]["network_password"] = src.pass;
+}
+
+// Extracts an ApConfig from JSON
+// (automatically called by `dst.accessPoint[dst.accessPoints] = ap`)
+void convertFromJson(JsonVariantConst src, networkConfig &dst) {
+  strlcpy(dst.ssid, src["network_type_wifi"]["network_ssid"] | "testvar", sizeof(dst.ssid));
+  strlcpy(dst.pass, src["network_type_wifi"]["network_password"] | "testvar", sizeof(dst.pass));
+}
+
+// Extracts a ServerConfig to JSON
+// (automatically called by `dst["server"] = src.server`)
+void convertToJson(const mqttConfig &src, JsonVariant dst) {
+  dst["io_username"] = src.aio_user;
+  dst["io_key"] = src.aio_pass;
+  dst["url"] = src.server_url;
+  dst["port"] = 8883;
+}
+
+// Convert a ServerConfig from JSON
+// (automatically called by `dst.server = src["server"]`)
+void convertFromJson(JsonVariantConst src, mqttConfig &dst) {
+  strlcpy(dst.aio_user, src["io_username"] | "iousertest", sizeof(dst.aio_user));
+  strlcpy(dst.aio_pass, src["io_key"] | "iokeytest", sizeof(dst.aio_pass));
+  strlcpy(dst.server_url, src["io_url"] | "io.adafruit.com", sizeof(dst.server_url));
+  strlcpy(dst.port, src["port"] | "8883", sizeof(dst.port));
+}
+
+// Converts a Config to JSON
+// (automatically called by `config = doc.as<Config>()`)
+void convertToJson(const Config &src, JsonVariant dst) {
+  dst["network"] = src.network;
+  dst["mqtt"] = src.mqtt;
+}
+
+// Extracts a Config from JSON
+// (automatically called by `doc.set(config)`)
+void convertFromJson(JsonVariantConst src, Config &dst) {
+  dst.network = src["network"];
+  dst.mqtt = src["mqtt"];
+}

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -1,3 +1,17 @@
+/*!
+ * @file ConfigJson.cpp
+ *
+ * Wippersnapper JSON Config File Converters
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) Brent Rubell 2024 for Adafruit Industries.
+ *
+ * BSD license, all text here must be included in any redistribution.
+ *
+*/
 #include "ConfigJson.h"
 
 // Converts a network configuration structure to a JSON variant

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -11,7 +11,7 @@
  *
  * BSD license, all text here must be included in any redistribution.
  *
-*/
+ */
 #include "ConfigJson.h"
 
 // Converts a network configuration structure to a JSON variant
@@ -39,7 +39,8 @@ void convertFromJson(JsonVariantConst src, secretsConfig &dst) {
   // Parse network credentials from secrets
   dst.network = src["network_type_wifi"];
   // Parse IO credentials from secrets
-  strlcpy(dst.aio_user, src["io_username"] | "YOUR_IO_USERNAME_HERE", sizeof(dst.aio_user));
+  strlcpy(dst.aio_user, src["io_username"] | "YOUR_IO_USERNAME_HERE",
+          sizeof(dst.aio_user));
   strlcpy(dst.aio_key, src["io_key"] | "YOUR_IO_KEY_HERE", sizeof(dst.aio_key));
   strlcpy(dst.aio_url, src["io_url"] | "io.adafruit.com", sizeof(dst.aio_url));
   // Parse status pixel brightness from secrets

--- a/src/provisioning/ConfigJson.h
+++ b/src/provisioning/ConfigJson.h
@@ -1,0 +1,11 @@
+#ifndef CONFIGJSON_H
+#define CONFIGJSON_H
+#define ARDUINOJSON_USE_DOUBLE 0
+#define ARDUINOJSON_USE_LONG_LONG 1
+#include <ArduinoJson.h>
+#include "Config.h"
+
+// Convert Config from/to JSON
+void convertToJson(const Config &src, JsonVariant dst);
+void convertFromJson(JsonVariantConst src, Config &dst);
+#endif // CONFIGJSON_H

--- a/src/provisioning/ConfigJson.h
+++ b/src/provisioning/ConfigJson.h
@@ -19,7 +19,10 @@
 #include "Config.h"
 #include <ArduinoJson.h>
 
-// Convert secretsConfig from/to JSON
+// Converters for secrets configuration
 void convertToJson(const secretsConfig &src, JsonVariant dst);
 void convertFromJson(JsonVariantConst src, secretsConfig &dst);
+// Converters for display configuration
+void convertToJson(const displayConfig &src, JsonVariant dst);
+void convertFromJson(JsonVariantConst src, displayConfig &dst);
 #endif // CONFIGJSON_H

--- a/src/provisioning/ConfigJson.h
+++ b/src/provisioning/ConfigJson.h
@@ -1,7 +1,7 @@
 /*!
  * @file ConfigJson.h
  *
- * Wippersnapper JSON Config File Converters
+ * Wippersnapper JSON secretsConfig File Converters
  *
  * Adafruit invests time and resources providing this open source code,
  * please support Adafruit and open-source hardware by purchasing
@@ -19,7 +19,7 @@
 #include <ArduinoJson.h>
 #include "Config.h"
 
-// Convert Config from/to JSON
-void convertToJson(const Config &src, JsonVariant dst);
-void convertFromJson(JsonVariantConst src, Config &dst);
+// Convert secretsConfig from/to JSON
+void convertToJson(const secretsConfig &src, JsonVariant dst);
+void convertFromJson(JsonVariantConst src, secretsConfig &dst);
 #endif // CONFIGJSON_H

--- a/src/provisioning/ConfigJson.h
+++ b/src/provisioning/ConfigJson.h
@@ -11,13 +11,13 @@
  *
  * BSD license, all text here must be included in any redistribution.
  *
-*/
+ */
 #ifndef CONFIGJSON_H
 #define CONFIGJSON_H
 #define ARDUINOJSON_USE_DOUBLE 0
 #define ARDUINOJSON_USE_LONG_LONG 1
-#include <ArduinoJson.h>
 #include "Config.h"
+#include <ArduinoJson.h>
 
 // Convert secretsConfig from/to JSON
 void convertToJson(const secretsConfig &src, JsonVariant dst);

--- a/src/provisioning/ConfigJson.h
+++ b/src/provisioning/ConfigJson.h
@@ -1,3 +1,17 @@
+/*!
+ * @file ConfigJson.h
+ *
+ * Wippersnapper JSON Config File Converters
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) Brent Rubell 2024 for Adafruit Industries.
+ *
+ * BSD license, all text here must be included in any redistribution.
+ *
+*/
 #ifndef CONFIGJSON_H
 #define CONFIGJSON_H
 #define ARDUINOJSON_USE_DOUBLE 0

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -49,84 +49,40 @@ WipperSnapper_LittleFS::~WipperSnapper_LittleFS() { LittleFS.end(); }
 */
 /**************************************************************************/
 void WipperSnapper_LittleFS::parseSecrets() {
-
-  // Check if `secrets.json` file exists on FS
-  if (!LittleFS.exists("/secrets.json")) {
-    WS_DEBUG_PRINTLN("ERROR: No secrets.json found on filesystem - did you "
-                     "upload credentials?");
-    fsHalt();
-  }
-
-  // open file for parsing
+  // Attempt to open secrets.json file for reading
   File secretsFile = LittleFS.open("/secrets.json", "r");
   if (!secretsFile) {
     WS_DEBUG_PRINTLN("ERROR: Could not open secrets.json file for reading!");
     fsHalt();
   }
 
+  // Attempt to deserialize the file's JSON document
   JsonDocument doc;
-  // check if we can deserialize the secrets.json file
   DeserializationError error = deserializeJson(doc, secretsFile);
   if (error) {
     WS_DEBUG_PRINT("ERROR: deserializeJson() failed with code ");
     WS_DEBUG_PRINTLN(error.c_str());
     fsHalt();
   }
-  // close the file
+
+  // Extract a config struct from the JSON document
+   WS._config =  doc.as<Config>();
+
+  // Validate the config struct is not filled with default values
+  if (strcmp(WS._config.aio_user, "YOUR_IO_USERNAME_HERE") == 0 || strcmp(WS._config.aio_key, "YOUR_IO_KEY_HERE") == 0) {
+    WS_DEBUG_PRINTLN("ERROR: Invalid IO credentials in secrets.json! TO FIX: Please change io_username and io_key to match your Adafruit IO credentials!\n");
+    fsHalt();
+  }
+
+  if (strcmp(WS._config.network.ssid, "YOUR_WIFI_SSID_HERE") == 0 || strcmp(WS._config.network.pass, "YOUR_WIFI_PASS_HERE") == 0) {
+    WS_DEBUG_PRINTLN("ERROR: Invalid network credentials in secrets.json! TO FIX: Please change network_ssid and network_password to match your Adafruit IO credentials!\n");
+    fsHalt();
+  }
+
+  // Close the file
   secretsFile.close();
 
-  // Get IO username from JSON
-  const char *io_username = doc["io_username"]; // "YOUR_IO_USERNAME_HERE"
-  // error check against default values [ArduinoJSON, 3.3.3]
-  if (io_username == nullptr) {
-    WS_DEBUG_PRINTLN("ERROR: io_username not set!");
-    fsHalt();
-  }
-  // Set IO username
-  WS._config.aio_user = io_username;
-
-  // Get IO key from JSON
-  const char *io_key = doc["io_key"]; // "YOUR_IO_KEY_HERE"
-  // error check against default values [ArduinoJSON, 3.3.3]
-  if (io_key == nullptr) {
-    WS_DEBUG_PRINTLN("ERROR: io_key not set!");
-    fsHalt();
-  }
-  // Set IO key
-  WS._config.aio_key = io_key;
-
-  // Parse SSID
-  // Check if network type is WiFi
-  const char *network_type_wifi_network_ssid =
-      doc["network_type_wifi"]["network_ssid"];
-  if (network_type_wifi_network_ssid != nullptr) {
-    WS._config.network.ssid = network_type_wifi_network_ssid;
-  }
-
-  if (WS._config.network.ssid == nullptr) {
-    WS_DEBUG_PRINTLN("ERROR: network_ssid not set!");
-    fsHalt();
-  }
-
-  // Parse WiFi network password
-  const char *network_type_wifi_network_password =
-      doc["network_type_wifi"]["network_password"];
-  if (network_type_wifi_network_password != nullptr) {
-    WS._config.network.pass = network_type_wifi_network_password;
-  }
-
-  // error check WiFi network password
-  if (WS._config.network.pass == nullptr) {
-    WS_DEBUG_PRINTLN("ERROR: network_password not set!");
-    fsHalt();
-  }
-
-  // Get (optional) setting for the status pixel brightness
-  float status_pixel_brightness = doc["status_pixel_brightness"];
-  // Note: ArduinoJSON's default value on failure to find is 0.0
-  setStatusLEDBrightness(status_pixel_brightness);
-
-  // stop LittleFS, we no longer need it
+  // Stop LittleFS, we no longer need it
   LittleFS.end();
 }
 

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -83,7 +83,7 @@ void WipperSnapper_LittleFS::parseSecrets() {
     fsHalt();
   }
   // Set IO username
-  WS._username = io_username;
+  WS._config.aio_user = io_username;
 
   // Get IO key from JSON
   const char *io_key = doc["io_key"]; // "YOUR_IO_KEY_HERE"
@@ -93,7 +93,7 @@ void WipperSnapper_LittleFS::parseSecrets() {
     fsHalt();
   }
   // Set IO key
-  WS._key = io_key;
+  WS._config.aio_key = io_key;
 
   // Parse SSID
   // Check if network type is WiFi

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -66,16 +66,22 @@ void WipperSnapper_LittleFS::parseSecrets() {
   }
 
   // Extract a config struct from the JSON document
-   WS._config =  doc.as<secretsConfig>();
+  WS._config = doc.as<secretsConfig>();
 
   // Validate the config struct is not filled with default values
-  if (strcmp(WS._config.aio_user, "YOUR_IO_USERNAME_HERE") == 0 || strcmp(WS._config.aio_key, "YOUR_IO_KEY_HERE") == 0) {
-    WS_DEBUG_PRINTLN("ERROR: Invalid IO credentials in secrets.json! TO FIX: Please change io_username and io_key to match your Adafruit IO credentials!\n");
+  if (strcmp(WS._config.aio_user, "YOUR_IO_USERNAME_HERE") == 0 ||
+      strcmp(WS._config.aio_key, "YOUR_IO_KEY_HERE") == 0) {
+    WS_DEBUG_PRINTLN(
+        "ERROR: Invalid IO credentials in secrets.json! TO FIX: Please change "
+        "io_username and io_key to match your Adafruit IO credentials!\n");
     fsHalt();
   }
 
-  if (strcmp(WS._config.network.ssid, "YOUR_WIFI_SSID_HERE") == 0 || strcmp(WS._config.network.pass, "YOUR_WIFI_PASS_HERE") == 0) {
-    WS_DEBUG_PRINTLN("ERROR: Invalid network credentials in secrets.json! TO FIX: Please change network_ssid and network_password to match your Adafruit IO credentials!\n");
+  if (strcmp(WS._config.network.ssid, "YOUR_WIFI_SSID_HERE") == 0 ||
+      strcmp(WS._config.network.pass, "YOUR_WIFI_PASS_HERE") == 0) {
+    WS_DEBUG_PRINTLN("ERROR: Invalid network credentials in secrets.json! TO "
+                     "FIX: Please change network_ssid and network_password to "
+                     "match your Adafruit IO credentials!\n");
     fsHalt();
   }
 

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -49,6 +49,13 @@ WipperSnapper_LittleFS::~WipperSnapper_LittleFS() { LittleFS.end(); }
 */
 /**************************************************************************/
 void WipperSnapper_LittleFS::parseSecrets() {
+  // Check if `secrets.json` file exists on FS
+  if (!LittleFS.exists("/secrets.json")) {
+    WS_DEBUG_PRINTLN("ERROR: No secrets.json found on filesystem - did you "
+                     "upload credentials?");
+    fsHalt();
+  }
+
   // Attempt to open secrets.json file for reading
   File secretsFile = LittleFS.open("/secrets.json", "r");
   if (!secretsFile) {

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -121,9 +121,6 @@ void WipperSnapper_LittleFS::parseSecrets() {
     fsHalt();
   }
 
-  // Optionally set the Adafruit.io URL
-  WS._mqttBrokerURL = doc["io_url"];
-
   // Get (optional) setting for the status pixel brightness
   float status_pixel_brightness = doc["status_pixel_brightness"];
   // Note: ArduinoJSON's default value on failure to find is 0.0

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -64,6 +64,8 @@ void WipperSnapper_LittleFS::parseSecrets() {
     fsHalt();
   }
 
+  //JsonDocument doc;
+
   // check if we can deserialize the secrets.json file
   DeserializationError err = deserializeJson(_doc, secretsFile);
   if (err) {

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -64,18 +64,19 @@ void WipperSnapper_LittleFS::parseSecrets() {
     fsHalt();
   }
 
-  //JsonDocument doc;
-
+  JsonDocument doc;
   // check if we can deserialize the secrets.json file
-  DeserializationError err = deserializeJson(_doc, secretsFile);
-  if (err) {
+  DeserializationError error = deserializeJson(doc, secretsFile);
+  if (error) {
     WS_DEBUG_PRINT("ERROR: deserializeJson() failed with code ");
-    WS_DEBUG_PRINTLN(err.c_str());
+    WS_DEBUG_PRINTLN(error.c_str());
     fsHalt();
   }
+  // close the file
+  secretsFile.close();
 
   // Get IO username from JSON
-  const char *io_username = _doc["io_username"];
+  const char *io_username = doc["io_username"]; // "YOUR_IO_USERNAME_HERE"
   // error check against default values [ArduinoJSON, 3.3.3]
   if (io_username == nullptr) {
     WS_DEBUG_PRINTLN("ERROR: io_username not set!");
@@ -85,7 +86,7 @@ void WipperSnapper_LittleFS::parseSecrets() {
   WS._username = io_username;
 
   // Get IO key from JSON
-  const char *io_key = _doc["io_key"];
+  const char *io_key = doc["io_key"]; // "YOUR_IO_KEY_HERE"
   // error check against default values [ArduinoJSON, 3.3.3]
   if (io_key == nullptr) {
     WS_DEBUG_PRINTLN("ERROR: io_key not set!");
@@ -96,10 +97,10 @@ void WipperSnapper_LittleFS::parseSecrets() {
 
   // Parse SSID
   // Check if network type is WiFi
-  const char *network_type_wifi_ssid =
-      _doc["network_type_wifi"]["network_ssid"];
-  if (network_type_wifi_ssid != nullptr) {
-    WS._network_ssid = network_type_wifi_ssid;
+  const char *network_type_wifi_network_ssid =
+      doc["network_type_wifi"]["network_ssid"];
+  if (network_type_wifi_network_ssid != nullptr) {
+    WS._network_ssid = network_type_wifi_network_ssid;
   }
 
   if (WS._network_ssid == nullptr) {
@@ -108,10 +109,10 @@ void WipperSnapper_LittleFS::parseSecrets() {
   }
 
   // Parse WiFi network password
-  const char *network_type_wifi_password =
-      _doc["network_type_wifi"]["network_password"];
-  if (network_type_wifi_password != nullptr) {
-    WS._network_pass = network_type_wifi_password;
+  const char *network_type_wifi_network_password =
+      doc["network_type_wifi"]["network_password"];
+  if (network_type_wifi_network_password != nullptr) {
+    WS._network_pass = network_type_wifi_network_password;
   }
 
   // error check WiFi network password
@@ -121,18 +122,12 @@ void WipperSnapper_LittleFS::parseSecrets() {
   }
 
   // Optionally set the Adafruit.io URL
-  WS._mqttBrokerURL = _doc["io_url"];
+  WS._mqttBrokerURL = doc["io_url"];
 
   // Get (optional) setting for the status pixel brightness
-  float status_pixel_brightness = _doc["status_pixel_brightness"];
+  float status_pixel_brightness = doc["status_pixel_brightness"];
   // Note: ArduinoJSON's default value on failure to find is 0.0
   setStatusLEDBrightness(status_pixel_brightness);
-
-  // close the file
-  secretsFile.close();
-
-  // clear the document and release all memory from the memory pool
-  _doc.clear();
 
   // stop LittleFS, we no longer need it
   LittleFS.end();

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -66,7 +66,7 @@ void WipperSnapper_LittleFS::parseSecrets() {
   }
 
   // Extract a config struct from the JSON document
-   WS._config =  doc.as<Config>();
+   WS._config =  doc.as<secretsConfig>();
 
   // Validate the config struct is not filled with default values
   if (strcmp(WS._config.aio_user, "YOUR_IO_USERNAME_HERE") == 0 || strcmp(WS._config.aio_key, "YOUR_IO_KEY_HERE") == 0) {

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -100,10 +100,10 @@ void WipperSnapper_LittleFS::parseSecrets() {
   const char *network_type_wifi_network_ssid =
       doc["network_type_wifi"]["network_ssid"];
   if (network_type_wifi_network_ssid != nullptr) {
-    WS._network_ssid = network_type_wifi_network_ssid;
+    WS._config.network.ssid = network_type_wifi_network_ssid;
   }
 
-  if (WS._network_ssid == nullptr) {
+  if (WS._config.network.ssid == nullptr) {
     WS_DEBUG_PRINTLN("ERROR: network_ssid not set!");
     fsHalt();
   }
@@ -112,11 +112,11 @@ void WipperSnapper_LittleFS::parseSecrets() {
   const char *network_type_wifi_network_password =
       doc["network_type_wifi"]["network_password"];
   if (network_type_wifi_network_password != nullptr) {
-    WS._network_pass = network_type_wifi_network_password;
+    WS._config.network.pass = network_type_wifi_network_password;
   }
 
   // error check WiFi network password
-  if (WS._network_pass == nullptr) {
+  if (WS._config.network.pass == nullptr) {
     WS_DEBUG_PRINTLN("ERROR: network_password not set!");
     fsHalt();
   }

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.h
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.h
@@ -16,6 +16,8 @@
 #define WIPPERSNAPPER_LITTLEFS_H
 
 #include "Wippersnapper.h"
+#define ARDUINOJSON_USE_DOUBLE 0
+#define ARDUINOJSON_USE_LONG_LONG 1
 #include <ArduinoJson.h>
 #include <FS.h>
 #include <LittleFS.h>
@@ -32,15 +34,8 @@ class WipperSnapper_LittleFS {
 public:
   WipperSnapper_LittleFS();
   ~WipperSnapper_LittleFS();
-
   void parseSecrets();
   void fsHalt();
-
-private:
-  // NOTE: calculated capacity with maximum
-  // length of usernames/passwords/tokens
-  // is 382 bytes, rounded to nearest power of 2.
-  StaticJsonDocument<512> _doc; /*!< Json configuration file */
 };
 
 extern Wippersnapper WS;

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.h
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.h
@@ -7,7 +7,7 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Copyright (c) Brent Rubell 2021-2022 for Adafruit Industries.
+ * Copyright (c) Brent Rubell 2021-2024 for Adafruit Industries.
  *
  * BSD license, all text here must be included in any redistribution.
  *
@@ -16,9 +16,7 @@
 #define WIPPERSNAPPER_LITTLEFS_H
 
 #include "Wippersnapper.h"
-#define ARDUINOJSON_USE_DOUBLE 0
-#define ARDUINOJSON_USE_LONG_LONG 1
-#include <ArduinoJson.h>
+
 #include <FS.h>
 #include <LittleFS.h>
 

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -529,7 +529,7 @@ void Wippersnapper_FS::parseDisplayConfig(displayConfig &displayFile) {
   JsonObject spi = doc["spi"];
   if (spi != nullptr) {
     displayFile.isSPI = true;             // indicate that we're using SPI bus
-    int spi_spiMode = spi["spiMode"];     // 1
+    displayFile.spiMode= spi["spiMode"];  // 1
     displayFile.pinCS = spi["pinCs"];     // 40
     displayFile.pinDC = spi["pinDc"];     // 39
     displayFile.pinMOSI = spi["pinMosi"]; // 0

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -296,15 +296,15 @@ void Wippersnapper_FS::createSecretsFile() {
   // Open file for writing
   File32 secretsFile = wipperFatFs.open("/secrets.json", FILE_WRITE);
   
-  // Create a default Config structure
-  Config secretsConfig;
+  // Create a default secretsConfig structure
+  secretsConfig secretsConfig;
   strcpy(secretsConfig.aio_user, "YOUR_IO_USERNAME_HERE");
   strcpy(secretsConfig.aio_key, "YOUR_IO_KEY_HERE");
   strcpy(secretsConfig.network.ssid, "YOUR_WIFI_SSID_HERE");
   strcpy(secretsConfig.network.pass, "YOUR_WIFI_PASS_HERE");
   secretsConfig.status_pixel_brightness = 0.2;
 
-  // Create and fill JSON document from Config
+  // Create and fill JSON document from secretsConfig
   JsonDocument doc;
   doc.set(secretsConfig);
 
@@ -351,7 +351,7 @@ void Wippersnapper_FS::parseSecrets() {
   }
 
   // Extract a config struct from the JSON document
-   WS._config =  doc.as<Config>();
+   WS._config =  doc.as<secretsConfig>();
 
   // Validate the config struct is not filled with default values
   if (strcmp(WS._config.aio_user, "YOUR_IO_USERNAME_HERE") == 0 || strcmp(WS._config.aio_key, "YOUR_IO_KEY_HERE") == 0) {

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -332,14 +332,14 @@ void Wippersnapper_FS::createSecretsFile() {
 */
 /**************************************************************************/
 void Wippersnapper_FS::parseSecrets() {
-
-  // open file for parsing
+  // Attempt to open the secrets.json file for reading
   File32 secretsFile = wipperFatFs.open("/secrets.json");
   if (!secretsFile) {
     WS_DEBUG_PRINTLN("ERROR: Could not open secrets.json file for reading!");
     fsHalt();
   }
 
+  // Attempt to deserialize the file's JSON document
   JsonDocument doc;
   DeserializationError error = deserializeJson(doc, secretsFile);
   if (error) {
@@ -347,20 +347,19 @@ void Wippersnapper_FS::parseSecrets() {
     fsHalt();
   }
   
-  // Extract config struct from the JSON document
+  // Extract a config struct from the JSON document
    WS._config =  doc.as<Config>();
+
+  // Close secrets.json file
+  secretsFile.close();
 
   // Optionally set the MQTT broker url (used to switch btween prod. and
   // staging)
+  // TODO: this needs to be changed
   WS._mqttBrokerURL = doc["io_url"];
 
-  // Get (optional) setting for the status pixel brightness
-  float status_pixel_brightness = doc["status_pixel_brightness"]; // default is "0.2"
-  // Note: ArduinoJSON's default value on failure to find is 0.0
-  setStatusLEDBrightness(status_pixel_brightness);
-
-  // close the tempFile
-  secretsFile.close();
+  // Set the status pixel brightness
+  setStatusLEDBrightness(WS._config.status_pixel_brightness);
 }
 
 /**************************************************************************/

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -345,7 +345,7 @@ void Wippersnapper_FS::parseSecrets() {
   DeserializationError error = deserializeJson(doc, secretsFile);
   if (error) {
     WS_DEBUG_PRINT("ERROR: deserializeJson() failed with code ");
-    WS_DEBUG_PRINTLN(err.c_str());
+    WS_DEBUG_PRINTLN(error.c_str());
     fsHalt();
   }
 
@@ -384,8 +384,8 @@ void Wippersnapper_FS::parseSecrets() {
   // Parse WiFi SSID
   const char *network_type_wifi_network_ssid =
       doc["network_type_wifi"]["network_ssid"];
-  if (network_type_wifi_ssid == nullptr ||
-      strcmp(network_type_wifi_ssid, "YOUR_WIFI_SSID_HERE") == 0) {
+  if (network_type_wifi_network_ssid == nullptr ||
+      strcmp(network_type_wifi_network_ssid, "YOUR_WIFI_SSID_HERE") == 0) {
     WS_DEBUG_PRINTLN("ERROR: invalid network_ssid value in secrets.json!");
     writeToBootOut("ERROR: invalid network_ssid value in secrets.json!\n");
 #ifdef USE_DISPLAY
@@ -397,13 +397,13 @@ void Wippersnapper_FS::parseSecrets() {
     fsHalt();
   }
   // Set network SSID
-  WS._network_ssid = network_type_wifi_ssid;
+  WS._network_ssid = network_type_wifi_network_ssid;
 
   // Parse WiFi Network Password
   const char *network_type_wifi_network_password =
       doc["network_type_wifi"]["network_password"];
-  if (network_type_wifi_password == nullptr ||
-      strcmp(network_type_wifi_password, "YOUR_WIFI_PASS_HERE") == 0) {
+  if (network_type_wifi_network_password == nullptr ||
+      strcmp(network_type_wifi_network_password, "YOUR_WIFI_PASS_HERE") == 0) {
     WS_DEBUG_PRINTLN("ERROR: invalid network_type_wifi_password value in "
                      "secrets.json!");
     writeToBootOut("ERROR: invalid network_type_wifi_password value in "
@@ -416,15 +416,14 @@ void Wippersnapper_FS::parseSecrets() {
 #endif
     fsHalt();
   }
-  WS._network_pass = network_type_wifi_password;
+  WS._network_pass = network_type_wifi_network_password;
 
   // Optionally set the MQTT broker url (used to switch btween prod. and
   // staging)
   WS._mqttBrokerURL = doc["io_url"];
 
   // Get (optional) setting for the status pixel brightness
-  const char *status_pixel_brightness =
-      doc["status_pixel_brightness"]; // default is "0.2"
+  float status_pixel_brightness = doc["status_pixel_brightness"]; // default is "0.2"
   // Note: ArduinoJSON's default value on failure to find is 0.0
   setStatusLEDBrightness(status_pixel_brightness);
 

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -353,11 +353,6 @@ void Wippersnapper_FS::parseSecrets() {
   // Close secrets.json file
   secretsFile.close();
 
-  // Optionally set the MQTT broker url (used to switch btween prod. and
-  // staging)
-  // TODO: this needs to be changed
-  WS._mqttBrokerURL = doc["io_url"];
-
   // Set the status pixel brightness
   setStatusLEDBrightness(WS._config.status_pixel_brightness);
 }

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -343,7 +343,8 @@ void Wippersnapper_FS::parseSecrets() {
   JsonDocument doc;
   DeserializationError error = deserializeJson(doc, secretsFile);
   if (error) {
-    return false;
+    // TODO: Catch error here!
+    fsHalt();
   }
   
   // Extract config struct from the JSON document

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -480,7 +480,6 @@ void Wippersnapper_FS::createDisplayConfig() {
   doc["height"] = 240;
   doc["rotation"] = 0;
   JsonObject spi = doc["spi"].to<JsonObject>();
-  spi["spiMode"] = 1;
   spi["pinCs"] = 40;
   spi["pinDc"] = 39;
   spi["pinMosi"] = 0;
@@ -529,7 +528,6 @@ void Wippersnapper_FS::parseDisplayConfig(displayConfig &displayFile) {
   JsonObject spi = doc["spi"];
   if (spi != nullptr) {
     displayFile.isSPI = true;             // indicate that we're using SPI bus
-    displayFile.spiMode= spi["spiMode"];  // 1
     displayFile.pinCS = spi["pinCs"];     // 40
     displayFile.pinDC = spi["pinDc"];     // 39
     displayFile.pinMOSI = spi["pinMosi"]; // 0

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -348,9 +348,8 @@ void Wippersnapper_FS::parseSecrets() {
     WS_DEBUG_PRINT("ERROR: deserializeJson() failed with code ");
     WS_DEBUG_PRINTLN(error.c_str());
     fsHalt();
-    fsHalt();
   }
-  
+
   // Extract a config struct from the JSON document
    WS._config =  doc.as<Config>();
 

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -400,8 +400,7 @@ void Wippersnapper_FS::parseSecrets() {
   WS._network_ssid = network_type_wifi_network_ssid;
 
   // Parse WiFi Network Password
-  const char *network_type_wifi_network_password =
-      doc["network_type_wifi"]["network_password"];
+  const char *network_type_wifi_network_password = doc["network_type_wifi"]["network_password"];
   if (network_type_wifi_network_password == nullptr ||
       strcmp(network_type_wifi_network_password, "YOUR_WIFI_PASS_HERE") == 0) {
     WS_DEBUG_PRINTLN("ERROR: invalid network_type_wifi_password value in "
@@ -426,9 +425,6 @@ void Wippersnapper_FS::parseSecrets() {
   float status_pixel_brightness = doc["status_pixel_brightness"]; // default is "0.2"
   // Note: ArduinoJSON's default value on failure to find is 0.0
   setStatusLEDBrightness(status_pixel_brightness);
-
-  // clear the document and release all memory from the memory pool
-  doc.clear();
 
   // Write configuration out to boot_out file
   writeToBootOut("Adafruit.io Username: ");

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -298,10 +298,10 @@ void Wippersnapper_FS::createSecretsFile() {
   
   // Create a default Config structure
   Config secretsConfig;
-  strcpy(secretsConfig.network.ssid, "YOUR_WIFI_SSID_HERE");
-  strcpy(secretsConfig.network.pass, "YOUR_WIFI_PASS_HERE");
   strcpy(secretsConfig.aio_user, "YOUR_IO_USERNAME_HERE");
   strcpy(secretsConfig.aio_key, "YOUR_IO_KEY_HERE");
+  strcpy(secretsConfig.network.ssid, "YOUR_WIFI_SSID_HERE");
+  strcpy(secretsConfig.network.pass, "YOUR_WIFI_PASS_HERE");
   secretsConfig.status_pixel_brightness = 0.2;
 
   // Create and fill JSON document from Config
@@ -353,6 +353,29 @@ void Wippersnapper_FS::parseSecrets() {
   
   // Extract a config struct from the JSON document
    WS._config =  doc.as<Config>();
+
+  // Validate the config struct is not filled with default values
+  if (strcmp(WS._config.aio_user, "YOUR_IO_USERNAME_HERE") == 0 || strcmp(WS._config.aio_key, "YOUR_IO_KEY_HERE") == 0) {
+    writeToBootOut("ERROR: Invalid IO credentials in secrets.json! TO FIX: Please change io_username and io_key to match your Adafruit IO credentials!\n");
+#ifdef USE_DISPLAY
+    WS._ui_helper->show_scr_error(
+        "INVALID IO CREDS",
+        "The \"io_username/io_key\" fields within secrets.json are invalid, please "
+        "change it to match your Adafruit IO credentials. Then, press RESET.");
+#endif
+    fsHalt();
+  }
+
+  if (strcmp(WS._config.network.ssid, "YOUR_WIFI_SSID_HERE") == 0 || strcmp(WS._config.network.pass, "YOUR_WIFI_PASS_HERE") == 0) {
+    writeToBootOut("ERROR: Invalid network credentials in secrets.json! TO FIX: Please change network_ssid and network_password to match your Adafruit IO credentials!\n");
+#ifdef USE_DISPLAY
+    WS._ui_helper->show_scr_error(
+        "INVALID NETWORK",
+        "The \"network_ssid and network_password\" fields within secrets.json are invalid, please "
+        "change it to match your WiFi credentials. Then, press RESET.");
+#endif
+    fsHalt();
+  }
 
   // Close secrets.json file
   secretsFile.close();

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -17,13 +17,13 @@
 
 #include "Adafruit_SPIFlash.h"
 #include "Adafruit_TinyUSB.h"
+#include "SdFat.h"
 #define ARDUINOJSON_USE_DOUBLE 0
 #define ARDUINOJSON_USE_LONG_LONG 1
 #include "ArduinoJson.h"
-#include "SdFat.h"
 // using f_mkfs() for formatting
-#include "fatfs/diskio.h"
 #include "fatfs/ff.h" // NOTE: This should be #included before fatfs/diskio.h!!!
+#include "fatfs/diskio.h"
 
 #include "Wippersnapper.h"
 

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -17,11 +17,13 @@
 
 #include "Adafruit_SPIFlash.h"
 #include "Adafruit_TinyUSB.h"
+#define ARDUINOJSON_USE_DOUBLE 0
+#define ARDUINOJSON_USE_LONG_LONG 1
 #include "ArduinoJson.h"
 #include "SdFat.h"
 // using f_mkfs() for formatting
-#include "fatfs/ff.h" // NOTE: This should be #included before fatfs/diskio.h!!!
 #include "fatfs/diskio.h"
+#include "fatfs/ff.h" // NOTE: This should be #included before fatfs/diskio.h!!!
 
 #include "Wippersnapper.h"
 
@@ -59,15 +61,10 @@ public:
 
   void parseSecrets();
 
-  #ifdef ARDUINO_FUNHOUSE_ESP32S2
-  void parseDisplayConfig(displayConfig& displayFile);
+#ifdef ARDUINO_FUNHOUSE_ESP32S2
+  void parseDisplayConfig(displayConfig &displayFile);
   void createDisplayConfig();
-  #endif
-
-  // NOTE: calculated capacity with maximum
-  // length of usernames/passwords/tokens
-  // is 382 bytes, rounded to nearest power of 2.
-  StaticJsonDocument<512> doc; /*!< Json configuration file */
+#endif
 private:
   bool _freshFS = false; /*!< True if filesystem was initialized by
                             WipperSnapper, False otherwise. */

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -18,9 +18,9 @@
 #include "Adafruit_SPIFlash.h"
 #include "Adafruit_TinyUSB.h"
 #include "SdFat.h"
-#define ARDUINOJSON_USE_DOUBLE 0
-#define ARDUINOJSON_USE_LONG_LONG 1
-#include "ArduinoJson.h"
+// #define ARDUINOJSON_USE_DOUBLE 0
+// #define ARDUINOJSON_USE_LONG_LONG 1
+// #include "ArduinoJson.h"
 // using f_mkfs() for formatting
 #include "fatfs/ff.h" // NOTE: This should be #included before fatfs/diskio.h!!!
 #include "fatfs/diskio.h"

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -7,11 +7,11 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Copyright (c) Brent Rubell 2021-2023 for Adafruit Industries.
+ * Copyright (c) Brent Rubell 2021-2024 for Adafruit Industries.
  *
  * BSD license, all text here must be included in any redistribution.
  *
- */
+*/
 #ifndef WIPPERSNAPPER_FS_H
 #define WIPPERSNAPPER_FS_H
 

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -18,9 +18,6 @@
 #include "Adafruit_SPIFlash.h"
 #include "Adafruit_TinyUSB.h"
 #include "SdFat.h"
-// #define ARDUINOJSON_USE_DOUBLE 0
-// #define ARDUINOJSON_USE_LONG_LONG 1
-// #include "ArduinoJson.h"
 // using f_mkfs() for formatting
 #include "fatfs/ff.h" // NOTE: This should be #included before fatfs/diskio.h!!!
 #include "fatfs/diskio.h"


### PR DESCRIPTION
Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/533 by:

* Upgrades ArduinoJSON dependency version to v7.x
  * All API calls to ArduinoJSON are now in v7-format
*  Refactored encoding/decoding the `secrets.json` file to use user-defined structures and ArduinoJSON converters to separate parsing/storage code, allowing scaling when we need to modify `secrets.json`
* Use arduinojson converters for display configuration file, too

Test Requirements before merge:

* [x] Test LittleFS Implementation
* [x] Test TinyUSB Implementation on FunHouse
  * [x] Delete and re-create the secrets.json file
    * [x] Should error if IO credentials not filled
      * [x] Show error in `boot_out.txt`
      * [x] Show error on display
    * [x] Should error if network credentials not filled
      * [x] Show error in boot_out.txt
      * [x] Show error on display
    * [x] No errors if non-default credentials are used
   * [x] Use a production secrets.json file and magic config to create a FunHouse test device
   * [x] Upgrade a device (already connected to IO and contains secrets.json) running Beta 74 to Beta 75 (this PR) 
   * [x] Test boot from factory reset uf2 (funhouse) then load beta 75
* [x] Test display configuration on FunHouse
  * [x] Test deleting and re-create
  * [x] Test upgrade existing funhouse with display configuration file to beta 75 