### PR TITLE
Fix ESP32 WiFi.h missing + macAddress for arduino-esp32 v3.0.0-rc1

### DIFF
--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -23,6 +23,7 @@
 #include "Adafruit_MQTT.h"
 #include "Adafruit_MQTT_Client.h"
 #include "Arduino.h"
+#include "WiFi.h"
 #include <WiFiClientSecure.h>
 extern Wippersnapper WS;
 
@@ -133,7 +134,7 @@ public:
   /********************************************************/
   void getMacAddr() {
     uint8_t mac[6] = {0};
-    WiFi.macAddress(mac);
+    Network.macAddress(mac);
     memcpy(WS._macAddr, mac, sizeof(mac));
   }
 


### PR DESCRIPTION
Tagging @brentru for review.
This closes #568