### PR TITLE
Fix WiFi Scan Issue

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -33,7 +33,7 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: adafruit/ci-arduino
+          repository: brentru/ci-arduino
           path: ci
       - name: Checkout Board Definitions
         uses: actions/checkout@v4
@@ -258,7 +258,7 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: adafruit/ci-arduino
+          repository: brentru/ci-arduino
           path: ci
       - name: Checkout Board Definitions
         uses: actions/checkout@v4
@@ -646,7 +646,7 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: adafruit/ci-arduino
+          repository: brentru/ci-arduino
           path: ci
       - name: Checkout Board Definitions
         uses: actions/checkout@v4

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-esp32sx-esptool:
-    name: Build WipperSnapper ESP32-Sx
+    name: Build ESP32-Sx
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -144,7 +144,7 @@ jobs:
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
 
   build-esp32sx:
-    name: Build WipperSnapper ESP32-Sx
+    name: Build ESP32-Sx
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -226,7 +226,7 @@ jobs:
             wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.bin
 
   build-esp32:
-    name: Build WipperSnapper ESP32, ESP32-Cx
+    name: Build ESP32 and Cx
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           repository: brentru/ci-arduino
           path: ci
+          ref: add-ws-partition-scheme-targets
       - name: Checkout Board Definitions
         uses: actions/checkout@v4
         with:
@@ -260,6 +261,7 @@ jobs:
         with:
           repository: brentru/ci-arduino
           path: ci
+          ref: add-ws-partition-scheme-targets
       - name: Checkout Board Definitions
         uses: actions/checkout@v4
         with:
@@ -648,6 +650,7 @@ jobs:
         with:
           repository: brentru/ci-arduino
           path: ci
+          ref: add-ws-partition-scheme-targets
       - name: Checkout Board Definitions
         uses: actions/checkout@v4
         with:

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.89
+version=1.0.0-beta.90
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino application for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -142,7 +142,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.89" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.90" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic


### PR DESCRIPTION
Attempts to patch WiFi Scan issue in Beta 89 by building WipperSnapper firmware off the latest `espressif/arduino-esp32` master branch that includes a patch for the WiFi AP Scan issue and also includes updates for TinyUF2.


Resolves: https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/628