### PR TITLE
Print ESP-IDF and arduino-esp32 core versions to the boot file

### DIFF
--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -115,9 +115,10 @@
 #include "components/digitalIO/Wippersnapper_DigitalGPIO.h"
 #include "components/i2c/WipperSnapper_I2C.h"
 
-// LEDC-Manager, ESP32-only
+// Inlcudes for ESP32-only
 #ifdef ARDUINO_ARCH_ESP32
 #include "components/ledc/ws_ledc.h"
+#include <Esp.h>
 #endif
 
 // Display

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -279,6 +279,16 @@ bool Wippersnapper_FS::createBootFile() {
     bootFile.print("MAC Address: ");
     bootFile.println(sMAC);
 
+    // Print ESP-specific info to boot file
+    #ifdef ARDUINO_ARCH_ESP32
+    // Get version of ESP-IDF
+    bootFile.print("ESP-IDF Version: ");
+    bootFile.println(ESP.getSdkVersion());
+    // Get version of this core
+    bootFile.print("ESP32 Core Version: ");
+    bootFile.println(ESP.getCoreVersion());
+    #endif
+
     bootFile.flush();
     bootFile.close();
     is_success = true;


### PR DESCRIPTION
This pull request prints the ESP-IDF version and arduino-esp32 core versions to the boot text file.

@tyeth  Would it be possible to double-check this works and tests OK? I used a QT Py ESP32-S2.

Resolves: https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/597