### PR TITLE
Change AnalogIO DEFAULT_HYSTERESIS to 0.02

### DIFF
--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -18,7 +18,7 @@
 
 #include "Wippersnapper.h"
 
-#define DEFAULT_HYSTERISIS 0.2 ///< Default DEFAULT_HYSTERISIS of 2%
+#define DEFAULT_HYSTERISIS 0.02 ///< Default DEFAULT_HYSTERISIS of 2%
 
 /** Data about an analog input pin */
 struct analogInputPin {


### PR DESCRIPTION
Was experiencing some lower than expected resolution with the analog potentiometer, S3 TFT Feather. Double checked the code and it's good as far as resolution etc goes. Noticed the value for hysteresis was 0.2 and labelled 2%. The calculation in the update check is 
[(_analog_input_pins[i].prvPinVal * DEFAULT_HYSTERISIS);](https://github.com/tyeth/Adafruit_Wippersnapper_Arduino/blob/325dfb66c2470fe3933281e4c83176787bca6ce7/src/components/analogIO/Wippersnapper_AnalogIO.cpp#L369)

I'm running a build with 
`#define DEFAULT_HYSTERISIS 0.02 ///< Default DEFAULT_HYSTERISIS of 2%
`