### PR TITLE
Update network port/cert support for local testing

### DIFF
--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -148,14 +148,16 @@ public:
   void setupMQTTClient(const char *clientID) {
     if (strcmp(WS._config.aio_url, "io.adafruit.com") == 0) {
       _mqtt_client->setCACert(_aio_root_ca_prod);
-    } else {
+    } else if (strcmp(WS._config.aio_url, "io.adafruit.us") == 0) {
       _mqtt_client->setCACert(_aio_root_ca_staging);
+    } else {
+      _mqtt_client->setInsecure();
     }
 
     // Construct MQTT client
-    WS._mqtt = new Adafruit_MQTT_Client(_mqtt_client, WS._config.aio_url, 8883,
-                                        clientID, WS._config.aio_user,
-                                        WS._config.aio_key);
+    WS._mqtt = new Adafruit_MQTT_Client(
+        _mqtt_client, WS._config.aio_url, WS._config.io_port, clientID,
+        WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP8266.h
+++ b/src/network_interfaces/Wippersnapper_ESP8266.h
@@ -173,10 +173,11 @@ public:
     // re-compile after. _wifi_client->setFingerprint(fingerprint); WS._mqtt =
     // new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url,
     // WS._config.io_port, clientID, WS._config.aio_user, WS._config.aio_key);
-
-    WS._mqtt = new Adafruit_MQTT_Client(_wifi_client, WS._config.aio_url, 1883,
-                                        clientID, WS._config.aio_user,
-                                        WS._config.aio_key);
+    if (WS._config.io_port == 8883)
+      WS._config.io_port = 1883;
+    WS._mqtt = new Adafruit_MQTT_Client(
+        _wifi_client, WS._config.aio_url, WS._config.io_port, clientID,
+        WS._config.aio_user, WS._config.aio_key);
   }
 
   /********************************************************/

--- a/src/network_interfaces/ws_networking_pico.h
+++ b/src/network_interfaces/ws_networking_pico.h
@@ -149,8 +149,10 @@ public:
     // compare WS._config.aio_url to "io.adafruit.com"
     if (strcmp(WS._config.aio_url, "io.adafruit.com") == 0) {
       _mqtt_client->setCACert(_aio_root_ca_prod);
-    } else {
+    } else if (strcmp(WS._config.aio_url, "io.adafruit.us") == 0) {
       _mqtt_client->setCACert(_aio_root_ca_staging);
+    } else {
+      _mqtt_client->setInsecure();
     }
 
     WS._mqtt = new Adafruit_MQTT_Client(


### PR DESCRIPTION
Adds support for local dev machine testing, by allowing esp32 to specify port, and also disable mqtt security checking if not staging/production url