### PR TITLE
Fix: MAX17048 - Return NaN if no battery attached

### DIFF
--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
@@ -56,7 +56,7 @@ public:
   /*******************************************************************************/
   bool begin() {
     _maxlipo = new Adafruit_MAX17048();
-    if (!_maxlipo->begin(_i2c) or !_maxlipo->isDeviceReady()) {
+    if (!_maxlipo->begin(_i2c)) {
       return false;
     }
     return true;
@@ -73,11 +73,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventVoltage(sensors_event_t *voltageEvent) {
-    if (!_maxlipo->isDeviceReady()) {
-      voltageEvent->voltage = NAN;
-    } else {
-      voltageEvent->voltage = _maxlipo->cellVoltage();
-    }
+    voltageEvent->voltage = _maxlipo->cellVoltage();
     return true;
   }
 
@@ -92,11 +88,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventUnitlessPercent(sensors_event_t *unitlessPercentEvent) {
-    if (!_maxlipo->isDeviceReady()) {
-      unitlessPercentEvent->unitless_percent = NAN;
-    } else {
-      unitlessPercentEvent->unitless_percent = _maxlipo->cellPercent();
-    }
+    unitlessPercentEvent->unitless_percent = _maxlipo->cellPercent();
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
@@ -56,11 +56,28 @@ public:
   /*******************************************************************************/
   bool begin() {
     _maxlipo = new Adafruit_MAX17048();
-    if (!_maxlipo->begin(_i2c))
+    if (!_maxlipo->begin(_i2c) or deviceNotReady()) {
       return false;
+    }
     return true;
   }
 
+  /*******************************************************************************/
+  /*!
+      @brief Checks the response of the MAX17048 chip by verifying ID and version.
+      @returns true if the chip ID or version is invalid, false otherwise.
+   */
+  /*******************************************************************************/
+  bool deviceNotReady() {
+    uint8_t chipID = _maxlipo->getChipID();
+    if (chipID == 0x00 || chipID == 0xFF)
+      return true;
+    uint16_t chipVersion = _maxlipo->getICversion();
+    if (chipVersion == 0x0000 || chipVersion == 0xFFFF)
+      return true;
+    return false;
+  }
+  
   /*******************************************************************************/
   /*!
       @brief    Reads a voltage sensor and converts the
@@ -72,7 +89,11 @@ public:
   */
   /*******************************************************************************/
   bool getEventVoltage(sensors_event_t *voltageEvent) {
-    voltageEvent->voltage = _maxlipo->cellVoltage();
+    if (deviceNotReady()) {
+      voltageEvent->voltage = NAN;
+    } else {
+      voltageEvent->voltage = _maxlipo->cellVoltage();
+    }
     return true;
   }
 
@@ -87,7 +108,11 @@ public:
   */
   /*******************************************************************************/
   bool getEventUnitlessPercent(sensors_event_t *unitlessPercentEvent) {
-    unitlessPercentEvent->unitless_percent = _maxlipo->cellPercent();
+    if (deviceNotReady()) {
+      unitlessPercentEvent->unitless_percent = NAN;
+    } else {
+      unitlessPercentEvent->unitless_percent = _maxlipo->cellPercent();
+    }
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX17048.h
@@ -56,28 +56,12 @@ public:
   /*******************************************************************************/
   bool begin() {
     _maxlipo = new Adafruit_MAX17048();
-    if (!_maxlipo->begin(_i2c) or deviceNotReady()) {
+    if (!_maxlipo->begin(_i2c) or !_maxlipo->isDeviceReady()) {
       return false;
     }
     return true;
   }
 
-  /*******************************************************************************/
-  /*!
-      @brief Checks the response of the MAX17048 chip by verifying ID and version.
-      @returns true if the chip ID or version is invalid, false otherwise.
-   */
-  /*******************************************************************************/
-  bool deviceNotReady() {
-    uint8_t chipID = _maxlipo->getChipID();
-    if (chipID == 0x00 || chipID == 0xFF)
-      return true;
-    uint16_t chipVersion = _maxlipo->getICversion();
-    if (chipVersion == 0x0000 || chipVersion == 0xFFFF)
-      return true;
-    return false;
-  }
-  
   /*******************************************************************************/
   /*!
       @brief    Reads a voltage sensor and converts the
@@ -89,7 +73,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventVoltage(sensors_event_t *voltageEvent) {
-    if (deviceNotReady()) {
+    if (!_maxlipo->isDeviceReady()) {
       voltageEvent->voltage = NAN;
     } else {
       voltageEvent->voltage = _maxlipo->cellVoltage();
@@ -108,7 +92,7 @@ public:
   */
   /*******************************************************************************/
   bool getEventUnitlessPercent(sensors_event_t *unitlessPercentEvent) {
-    if (deviceNotReady()) {
+    if (!_maxlipo->isDeviceReady()) {
       unitlessPercentEvent->unitless_percent = NAN;
     } else {
       unitlessPercentEvent->unitless_percent = _maxlipo->cellPercent();


### PR DESCRIPTION
This checks the version + ID before each read, returning NaN if not valid (no battery attached).