### PR TITLE
Reset wifi coprocessor on disconnect

### DIFF
--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -2527,9 +2527,15 @@ void Wippersnapper::pingBroker() {
   // ping within keepalive-10% to keep connection open
   if (millis() > (_prv_ping + (WS_KEEPALIVE_INTERVAL_MS -
                                (WS_KEEPALIVE_INTERVAL_MS * 0.10)))) {
-    WS_DEBUG_PRINTLN("PING!");
+    WS_DEBUG_PRINT("PING!");
     // TODO: Add back, is crashing currently
-    WS._mqtt->ping();
+    if (WS._mqtt->ping()) {
+      WS_DEBUG_PRINTLN("SUCCESS!");
+    } else {
+      WS_DEBUG_PRINTLN("FAILURE! Running network FSM...");
+      WS._mqtt->disconnect();
+      runNetFSM();
+    }
     _prv_ping = millis();
   }
   // blink status LED every STATUS_LED_KAT_BLINK_TIME millis

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -2527,7 +2527,7 @@ void Wippersnapper::pingBroker() {
   // ping within keepalive-10% to keep connection open
   if (millis() > (_prv_ping + (WS_KEEPALIVE_INTERVAL_MS -
                                (WS_KEEPALIVE_INTERVAL_MS * 0.10)))) {
-    WS_DEBUG_PRINT("PING!");
+    WS_DEBUG_PRINT("MQTT PING: ");
     // TODO: Add back, is crashing currently
     if (WS._mqtt->ping()) {
       WS_DEBUG_PRINTLN("SUCCESS!");

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -266,6 +266,20 @@ protected:
       // disconnect from possible previous connection
       _disconnect();
 
+      // reset the esp32 if possible
+      if (_rstPin != -1) {
+        WS_DEBUG("Resetting ESP32...");
+        pinMode(_rstPin, OUTPUT);
+        digitalWrite(_rstPin, LOW);
+        delay(10);
+        digitalWrite(_rstPin, HIGH);
+        delay(10);
+      }
+      // wait for the ESP32 to boot
+      delay(1000);
+
+      WS_DEBUG_PRINT("Connecting to ");
+      WS_DEBUG_PRINTLN(_ssid);
       WiFi.begin(_ssid, _pass);
       _status = WS_NET_DISCONNECTED;
     }

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -280,6 +280,7 @@ protected:
     } else {
       // disconnect from possible previous connection
       _disconnect();
+      WiFi.end();
       feedWDT();
       WS_DEBUG_PRINT("Reset Pin: ");
       WS_DEBUG_PRINTLN(_rstPin);
@@ -289,8 +290,7 @@ protected:
         WS_PRINTER.flush();
         // Chip select for esp32
         pinMode(_ssPin, OUTPUT);
-        digitalWrite(_ssPin, HIGH);
-        // Do we need to set SS low again?
+        digitalWrite(_ssPin, HIGH); // Do we need to set SS low again?
         if (_gpio0Pin != -1) {
           pinMode(_gpio0Pin, OUTPUT);
           digitalWrite(_gpio0Pin, LOW);
@@ -304,7 +304,7 @@ protected:
           pinMode(_gpio0Pin, INPUT);
         }
         // wait for the ESP32 to boot
-        delay(1000);
+        delay(2000);
       }
       feedWDT();
       // WS_DEBUG_PRINT("ESP32 booted, version: ");

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -47,14 +47,14 @@ public:
   */
   /**************************************************************************/
   Wippersnapper_AIRLIFT() : Wippersnapper() {
-    _ssPin = SPIWIFI_SS; // 10;
-    _ackPin = SPIWIFI_ACK; //7;
+    _ssPin = SPIWIFI_SS;     // 10;
+    _ackPin = SPIWIFI_ACK;   // 7;
     _rstPin = SPIWIFI_RESET; // 5; // should be 7 on PyPortals
-    #ifdef ESP32_GPIO0
+#ifdef ESP32_GPIO0
     _gpio0Pin = ESP32_GPIO0;
-    #else
+#else
     _gpio0Pin = -1;
-    #endif
+#endif
     _wifi = &SPIWIFI;
     _ssid = 0;
     _pass = 0;
@@ -193,17 +193,21 @@ public:
           equal to the required version, False otherwise.
   */
   /********************************************************/
-  bool compareVersions(const String& currentVersion, const String& requiredVersion) {
-      int curMajor, curMinor, curPatch;
-      int reqMajor, reqMinor, reqPatch;
-      int per_major, per_minor, per_patch;
-      
-      sscanf(currentVersion.c_str(), "%d.%d.%d", &curMajor, &curMinor, &curPatch);
-      sscanf(requiredVersion.c_str(), "%d.%d.%d", &reqMajor, &reqMinor, &reqPatch);
+  bool compareVersions(const String &currentVersion,
+                       const String &requiredVersion) {
+    int curMajor, curMinor, curPatch;
+    int reqMajor, reqMinor, reqPatch;
+    int per_major, per_minor, per_patch;
 
-      if (curMajor != reqMajor) return curMajor > reqMajor;
-      if (curMinor != reqMinor) return curMinor > reqMinor;
-      return curPatch >= reqPatch;
+    sscanf(currentVersion.c_str(), "%d.%d.%d", &curMajor, &curMinor, &curPatch);
+    sscanf(requiredVersion.c_str(), "%d.%d.%d", &reqMajor, &reqMinor,
+           &reqPatch);
+
+    if (curMajor != reqMajor)
+      return curMajor > reqMajor;
+    if (curMinor != reqMinor)
+      return curMinor > reqMinor;
+    return curPatch >= reqPatch;
   }
 
   /********************************************************/
@@ -276,7 +280,8 @@ protected:
   /**************************************************************************/
   void _connect() {
     if (strlen(_ssid) == 0) {
-      _status = WS_SSID_INVALID;  // possibly unneccesary  as already checking elsewhere
+      _status = WS_SSID_INVALID; // possibly unneccesary  as already checking
+                                 // elsewhere
     } else {
       // disconnect from possible previous connection
       _disconnect();

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -280,7 +280,10 @@ protected:
     } else {
       // disconnect from possible previous connection
       _disconnect();
+      delay(100);
       WiFi.end();
+      delay(100);
+      _wifi->begin();
       feedWDT();
       WS_DEBUG_PRINT("Reset Pin: ");
       WS_DEBUG_PRINTLN(_rstPin);
@@ -307,11 +310,11 @@ protected:
         delay(2000);
       }
       feedWDT();
-      // WS_DEBUG_PRINT("ESP32 booted, version: ");
-      // WS_PRINTER.flush();
-      // WS_DEBUG_PRINTLN(WiFi.firmwareVersion());
-      // WS_PRINTER.flush();
-      // feedWDT();
+      WS_DEBUG_PRINT("ESP32 booted, version: ");
+      WS_PRINTER.flush();
+      WS_DEBUG_PRINTLN(WiFi.firmwareVersion());
+      WS_PRINTER.flush();
+      feedWDT();
 
       // // validate co-processor is physically connected connection
       // if (WiFi.status() == WL_NO_MODULE) {

--- a/src/network_interfaces/Wippersnapper_AIRLIFT.h
+++ b/src/network_interfaces/Wippersnapper_AIRLIFT.h
@@ -282,6 +282,7 @@ protected:
       _disconnect();
       delay(100);
       WiFi.end();
+      _wifi->end();
       delay(100);
       _wifi->begin();
       feedWDT();

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -256,6 +256,22 @@ protected:
       // disconnect from possible previous connection
       _disconnect();
 
+#if defined(ESP32_RESETN)
+      // reset the esp32 if possible, better if we didn't do this first time
+      if (ESP32_RESETN != -1) {
+        WS_DEBUG("Resetting ESP32...");
+        pinMode(ESP32_RESETN, OUTPUT);
+        digitalWrite(ESP32_RESETN, LOW);
+        delay(10);
+        digitalWrite(ESP32_RESETN, HIGH);
+        delay(10);
+      }
+      // wait for the ESP32 to boot
+      delay(1000);
+#endif
+
+      WS_DEBUG_PRINT("Connecting to ");
+      WS_DEBUG_PRINTLN(_ssid);
       WiFi.begin(_ssid, _pass);
       _status = WS_NET_DISCONNECTED;
     }

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -256,14 +256,23 @@ protected:
       // disconnect from possible previous connection
       _disconnect();
 
-#if defined(ESP32_RESETN)
+// no clear recommendation, all three defined for both boards, future-proofing
+#if defined(NINA_RESETN)
+#define NINA_RESET_PIN NINA_RESETN
+#elif defined(SPIWIFI_RESET)
+#define NINA_RESET_PIN SPIWIFI_RESET
+#elif defined(ESP32_RESETN)
+#define NINA_RESET_PIN ESP32_RESETN
+#endif
+
+#if defined(NINA_RESET_PIN)
       // reset the esp32 if possible, better if we didn't do this first time
-      if (ESP32_RESETN != -1) {
+      if (NINA_RESET_PIN != -1) {
         WS_DEBUG("Resetting ESP32...");
-        pinMode(ESP32_RESETN, OUTPUT);
-        digitalWrite(ESP32_RESETN, LOW);
+        pinMode(NINA_RESET_PIN, OUTPUT);
+        digitalWrite(NINA_RESET_PIN, LOW);
         delay(10);
-        digitalWrite(ESP32_RESETN, HIGH);
+        digitalWrite(NINA_RESET_PIN, HIGH);
         delay(10);
       }
       // wait for the ESP32 to boot

--- a/src/network_interfaces/Wippersnapper_WIFININA.h
+++ b/src/network_interfaces/Wippersnapper_WIFININA.h
@@ -268,21 +268,28 @@ protected:
 #if defined(NINA_RESET_PIN)
       // reset the esp32 if possible, better if we didn't do this first time
       if (NINA_RESET_PIN != -1) {
-        WS_DEBUG("Resetting ESP32...");
+        WS_DEBUG_PRINTLN("Resetting ESP32...");
+        WS_PRINTER.flush();
         pinMode(NINA_RESET_PIN, OUTPUT);
         digitalWrite(NINA_RESET_PIN, LOW);
-        delay(10);
+        delay(50);
         digitalWrite(NINA_RESET_PIN, HIGH);
         delay(10);
       }
       // wait for the ESP32 to boot
-      delay(1000);
+      delay(2000);
+      feedWDT();
 #endif
 
       WS_DEBUG_PRINT("Connecting to ");
       WS_DEBUG_PRINTLN(_ssid);
       WiFi.begin(_ssid, _pass);
       _status = WS_NET_DISCONNECTED;
+      feedWDT();
+      delay(5000);
+      feedWDT();
+      delay(5000);
+      feedWDT();
     }
   }
 

--- a/src/network_interfaces/ws_networking_pico.h
+++ b/src/network_interfaces/ws_networking_pico.h
@@ -282,6 +282,9 @@ protected:
         }
       }
       _status = WS_NET_DISCONNECTED;
+      WS.feedWDT();
+      delay(5000);
+      WS.feedWDT();
     }
   }
 


### PR DESCRIPTION
This PR along with RSSI (#589) precedes #584.

Here we add reset code for the Airlift boards + WIFININA boards (arduino), along with setting the mqtt client to disconnected if we fail the mqtt ping (the mqtt client connected check is very simplistic and still returns true when wifi lost) and then calling runNetFSM to re-establish network connectivity