### PR TITLE
Downgrade patch for ESP32-S3 BSP 3.0.2

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -22,69 +22,69 @@ jobs:
         include:
           - offset: "0x1000"
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v4
-    - name: Get WipperSnapper version
-      run: |
-        git fetch --prune --unshallow --tags
-        git describe --dirty --tags
-        echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v4
-      with:
-         repository: adafruit/ci-arduino
-         path: ci
-    - name: Checkout Board Definitions
-      uses: actions/checkout@v4
-      with:
-        repository: adafruit/Wippersnapper_Boards
-        path: ws-boards
-    - name: Install CI-Arduino
-      run: bash ci/actions_install.sh
-    - name: Install extra Arduino libraries
-      run: |
-        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-        git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
-        git clone --quiet https://github.com/adafruit/Adafruit_HX8357_Library.git /home/runner/Arduino/libraries/Adafruit_HX8357_Library
-        git clone --quiet https://github.com/adafruit/Adafruit_ILI9341.git /home/runner/Arduino/libraries/Adafruit_ILI9341
-        git clone --quiet https://github.com/adafruit/Adafruit_STMPE610.git /home/runner/Arduino/libraries/Adafruit_STMPE610
-        git clone --quiet https://github.com/adafruit/Adafruit-ST7735-Library.git /home/runner/Arduino/libraries/Adafruit-ST7735-Library
-        git clone --quiet https://github.com/adafruit/Adafruit_TouchScreen.git /home/runner/Arduino/libraries/Adafruit_TouchScreen
-        git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
-        git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-    - name: Download and install stable Nanopb
-      run: |
-        # Download and extract nanopb
-        wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-        tar -xf nanopb-0.4.8.tar.gz
-        # Copy files to WipperSnapper's src/nanopb directory
-        cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
-        mv nanopb/pb.h src/nanopb/nanopb.pb.h
-    - name: List all files in Adafruit_LittlevGL_Glue_Library folder
-      run: |
-        ls /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-    - name: Copy lv_conf.h file in Adafruit_LittlevGL_Glue_Library to the arduino library folder
-      run: |
-        cp /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library/lv_conf.h /home/runner/Arduino/libraries
-    - name: Install Dependencies (esptool)
-      run: |
-        pip3 install esptool
-    - name: Build for ESP32-SX
-      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
-    - name: list files
-      run: |
-            ls -Rla examples/
-    - name: Rename build artifacts to reflect the platform name
-      run: |
-            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.bin
-            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.elf
-            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.map
-            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.bootloader.bin wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.bootloader.bin
-            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.partitions.bin wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.partitions.bin
-    - name: Get Board Flash Parameters
-      id: get_board_json
-      run: |
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: actions/checkout@v4
+      - name: Get WipperSnapper version
+        run: |
+          git fetch --prune --unshallow --tags
+          git describe --dirty --tags
+          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+      - uses: actions/checkout@v4
+        with:
+          repository: adafruit/ci-arduino
+          path: ci
+      - name: Checkout Board Definitions
+        uses: actions/checkout@v4
+        with:
+          repository: adafruit/Wippersnapper_Boards
+          path: ws-boards
+      - name: Install CI-Arduino
+        run: bash ci/actions_install.sh
+      - name: Install extra Arduino libraries
+        run: |
+          git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+          git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
+          git clone --quiet https://github.com/adafruit/Adafruit_HX8357_Library.git /home/runner/Arduino/libraries/Adafruit_HX8357_Library
+          git clone --quiet https://github.com/adafruit/Adafruit_ILI9341.git /home/runner/Arduino/libraries/Adafruit_ILI9341
+          git clone --quiet https://github.com/adafruit/Adafruit_STMPE610.git /home/runner/Arduino/libraries/Adafruit_STMPE610
+          git clone --quiet https://github.com/adafruit/Adafruit-ST7735-Library.git /home/runner/Arduino/libraries/Adafruit-ST7735-Library
+          git clone --quiet https://github.com/adafruit/Adafruit_TouchScreen.git /home/runner/Arduino/libraries/Adafruit_TouchScreen
+          git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
+          git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
+      - name: Download and install stable Nanopb
+        run: |
+          # Download and extract nanopb
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+          tar -xf nanopb-0.4.8.tar.gz
+          # Copy files to WipperSnapper's src/nanopb directory
+          cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
+          mv nanopb/pb.h src/nanopb/nanopb.pb.h
+      - name: List all files in Adafruit_LittlevGL_Glue_Library folder
+        run: |
+          ls /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
+      - name: Copy lv_conf.h file in Adafruit_LittlevGL_Glue_Library to the arduino library folder
+        run: |
+          cp /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library/lv_conf.h /home/runner/Arduino/libraries
+      - name: Install Dependencies (esptool)
+        run: |
+          pip3 install esptool
+      - name: Build for ESP32-SX
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
+      - name: list files
+        run: |
+          ls -Rla examples/
+      - name: Rename build artifacts to reflect the platform name
+        run: |
+          mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.bin
+          mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.elf
+          mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.map
+          mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.bootloader.bin wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.bootloader.bin
+          mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.partitions.bin wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.partitions.bin
+      - name: Get Board Flash Parameters
+        id: get_board_json
+        run: |
           board_name=${{ matrix.arduino-platform }}
           # Remove '_noota' suffix if present
           board_name=${board_name%_noota}
@@ -96,22 +96,22 @@ jobs:
             echo $content
             echo EOF
           } >> "$GITHUB_OUTPUT"
-    - name: list arduino esp32 core files
-      run: |
-        ls /home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions
-    - name: Check boot_app0 file existence (esp32sx built from core, not-source)
-      id: check_files
-      uses: andstor/file-existence-action@v2
-      with:
-        files: "/home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin"
-    - name: boot_app0 file from arduino-cli core
-      if: steps.check_files.outputs.files_exists == 'true'
-      run: mv /home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.boot_app0.bin
-    - name: boot_app0 file from esp32 source bsp
-      if: steps.check_files.outputs.files_exists == 'false'
-      run: mv /home/runner/Arduino/hardware/espressif/esp32/tools/partitions/boot_app0.bin wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.boot_app0.bin
-    - name: Create combined binary using Esptool merge_bin
-      run: |
+      - name: list arduino esp32 core files
+        run: |
+          ls /home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions
+      - name: Check boot_app0 file existence (esp32sx built from core, not-source)
+        id: check_files
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "/home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin"
+      - name: boot_app0 file from arduino-cli core
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: mv /home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.boot_app0.bin
+      - name: boot_app0 file from esp32 source bsp
+        if: steps.check_files.outputs.files_exists == 'false'
+        run: mv /home/runner/Arduino/hardware/espressif/esp32/tools/partitions/boot_app0.bin wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.boot_app0.bin
+      - name: Create combined binary using Esptool merge_bin
+        run: |
           echo ${{ steps.get_board_json.outputs.boardJson }}
           echo ${{ fromJson(steps.get_board_json.outputs.boardJson) }}
           python3 -m esptool --chip ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.chip}} merge_bin \
@@ -123,25 +123,24 @@ jobs:
             0x8000 wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.partitions.bin \
             0xe000 wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.boot_app0.bin \
             0x10000 wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.bin
-    - name: Zip build artifacts
-      run: |
-            zip -r wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.*
-    - name: upload build artifacts zip
-      uses: actions/upload-artifact@v3
-      with:
-        name: build-files
-        path: |
+      - name: Zip build artifacts
+        run: |
+          zip -r wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.*
+      - name: upload build artifacts zip
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-files
+          path: |
             wippersnapper.${{ matrix.arduino-platform }}.fatfs.${{ env.WS_VERSION }}.zip
-    - name: Rename build artifacts to reflect the platform name
-      run: |
-            mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: build-files
-        path: |
+      - name: Rename build artifacts to reflect the platform name
+        run: |
+          mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-files
+          path: |
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
-
 
   build-esp32sx:
     name: Build WipperSnapper ESP32-Sx
@@ -149,68 +148,77 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arduino-platform: ["magtag", "metroesp32s2", "feather_esp32s2",
-                           "feather_esp32s2_tft", "feather_esp32s2_reverse_tft",
-                           "feather_esp32s3", "feather_esp32s3_4mbflash_2mbpsram",
-                           "feather_esp32s3_tft", "qtpy_esp32s3",
-                           "qtpy_esp32s2", "feather_esp32s3_reverse_tft",
-                           "qtpy_esp32s3_n4r2"]
+        arduino-platform:
+          [
+            "magtag",
+            "metroesp32s2",
+            "feather_esp32s2",
+            "feather_esp32s2_tft",
+            "feather_esp32s2_reverse_tft",
+            "feather_esp32s3",
+            "feather_esp32s3_4mbflash_2mbpsram",
+            "feather_esp32s3_tft",
+            "qtpy_esp32s3",
+            "qtpy_esp32s2",
+            "feather_esp32s3_reverse_tft",
+            "qtpy_esp32s3_n4r2",
+          ]
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v4
-    - name: Get WipperSnapper version
-      run: |
-        git fetch --prune --unshallow --tags
-        git describe --dirty --tags
-        echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v4
-      with:
-         repository: adafruit/ci-arduino
-         path: ci
-    - name: Install CI-Arduino
-      run: bash ci/actions_install.sh
-    - name: Install extra Arduino libraries
-      run: |
-        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-        git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
-        git clone --quiet https://github.com/adafruit/Adafruit_HX8357_Library.git /home/runner/Arduino/libraries/Adafruit_HX8357_Library
-        git clone --quiet https://github.com/adafruit/Adafruit_ILI9341.git /home/runner/Arduino/libraries/Adafruit_ILI9341
-        git clone --quiet https://github.com/adafruit/Adafruit_STMPE610.git /home/runner/Arduino/libraries/Adafruit_STMPE610
-        git clone --quiet https://github.com/adafruit/Adafruit-ST7735-Library.git /home/runner/Arduino/libraries/Adafruit-ST7735-Library
-        git clone --quiet https://github.com/adafruit/Adafruit_TouchScreen.git /home/runner/Arduino/libraries/Adafruit_TouchScreen
-        git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
-        git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-    - name: Download and install stable Nanopb
-      run: |
-        # Download and extract nanopb
-        wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-        tar -xf nanopb-0.4.8.tar.gz
-        # Copy files to WipperSnapper's src/nanopb directory
-        cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
-        mv nanopb/pb.h src/nanopb/nanopb.pb.h
-    - name: List all files in Adafruit_LittlevGL_Glue_Library folder
-      run: |
-        ls /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-    - name: Copy lv_conf.h file in Adafruit_LittlevGL_Glue_Library to the arduino library folder
-      run: |
-        cp /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library/lv_conf.h /home/runner/Arduino/libraries
-    - name: Build for ESP32-SX
-      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
-    - name: list
-      run: |
-            ls
-            ls examples/*/build/
-    - name: Rename build artifacts to reflect the platform name
-      run: |
-            mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
-            mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: build-files
-        path: |
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: actions/checkout@v4
+      - name: Get WipperSnapper version
+        run: |
+          git fetch --prune --unshallow --tags
+          git describe --dirty --tags
+          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+      - uses: actions/checkout@v4
+        with:
+          repository: brentru/ci-arduino
+          path: ci
+      - name: Install CI-Arduino
+        run: bash ci/actions_install.sh
+      - name: Install extra Arduino libraries
+        run: |
+          git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+          git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
+          git clone --quiet https://github.com/adafruit/Adafruit_HX8357_Library.git /home/runner/Arduino/libraries/Adafruit_HX8357_Library
+          git clone --quiet https://github.com/adafruit/Adafruit_ILI9341.git /home/runner/Arduino/libraries/Adafruit_ILI9341
+          git clone --quiet https://github.com/adafruit/Adafruit_STMPE610.git /home/runner/Arduino/libraries/Adafruit_STMPE610
+          git clone --quiet https://github.com/adafruit/Adafruit-ST7735-Library.git /home/runner/Arduino/libraries/Adafruit-ST7735-Library
+          git clone --quiet https://github.com/adafruit/Adafruit_TouchScreen.git /home/runner/Arduino/libraries/Adafruit_TouchScreen
+          git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
+          git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
+      - name: Download and install stable Nanopb
+        run: |
+          # Download and extract nanopb
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+          tar -xf nanopb-0.4.8.tar.gz
+          # Copy files to WipperSnapper's src/nanopb directory
+          cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
+          mv nanopb/pb.h src/nanopb/nanopb.pb.h
+      - name: List all files in Adafruit_LittlevGL_Glue_Library folder
+        run: |
+          ls /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
+      - name: Copy lv_conf.h file in Adafruit_LittlevGL_Glue_Library to the arduino library folder
+        run: |
+          cp /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library/lv_conf.h /home/runner/Arduino/libraries
+      - name: Build for ESP32-SX
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
+      - name: list
+        run: |
+          ls
+          ls examples/*/build/
+      - name: Rename build artifacts to reflect the platform name
+        run: |
+          mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
+          mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-files
+          path: |
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
 
@@ -220,73 +228,80 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arduino-platform: ["wippersnapper_feather_esp32", "qtpy_esp32", "feather_esp32_v2", "itsybitsy_esp32", "wippersnapper_qtpy_esp32c3"]
+        arduino-platform:
+          [
+            "wippersnapper_feather_esp32",
+            "qtpy_esp32",
+            "feather_esp32_v2",
+            "itsybitsy_esp32",
+            "wippersnapper_qtpy_esp32c3",
+          ]
         include:
           - offset: "0x1000"
           - offset: "0x0"
             arduino-platform: "wippersnapper_qtpy_esp32c3"
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v4
-    - name: Get WipperSnapper version
-      run: |
-        git fetch --prune --unshallow --tags
-        git describe --dirty --tags
-        echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v4
-      with:
-        repository: adafruit/ci-arduino
-        path: ci
-    - name: Checkout Board Definitions
-      uses: actions/checkout@v4
-      with:
-        repository: adafruit/Wippersnapper_Boards
-        path: ws-boards
-    - name: Install CI-Arduino
-      run: bash ci/actions_install.sh
-    - name: Install extra Arduino libraries
-      run: |
-        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-        git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
-    - name: Download and install stable Nanopb
-      run: |
-        # Download and extract nanopb
-        wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-        tar -xf nanopb-0.4.8.tar.gz
-        # Copy files to WipperSnapper's src/nanopb directory
-        cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
-        mv nanopb/pb.h src/nanopb/nanopb.pb.h
-    - name: Install Dependencies
-      run: |
-        pip3 install esptool
-    - name: build ESP32 platforms
-      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
-    - name: Check artifacts
-      run: |
-        ls examples/Wippersnapper_demo/build/*
-    - name: Rename build artifacts to reflect the platform name
-      run: |
-            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
-            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.elf
-            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.map
-            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.bootloader.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin
-            mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.partitions.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin
-    - name: Check boot_app0 file existence (esp32 built from core, not-source)
-      id: check_files
-      uses: andstor/file-existence-action@v2
-      with:
-        files: "/home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin"
-    - name: boot_app0 file from arduino-cli core
-      if: steps.check_files.outputs.files_exists == 'true'
-      run: mv /home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin
-    - name: boot_app0 file from esp32 source bsp
-      if: steps.check_files.outputs.files_exists == 'false'
-      run: mv /home/runner/Arduino/hardware/espressif/esp32/tools/partitions/boot_app0.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin
-    - name: Get Board Flash Parameters
-      id: get_board_json
-      run: |
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: actions/checkout@v4
+      - name: Get WipperSnapper version
+        run: |
+          git fetch --prune --unshallow --tags
+          git describe --dirty --tags
+          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+      - uses: actions/checkout@v4
+        with:
+          repository: adafruit/ci-arduino
+          path: ci
+      - name: Checkout Board Definitions
+        uses: actions/checkout@v4
+        with:
+          repository: adafruit/Wippersnapper_Boards
+          path: ws-boards
+      - name: Install CI-Arduino
+        run: bash ci/actions_install.sh
+      - name: Install extra Arduino libraries
+        run: |
+          git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+          git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
+      - name: Download and install stable Nanopb
+        run: |
+          # Download and extract nanopb
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+          tar -xf nanopb-0.4.8.tar.gz
+          # Copy files to WipperSnapper's src/nanopb directory
+          cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
+          mv nanopb/pb.h src/nanopb/nanopb.pb.h
+      - name: Install Dependencies
+        run: |
+          pip3 install esptool
+      - name: build ESP32 platforms
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
+      - name: Check artifacts
+        run: |
+          ls examples/Wippersnapper_demo/build/*
+      - name: Rename build artifacts to reflect the platform name
+        run: |
+          mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
+          mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.elf
+          mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.map
+          mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.bootloader.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin
+          mv examples/Wippersnapper_demo/build/*/Wippersnapper_demo.ino.partitions.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin
+      - name: Check boot_app0 file existence (esp32 built from core, not-source)
+        id: check_files
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "/home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin"
+      - name: boot_app0 file from arduino-cli core
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: mv /home/runner/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin
+      - name: boot_app0 file from esp32 source bsp
+        if: steps.check_files.outputs.files_exists == 'false'
+        run: mv /home/runner/Arduino/hardware/espressif/esp32/tools/partitions/boot_app0.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin
+      - name: Get Board Flash Parameters
+        id: get_board_json
+        run: |
           board_name=${{ matrix.arduino-platform }}
           # Remove '_noota' suffix if present
           board_name=${board_name%_noota}
@@ -298,8 +313,8 @@ jobs:
             echo $content
             echo EOF
           } >> "$GITHUB_OUTPUT"
-    - name: Create combined binary using Esptool merge_bin
-      run: |
+      - name: Create combined binary using Esptool merge_bin
+        run: |
           echo ${{ steps.get_board_json.outputs.boardJson }}
           echo ${{ fromJson(steps.get_board_json.outputs.boardJson) }}
           python3 -m esptool --chip ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.chip}} merge_bin \
@@ -311,14 +326,14 @@ jobs:
             0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \
             0xe000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin \
             0x10000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
-    - name: Zip build artifacts
-      run: |
-            zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*
-    - name: upload build artifacts zip
-      uses: actions/upload-artifact@v3
-      with:
-        name: build-files
-        path: |
+      - name: Zip build artifacts
+        run: |
+          zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*
+      - name: upload build artifacts zip
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-files
+          path: |
             wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip
 
   build-samd:
@@ -327,48 +342,53 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arduino-platform: ["pyportal_tinyusb", "pyportal_titano_tinyusb", "metro_m4_airliftlite_tinyusb"]
+        arduino-platform:
+          [
+            "pyportal_tinyusb",
+            "pyportal_titano_tinyusb",
+            "metro_m4_airliftlite_tinyusb",
+          ]
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v4
-    - name: Get WipperSnapper version
-      run: |
-        git fetch --prune --unshallow --tags
-        git describe --dirty --tags
-        echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v4
-      with:
-         repository: adafruit/ci-arduino
-         path: ci
-    - name: Install CI-Arduino
-      run: bash ci/actions_install.sh
-      # manually install Adafruit WiFiNINA library fork
-    - name: Install extra Arduino libraries
-      run: |
-        git clone --quiet https://github.com/adafruit/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
-        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-        git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-    - name: Download and install stable Nanopb
-      run: |
-        # Download and extract nanopb
-        wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-        tar -xf nanopb-0.4.8.tar.gz
-        # Copy files to WipperSnapper's src/nanopb directory
-        cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
-        mv nanopb/pb.h src/nanopb/nanopb.pb.h
-    - name: build platforms
-      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
-    - name: Rename build artifacts to reflect the platform name
-      run: |
-            mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
-            mv examples/*/build/*/Wippersnapper_demo.ino.hex wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.hex
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: build-files
-        path: |
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: actions/checkout@v4
+      - name: Get WipperSnapper version
+        run: |
+          git fetch --prune --unshallow --tags
+          git describe --dirty --tags
+          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+      - uses: actions/checkout@v4
+        with:
+          repository: adafruit/ci-arduino
+          path: ci
+      - name: Install CI-Arduino
+        run: bash ci/actions_install.sh
+        # manually install Adafruit WiFiNINA library fork
+      - name: Install extra Arduino libraries
+        run: |
+          git clone --quiet https://github.com/adafruit/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
+          git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+          git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
+      - name: Download and install stable Nanopb
+        run: |
+          # Download and extract nanopb
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+          tar -xf nanopb-0.4.8.tar.gz
+          # Copy files to WipperSnapper's src/nanopb directory
+          cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
+          mv nanopb/pb.h src/nanopb/nanopb.pb.h
+      - name: build platforms
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
+      - name: Rename build artifacts to reflect the platform name
+        run: |
+          mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
+          mv examples/*/build/*/Wippersnapper_demo.ino.hex wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.hex
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-files
+          path: |
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.hex
 
@@ -380,46 +400,45 @@ jobs:
       matrix:
         arduino-platform: ["picow_rp2040_tinyusb"]
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v4
-    - name: Get WipperSnapper version
-      run: |
-        git fetch --prune --unshallow --tags
-        git describe --dirty --tags
-        echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v4
-      with:
-         repository: adafruit/ci-arduino
-         path: ci
-    - name: Install CI-Arduino
-      run: bash ci/actions_install.sh
-      # manually install OneWireNG/TempControlLib for OneWireNg (RP2040 Supported OneWire w/backwards compat.)
-    - name: Install extra Arduino libraries
-      run: |
-        git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
-        git clone --quiet https://github.com/pstolarz/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-    - name: Download and install stable Nanopb
-      run: |
-        # Download and extract nanopb
-        wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-        tar -xf nanopb-0.4.8.tar.gz
-        # Copy files to WipperSnapper's src/nanopb directory
-        cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
-        mv nanopb/pb.h src/nanopb/nanopb.pb.h
-    - name: build platforms
-      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
-    - name: Rename build artifacts to reflect the platform name
-      run: |
-            mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: build-files
-        path: |
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: actions/checkout@v4
+      - name: Get WipperSnapper version
+        run: |
+          git fetch --prune --unshallow --tags
+          git describe --dirty --tags
+          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+      - uses: actions/checkout@v4
+        with:
+          repository: adafruit/ci-arduino
+          path: ci
+      - name: Install CI-Arduino
+        run: bash ci/actions_install.sh
+        # manually install OneWireNG/TempControlLib for OneWireNg (RP2040 Supported OneWire w/backwards compat.)
+      - name: Install extra Arduino libraries
+        run: |
+          git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
+          git clone --quiet https://github.com/pstolarz/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+      - name: Download and install stable Nanopb
+        run: |
+          # Download and extract nanopb
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+          tar -xf nanopb-0.4.8.tar.gz
+          # Copy files to WipperSnapper's src/nanopb directory
+          cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
+          mv nanopb/pb.h src/nanopb/nanopb.pb.h
+      - name: build platforms
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
+      - name: Rename build artifacts to reflect the platform name
+        run: |
+          mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-files
+          path: |
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
-
 
   # NOTE: This does NOT release artifacts, it only builds
   build-samd-non-fs:
@@ -430,37 +449,37 @@ jobs:
       matrix:
         arduino-platform: ["mkrwifi1010", "nano_33_iot"]
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v4
-    - name: Get WipperSnapper version
-      run: |
-        git fetch --prune --unshallow --tags
-        git describe --dirty --tags
-        echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v4
-      with:
-         repository: adafruit/ci-arduino
-         path: ci
-    - name: Install CI-Arduino
-      run: bash ci/actions_install.sh
-    - name: Install extra Arduino libraries
-      run: |
-        git clone --quiet https://github.com/arduino-libraries/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
-        git clone --quiet https://github.com/arduino-libraries/Servo.git /home/runner/Arduino/libraries/Servo
-        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-        git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-    - name: Download and install stable Nanopb
-      run: |
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: actions/checkout@v4
+      - name: Get WipperSnapper version
+        run: |
+          git fetch --prune --unshallow --tags
+          git describe --dirty --tags
+          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+      - uses: actions/checkout@v4
+        with:
+          repository: adafruit/ci-arduino
+          path: ci
+      - name: Install CI-Arduino
+        run: bash ci/actions_install.sh
+      - name: Install extra Arduino libraries
+        run: |
+          git clone --quiet https://github.com/arduino-libraries/WiFiNINA.git /home/runner/Arduino/libraries/WiFiNINA
+          git clone --quiet https://github.com/arduino-libraries/Servo.git /home/runner/Arduino/libraries/Servo
+          git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+          git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
+      - name: Download and install stable Nanopb
+        run: |
           # Download and extract nanopb
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
           tar -xf nanopb-0.4.8.tar.gz
           # Copy files to WipperSnapper's src/nanopb directory
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
           mv nanopb/pb.h src/nanopb/nanopb.pb.h
-    - name: build platforms
-      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
+      - name: build platforms
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
 
   build-esp8266:
     name: Build WipperSnapper ESP8266
@@ -470,52 +489,52 @@ jobs:
       matrix:
         arduino-platform: ["feather_esp8266"]
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v4
-    - name: Get WipperSnapper version
-      run: |
-        git fetch --prune --unshallow --tags
-        git describe --dirty --tags
-        echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v4
-      with:
-         repository: adafruit/ci-arduino
-         path: ci
-    - name: Install CI-Arduino
-      run: bash ci/actions_install.sh
-    - name: Install extra Arduino library
-      run: |
-        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-        git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-    - name: Download and install stable Nanopb
-      run: |
-        # Download and extract nanopb
-        wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-        tar -xf nanopb-0.4.8.tar.gz
-        # Copy files to WipperSnapper's src/nanopb directory
-        cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
-        mv nanopb/pb.h src/nanopb/nanopb.pb.h
-    - name: build platforms
-      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
-    - name: list build artifacts
-      run: |
-            ls
-            ls examples/*
-    - name: Rename build artifacts to reflect the platform name
-      run: |
-            mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
-            mv examples/*/build/*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.elf
-            mv examples/*/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.map
-    - name: Zip build artifacts
-      run: |
-            zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*
-    - name: upload build artifacts zip
-      uses: actions/upload-artifact@v3
-      with:
-        name: build-files
-        path: |
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: actions/checkout@v4
+      - name: Get WipperSnapper version
+        run: |
+          git fetch --prune --unshallow --tags
+          git describe --dirty --tags
+          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+      - uses: actions/checkout@v4
+        with:
+          repository: adafruit/ci-arduino
+          path: ci
+      - name: Install CI-Arduino
+        run: bash ci/actions_install.sh
+      - name: Install extra Arduino library
+        run: |
+          git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+          git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
+      - name: Download and install stable Nanopb
+        run: |
+          # Download and extract nanopb
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+          tar -xf nanopb-0.4.8.tar.gz
+          # Copy files to WipperSnapper's src/nanopb directory
+          cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
+          mv nanopb/pb.h src/nanopb/nanopb.pb.h
+      - name: build platforms
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
+      - name: list build artifacts
+        run: |
+          ls
+          ls examples/*
+      - name: Rename build artifacts to reflect the platform name
+        run: |
+          mv examples/*/build/*/Wippersnapper_demo.ino.bin wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin
+          mv examples/*/build/*/Wippersnapper_demo.ino.elf wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.elf
+          mv examples/*/build/*/Wippersnapper_demo.ino.map wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.map
+      - name: Zip build artifacts
+        run: |
+          zip -r wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.*
+      - name: upload build artifacts zip
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-files
+          path: |
             wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.zip
 
   build-esp32sx-dev:
@@ -524,90 +543,102 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arduino-platform: ["feather_esp32s2_debug", "feather_esp32s2_tft_debug",
-                           "feather_esp32s3_debug", "feather_esp32s3_4mbflash_2mbpsram_debug", "feather_esp32s3_tft_debug"]
+        arduino-platform:
+          [
+            "feather_esp32s2_debug",
+            "feather_esp32s2_tft_debug",
+            "feather_esp32s3_debug",
+            "feather_esp32s3_4mbflash_2mbpsram_debug",
+            "feather_esp32s3_tft_debug",
+          ]
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v4
-    - name: Get WipperSnapper version
-      run: |
-        git fetch --prune --unshallow --tags
-        git describe --dirty --tags
-        echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
-    - uses: actions/checkout@v4
-      with:
-         repository: adafruit/ci-arduino
-         path: ci
-    - name: Install CI-Arduino
-      run: bash ci/actions_install.sh
-    - name: Install extra Arduino libraries
-      run: |
-        git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-        git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
-        git clone --quiet https://github.com/adafruit/Adafruit_HX8357_Library.git /home/runner/Arduino/libraries/Adafruit_HX8357_Library
-        git clone --quiet https://github.com/adafruit/Adafruit_ILI9341.git /home/runner/Arduino/libraries/Adafruit_ILI9341
-        git clone --quiet https://github.com/adafruit/Adafruit_STMPE610.git /home/runner/Arduino/libraries/Adafruit_STMPE610
-        git clone --quiet https://github.com/adafruit/Adafruit-ST7735-Library.git /home/runner/Arduino/libraries/Adafruit-ST7735-Library
-        git clone --quiet https://github.com/adafruit/Adafruit_TouchScreen.git /home/runner/Arduino/libraries/Adafruit_TouchScreen
-        git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
-        git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-    - name: Download and install stable Nanopb
-      run: |
-        # Download and extract nanopb
-        wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-        tar -xf nanopb-0.4.8.tar.gz
-        # Copy files to WipperSnapper's src/nanopb directory
-        cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
-        mv nanopb/pb.h src/nanopb/nanopb.pb.h
-    - name: List all files in Adafruit_LittlevGL_Glue_Library folder
-      run: |
-        ls /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-    - name: Copy lv_conf.h file in Adafruit_LittlevGL_Glue_Library to the arduino library folder
-      run: |
-        cp /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library/lv_conf.h /home/runner/Arduino/libraries
-    - name: Build for ESP32-SX
-      run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
-    - name: list
-      run: |
-            ls
-            ls examples/*/build/
-    - name: Rename build artifacts to reflect the platform name
-      run: |
-            mv examples/*/build/*/wippersnapper_debug.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
-            mv examples/*/build/*/wippersnapper_debug.ino.bin wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: build-files-dev
-        path: |
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: actions/checkout@v4
+      - name: Get WipperSnapper version
+        run: |
+          git fetch --prune --unshallow --tags
+          git describe --dirty --tags
+          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+      - uses: actions/checkout@v4
+        with:
+          repository: adafruit/ci-arduino
+          path: ci
+      - name: Install CI-Arduino
+        run: bash ci/actions_install.sh
+      - name: Install extra Arduino libraries
+        run: |
+          git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
+          git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
+          git clone --quiet https://github.com/adafruit/Adafruit_HX8357_Library.git /home/runner/Arduino/libraries/Adafruit_HX8357_Library
+          git clone --quiet https://github.com/adafruit/Adafruit_ILI9341.git /home/runner/Arduino/libraries/Adafruit_ILI9341
+          git clone --quiet https://github.com/adafruit/Adafruit_STMPE610.git /home/runner/Arduino/libraries/Adafruit_STMPE610
+          git clone --quiet https://github.com/adafruit/Adafruit-ST7735-Library.git /home/runner/Arduino/libraries/Adafruit-ST7735-Library
+          git clone --quiet https://github.com/adafruit/Adafruit_TouchScreen.git /home/runner/Arduino/libraries/Adafruit_TouchScreen
+          git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
+          git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
+      - name: Download and install stable Nanopb
+        run: |
+          # Download and extract nanopb
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+          tar -xf nanopb-0.4.8.tar.gz
+          # Copy files to WipperSnapper's src/nanopb directory
+          cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
+          mv nanopb/pb.h src/nanopb/nanopb.pb.h
+      - name: List all files in Adafruit_LittlevGL_Glue_Library folder
+        run: |
+          ls /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
+      - name: Copy lv_conf.h file in Adafruit_LittlevGL_Glue_Library to the arduino library folder
+        run: |
+          cp /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library/lv_conf.h /home/runner/Arduino/libraries
+      - name: Build for ESP32-SX
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
+      - name: list
+        run: |
+          ls
+          ls examples/*/build/
+      - name: Rename build artifacts to reflect the platform name
+        run: |
+          mv examples/*/build/*/wippersnapper_debug.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
+          mv examples/*/build/*/wippersnapper_debug.ino.bin wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-files-dev
+          path: |
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
 
-
-
   clang_and_doxy:
     runs-on: ubuntu-latest
-    needs: [build-samd, build-esp32, build-esp32sx, build-esp8266, build-samd-non-fs, build-rp2040]
+    needs:
+      [
+        build-samd,
+        build-esp32,
+        build-esp32sx,
+        build-esp8266,
+        build-samd-non-fs,
+        build-rp2040,
+      ]
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: actions/checkout@v4
 
-    - uses: actions/checkout@v4
-      with:
-         repository: adafruit/ci-arduino
-         path: ci
-    - name: pre-install
-      run: bash ci/actions_install.sh
+      - uses: actions/checkout@v4
+        with:
+          repository: adafruit/ci-arduino
+          path: ci
+      - name: pre-install
+        run: bash ci/actions_install.sh
 
-    - name: clang
-      run: python3 ci/run-clang-format.py -r -e "ci/*" -e "bin/*" -e src/nanopb -e src/wippersnapper -e src/pb.h -e src/provisioning/tinyusb  src/
+      - name: clang
+        run: python3 ci/run-clang-format.py -r -e "ci/*" -e "bin/*" -e src/nanopb -e src/wippersnapper -e src/pb.h -e src/provisioning/tinyusb  src/
 
-    - name: doxygen
-      env:
-        GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
-        PRETTYNAME : "Adafruit.io WipperSnapper Library"
-      run: bash ci/doxy_gen_and_deploy.sh
+      - name: doxygen
+        env:
+          GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
+          PRETTYNAME: "Adafruit.io WipperSnapper Library"
+        run: bash ci/doxy_gen_and_deploy.sh

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.84
+version=1.0.0-beta.85
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino application for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -90,7 +90,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.84" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.85" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic


### PR DESCRIPTION
arduino-esp32 board support package v3.0.2 causes an infinite reboot error when used with ESP32-S3 boards with PSRAM. 

This patch transfers the ci for these build targets to use the brentru/ci-arduino fork, which has manual instructions to build WipperSnapper using esp32 BSP 3.0.1 for the affected boards.