### PR TITLE
Adjust SGP30 init to not call IAQinit unnecessarily

### DIFF
--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
@@ -44,11 +44,7 @@ public:
   /*******************************************************************************/
   bool begin() {
     _sgp30 = new Adafruit_SGP30();
-    bool isInit = _sgp30->begin(_i2c);
-    if (isInit) {
-      _sgp30->IAQinit();
-    }
-    return isInit;
+    return _sgp30->begin(_i2c);
   }
 
   bool getEventECO2(sensors_event_t *senseEvent) {


### PR DESCRIPTION
~~Minor tweak to the SGP30 initialisation to fail if IAQ doesn't initialise successfully instead of ignoring it.
Needs retesting - was in the way on another branch~~

Updated PR to be for the removal of the IAQinit call, as it's called here https://github.com/adafruit/Adafruit_SGP30/blob/b4a631b1d75996a4dc2b1dda07e02a8529365d33/Adafruit_SGP30.cpp#L73