### PR TITLE
Update build action to build on adafruit/ci-arduino's new wippersnapper branch

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -33,9 +33,9 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: brentru/ci-arduino
+          repository: adafruit/ci-arduino
           path: ci
-          ref: add-ws-partition-scheme-targets
+          ref: ci-wippersnapper
       - name: Checkout Board Definitions
         uses: actions/checkout@v4
         with:
@@ -177,9 +177,9 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: brentru/ci-arduino
+          repository: adafruit/ci-arduino
           path: ci
-          ref: add-ws-partition-scheme-targets
+          ref: ci-wippersnapper
       - name: Install CI-Arduino
         run: bash ci/actions_install.sh
       - name: Install extra Arduino libraries
@@ -259,9 +259,9 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: brentru/ci-arduino
+          repository: adafruit/ci-arduino
           path: ci
-          ref: add-ws-partition-scheme-targets
+          ref: ci-wippersnapper
       - name: Checkout Board Definitions
         uses: actions/checkout@v4
         with:
@@ -573,9 +573,9 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: brentru/ci-arduino
+          repository: adafruit/ci-arduino
           path: ci
-          ref: add-ws-partition-scheme-targets
+          ref: ci-wippersnapper
       - name: Install CI-Arduino
         run: bash ci/actions_install.sh
       - name: Install extra Arduino libraries
@@ -648,9 +648,9 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: brentru/ci-arduino
+          repository: adafruit/ci-arduino
           path: ci
-          ref: add-ws-partition-scheme-targets
+          ref: ci-wippersnapper
       - name: Checkout Board Definitions
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**Motivation**
This pull request simplifies our process for building WipperSnapper Arduino and allows us to: 
1) Not build WipperSnapper from arduino-esp32 release, by default
2) Apply patches to a fork/branch of the arduino-esp32 bsp. This will allow for us to stop waiting for a new release and patch/rebuild WS directly.
3) Build specific platforms (i.e: FunHouse ESP32-S2) on specific BSP versions (or patched BSP versions)


**Technical Details**
Instead of using adafruit/ci-arduino, which pulls from the [latest arduino-esp32 release](https://github.com/espressif/arduino-esp32/releases/latest), this PR points `build-clang-doxy.yml` to the `ci-wippersnapper` branch of adafruit/ci-arduino. 

Within this branch is a modified `all_platforms.py` file which:
1) Points to a branch of adafruit/arduino-esp32 corresponding to a release of the espressif/arduino-esp32.

> For example, the `all_platforms.py` targets currently point to the repo adafruit/arduino-esp32 and branch `wipper-bsp-3.0.5-idf-5.1.4`. This branch is wippersnapper-specific (denoted by the `wipper-` prefix), builds on espressif/arduino-esp32's release 3.0.5 (`bsp-3.0.5`), and uses ESP-IDF 5.1.4 (`idf-5.1.4`).


2) Prefixes the platform's FQBN with `espressif:`, allowing it to build from source rather than a pre-packaged release.


@ladyada  - As a result of this PR and tooling changes, you may see some new branches across adafruit/arduino-esp32 (i.e: https://github.com/adafruit/arduino-esp32/tree/wipper-bsp-3.0.5-idf-5.1.4) to track espressif's releases. We are also using the `ci-wippersnapper` branch of adafruit/ci-arduino as a build script for WipperSnapper. 