### PR TITLE
Switch Analog Voltage on esp32 to use analogReadMilliVolts

### DIFF
--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -87,8 +87,8 @@ void Wippersnapper_AnalogIO::setADCResolution(int resolution) {
   analogReadResolution(16);
   _nativeResolution = 12;
 #elif defined(ARDUINO_ARCH_ESP32)
-  scaleAnalogRead = true;
-  _nativeResolution = 13;
+  scaleAnalogRead = false; // handled in bsp
+  _nativeResolution = 13;  // S3 ADC is 13-bit, others are 12-bit
 #elif defined(ARDUINO_ARCH_RP2040)
   scaleAnalogRead = true;
   _nativeResolution = 10;
@@ -96,7 +96,6 @@ void Wippersnapper_AnalogIO::setADCResolution(int resolution) {
   scaleAnalogRead = true;
   _nativeResolution = 10;
 #endif
-
   _adcResolution = resolution;
 }
 
@@ -233,8 +232,10 @@ uint16_t Wippersnapper_AnalogIO::getPinValue(int pin) {
 /**********************************************************/
 float Wippersnapper_AnalogIO::getPinValueVolts(int pin) {
 #ifdef ARDUINO_ARCH_ESP32
+  WS_DEBUG_PRINTLN("ESP32: Using analogReadMilliVolts()");
   return analogReadMilliVolts(pin) / 1000.0;
 #else
+  WS_DEBUG_PRINTLN("Using old getPinValueVolts()");
   uint16_t rawValue = getPinValue(pin);
   return rawValue * getAref() / 65536;
 #endif

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -386,7 +386,7 @@ void Wippersnapper_AnalogIO::update() {
           // Perform voltage conversion if we need to
           if (_analog_input_pins[i].readMode ==
               wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode_ANALOG_READ_MODE_PIN_VOLTAGE) {
-            pinValVolts = pinValRaw * getAref() / 65536;
+            pinValVolts = getPinValueVolts(_analog_input_pins[i].pinName);
           }
 
           // Publish pin event to IO

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "Wippersnapper_AnalogIO.h"
+#include "Wippersnapper.h"
 
 /***********************************************************************************/
 /*!
@@ -87,7 +88,7 @@ void Wippersnapper_AnalogIO::setADCResolution(int resolution) {
   analogReadResolution(16);
   _nativeResolution = 12;
 #elif defined(ARDUINO_ARCH_ESP32)
-  scaleAnalogRead = false; // handled in bsp
+  scaleAnalogRead = true; // probably should be false, handled in bsp
   _nativeResolution = 13;  // S3 ADC is 13-bit, others are 12-bit
 #elif defined(ARDUINO_ARCH_RP2040)
   scaleAnalogRead = true;

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "Wippersnapper_AnalogIO.h"
-#include "Wippersnapper.h"
 
 /***********************************************************************************/
 /*!
@@ -89,7 +88,11 @@ void Wippersnapper_AnalogIO::setADCResolution(int resolution) {
   _nativeResolution = 12;
 #elif defined(ARDUINO_ARCH_ESP32)
   scaleAnalogRead = true; // probably should be false, handled in bsp
-  _nativeResolution = 13;  // S3 ADC is 13-bit, others are 12-bit
+#if defined(ESP32S3)
+  _nativeResolution = 13; // S3 ADC is 13-bit, others are 12-bit
+#else
+  _nativeResolution = 12;
+#endif
 #elif defined(ARDUINO_ARCH_RP2040)
   scaleAnalogRead = true;
   _nativeResolution = 10;
@@ -233,10 +236,8 @@ uint16_t Wippersnapper_AnalogIO::getPinValue(int pin) {
 /**********************************************************/
 float Wippersnapper_AnalogIO::getPinValueVolts(int pin) {
 #ifdef ARDUINO_ARCH_ESP32
-  WS_DEBUG_PRINTLN("ESP32: Using analogReadMilliVolts()");
   return analogReadMilliVolts(pin) / 1000.0;
 #else
-  WS_DEBUG_PRINTLN("Using old getPinValueVolts()");
   uint16_t rawValue = getPinValue(pin);
   return rawValue * getAref() / 65536;
 #endif

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -232,8 +232,12 @@ uint16_t Wippersnapper_AnalogIO::getPinValue(int pin) {
 */
 /**********************************************************/
 float Wippersnapper_AnalogIO::getPinValueVolts(int pin) {
+#ifdef ARDUINO_ARCH_ESP32
+  return analogReadMilliVolts(pin) / 1000.0;
+#else
   uint16_t rawValue = getPinValue(pin);
   return rawValue * getAref() / 65536;
+#endif
 }
 
 /******************************************************************/


### PR DESCRIPTION
Having issues with the C6 (set aVref to 1.1v and got 0.48v from 3v3 signal).
 Just wanted to look into attenuation and the aVref, but saw that analogReadMilliVolts returned the calibrated millivolts, rather than the raw adc value which is uncalibrated.

This PR now switches both periodic and on_change to use the same functions, along with using analogReadMilliVolts for ESP32 based boards.