### PR TITLE
Latest platformIO changes for ESP32 BSP v3.0.2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -76,11 +76,12 @@ lib_deps =
     https://github.com/adafruit/WiFiNINA.git
     https://github.com/Starmbi/hp_BH1750.git
 
+
 ; Common build environment for ESP32 platform
 [common:esp32]
-platform = espressif32 @ ^6.6.0
+platform = https://github.com/platformio/platform-espressif32.git#develop
 platform_packages =
-	platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0-rc1
+	platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.2
 	platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-release/v5.1
 lib_ignore = WiFiNINA
 monitor_filters = esp32_exception_decoder, time
@@ -246,6 +247,27 @@ extra_scripts =  pre:rename_usb_config.py
 extends = common:esp32
 board = adafruit_qtpy_esp32s3_nopsram
 build_flags = -DARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM
+extra_scripts = pre:rename_usb_config.py
+
+; Espressif ESP32-S3 NO PSRAM espressif_esp32s3_devkitc_1_n8
+[env:espressif_esp32s3_devkitc_1_n8]
+extends = common:esp32
+board = esp32-s3-devkitc-1
+build_type = debug
+build_flags = 
+    -DUSE_TINYUSB=1
+    -DARDUINO_ESPRESSIF_ESP32S3_DEVKITC_1_N8
+    -DNDEBUG=1
+    -DDEBUG=1
+    -DESP_LOG_LEVEL=5
+    -DARDUINO_CORE_DEBUG_LEVEL=5
+    -DARDUINO_DEBUG_LEVEL=5
+    ; -DARDUINO_DEBUG_OUTPUT=Serial
+    ; -DARDUINO_DEBUG_BAUD=115200
+    -DARDUINO_LOG_LEVEL=5
+    -DCORE_DEBUG_LEVEL=5
+    -DARDUHAL_LOG_LEVEL=5
+board_build.partitions = tinyuf2-partitions-8MB.csv
 extra_scripts = pre:rename_usb_config.py
 
 ; ESP8266 Boards


### PR DESCRIPTION
This is currently working for me @brentru , with the caveat that I had to remove my existing platform packages from my platformio folder inside my home folder. I actually uninstalled all espressif32 platforms, then went and removed the framework-arduinoesp32 related folders from the platform packages location.

 "I had some leftover platforms/framework-arduinoesp32's for PIO still installed, in my home folder (C:\Users\tyeth\.platformio\packages), and removing them has got me past the build error."