### PR TITLE
Build S3 targets on Adafruit CI

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -175,7 +175,7 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: brentru/ci-arduino
+          repository: adafruit/ci-arduino
           path: ci
       - name: Install CI-Arduino
         run: bash ci/actions_install.sh

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.85
+version=1.0.0-beta.86
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino application for Adafruit.io WipperSnapper


### PR DESCRIPTION
ESP32-S3 boards with QSPI on ESP32 Board Support Package 3.0.2 were experiencing crashes. This was due to an issue specific to the 3.0.2 BSP. Espressif fixed this in ESP32 BSP 3.0.3, which includes a temporary fix for mmu map and late init of psram (see - https://github.com/espressif/esp32-arduino-lib-builder/pull/188)

This pull request builds WipperSnapper from the Adafruit Arduino-CI repository, bypassing a forked CI with changes related to this issue.