### PR TITLE
Always return proximity result, or NaN if we know it's bad

### DIFF
--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor.h
@@ -85,16 +85,15 @@ public:
   bool getEventRaw(sensors_event_t *rawEvent) {
     uint16_t touchData = _seesaw->touchRead(0);
 
-    // seesaw->touchRead() will return 65535 on a read error
-    // see
+    // seesaw->touchRead() will return 65535 on a read error. See more at
     // https://github.com/adafruit/Adafruit_Seesaw/blob/master/Adafruit_seesaw.cpp
     if (touchData == 65535) {
-      return false;
+      rawEvent->data[0] = NAN;
+    } else {
+      // TODO: Update this should we add a capacitive moisture type to
+      // adafruit_sensor
+      rawEvent->data[0] = (float)touchData;
     }
-
-    // TODO: Update this should we add a capacitive moisture type to
-    // adafruit_sensor
-    rawEvent->data[0] = (float)touchData;
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VCNL4020.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VCNL4020.h
@@ -72,7 +72,6 @@ public:
   bool getEventLight(sensors_event_t *lightEvent) {
     // Get sensor event populated in lux via AUTO integration and gain
     lightEvent->light = _vcnl4020->readAmbient();
-
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VCNL4040.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VCNL4040.h
@@ -86,7 +86,6 @@ public:
   bool getEventLight(sensors_event_t *lightEvent) {
     // Get sensor event populated in lux via AUTO integration and gain
     lightEvent->light = _vcnl4040->getLux();
-
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VL53L0X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VL53L0X.h
@@ -76,10 +76,11 @@ public:
   /*******************************************************************************/
   bool getEventProximity(sensors_event_t *proximityEvent) {
     u_int16_t proximityMM = _vl53l0x->readRange();
-    if (proximityMM <= 0 || proximityMM > 4000) {
-      return false;
+    if (proximityMM == 0xffff) {
+      proximityEvent->data[0] = NAN;
+    } else {
+      proximityEvent->data[0] = proximityMM;
     }
-    proximityEvent->data[0] = proximityMM;
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VL6180X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VL6180X.h
@@ -96,13 +96,10 @@ public:
       } else if (status == VL6180X_ERROR_RANGEOFLOW) {
         WS_DEBUG_PRINTLN("VL6180X: Range reading overflow");
       }
-      return false;
+      proximityEvent->data[0] = NAN;
+    } else {
+      proximityEvent->data[0] = range;
     }
-
-    if (range <= 0 || range > 150) {
-      return false;
-    }
-    proximityEvent->data[0] = range;
     return true;
   }
 
@@ -117,12 +114,13 @@ public:
   /*******************************************************************************/
   bool getEventLight(sensors_event_t *lightEvent) {
     // TODO: Update when I2C Sensor Properties allow setting custom Gain, etc.
-    float notRealLux = _vl6180x->readLux(VL6180X_ALS_GAIN_5);
     // Gain_5 results in max 41.6klux with cover glass - See 2.10.3 in datasheet
-    if (notRealLux < 0 || notRealLux > 41600) {
-      return false;
+    float notRealLux = _vl6180x->readLux(VL6180X_ALS_GAIN_5);
+    if (notRealLux < 0 || notRealLux > 41700) {
+      lightEvent->light = NAN;
+    } else {
+      lightEvent->light = notRealLux;
     }
-    lightEvent->light = notRealLux;
     return true;
   }
 


### PR DESCRIPTION
~~Running CI so I can test easily~~

This addresses the issue raised in the meeting about NaN's being returned rather than artificially restricting values returned by sensors.