### PR TITLE
Add local build environment for arduino-esp32 bsp 3.0.3 and PIO

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -80,10 +80,7 @@ lib_deps =
 
 ; Common build environment for ESP32 platform
 [common:esp32]
-platform = https://github.com/platformio/platform-espressif32.git#develop
-platform_packages =
-	platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.2
-	platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-release/v5.1
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.03/platform-espressif32.zip
 lib_ignore = WiFiNINA
 monitor_filters = esp32_exception_decoder, time
 


### PR DESCRIPTION
@tyeth  I'm changing the esp32-specific build step to utilize the community platformio support. This'll help us build locally off the latest BSP (currently 3.0.3).

I'd do the first two steps on this thread (https://github.com/espressif/arduino-esp32/discussions/10039#discussioncomment-10094878) to ensure you're deleting your cache and building using the correct files. 

Also, if you are using a computer that pioarduino is missing from the Registry (https://github.com/pioarduino/registry), please  follow the steps above to checkout a PR so we can help their community-led effort. My computer's architecture is already listed.

Related Discussion - https://github.com/espressif/arduino-esp32/discussions/10039