### PR TITLE
Use analogReadMilliVolts for esp32 and update hysteresis

### DIFF
--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -325,7 +325,7 @@ bool Wippersnapper_AnalogIO::encodePinEvent(
 */
 /**********************************************************/
 void calculateHysteresis(analogInputPin pin, uint16_t pinValRaw,
-                         uint16_t pinValThreshHi, uint16_t pinValThreshLow) {
+                         uint16_t *pinValThreshHi, uint16_t *pinValThreshLow) {
   // All boards ADC values scaled to 16bit, in future we may need to
   // adjust dynamically
   uint16_t maxDecimalValue = 65535;
@@ -344,8 +344,8 @@ void calculateHysteresis(analogInputPin pin, uint16_t pinValRaw,
   }
 
   // get the threshold values for previous pin value
-  pinValThreshHi = pin.prvPinVal + CURRENT_HYSTERISIS;
-  pinValThreshLow = pin.prvPinVal - CURRENT_HYSTERISIS;
+  *pinValThreshHi = pin.prvPinVal + CURRENT_HYSTERISIS;
+  *pinValThreshLow = pin.prvPinVal - CURRENT_HYSTERISIS;
 }
 
 /**********************************************************/
@@ -425,8 +425,8 @@ void Wippersnapper_AnalogIO::update() {
 
         // check if pin value has changed enough
         uint16_t pinValThreshHi, pinValThreshLow;
-        calculateHysteresis(_analog_input_pins[i], pinValRaw, pinValThreshHi,
-                            pinValThreshLow);
+        calculateHysteresis(_analog_input_pins[i], pinValRaw, &pinValThreshHi,
+                            &pinValThreshLow);
         WS_DEBUG_PRINT("Returned pinValThreshHi: ");
         WS_DEBUG_PRINTLN(pinValThreshHi);
         WS_DEBUG_PRINT("Returned pinValThreshLow: ");

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -316,14 +316,16 @@ bool Wippersnapper_AnalogIO::encodePinEvent(
     @brief    Calculates the hysteresis for the pin value.
     @param    pin
               The desired analog pin to calculate hysteresis for.
-    @param    _pinValThreshHi
+    @param    pinValRaw
+              The pin's raw value.
+    @param    pinValThreshHi
               The pin's high threshold value.
-    @param    _pinValThreshLow
+    @param    pinValThreshLow
               The pin's low threshold value.
 */
 /**********************************************************/
 void calculateHysteresis(analogInputPin pin, uint16_t pinValRaw,
-                         uint16_t _pinValThreshHi, uint16_t _pinValThreshLow) {
+                         uint16_t pinValThreshHi, uint16_t pinValThreshLow) {
   // All boards ADC values scaled to 16bit, in future we may need to
   // adjust dynamically
   uint16_t maxDecimalValue = 65535;
@@ -342,8 +344,8 @@ void calculateHysteresis(analogInputPin pin, uint16_t pinValRaw,
   }
 
   // get the threshold values for previous pin value
-  _pinValThreshHi = pin.prvPinVal + CURRENT_HYSTERISIS;
-  _pinValThreshLow = pin.prvPinVal - CURRENT_HYSTERISIS;
+  pinValThreshHi = pin.prvPinVal + CURRENT_HYSTERISIS;
+  pinValThreshLow = pin.prvPinVal - CURRENT_HYSTERISIS;
 }
 
 /**********************************************************/

--- a/src/components/analogIO/Wippersnapper_AnalogIO.cpp
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.cpp
@@ -424,12 +424,18 @@ void Wippersnapper_AnalogIO::update() {
         uint16_t pinValRaw = getPinValue(_analog_input_pins[i].pinName);
 
         // check if pin value has changed enough
-        uint16_t _pinValThreshHi, _pinValThreshLow;
-        calculateHysteresis(_analog_input_pins[i], pinValRaw, _pinValThreshHi,
-                            _pinValThreshLow);
+        uint16_t pinValThreshHi, pinValThreshLow;
+        calculateHysteresis(_analog_input_pins[i], pinValRaw, pinValThreshHi,
+                            pinValThreshLow);
+        WS_DEBUG_PRINT("Returned pinValThreshHi: ");
+        WS_DEBUG_PRINTLN(pinValThreshHi);
+        WS_DEBUG_PRINT("Returned pinValThreshLow: ");
+        WS_DEBUG_PRINTLN(pinValThreshLow);
+        WS_DEBUG_PRINT("Current pinValRaw: ");
+        WS_DEBUG_PRINTLN(pinValRaw);
 
         if (_analog_input_pins[i].prvPeriod == 0 ||
-            pinValRaw > _pinValThreshHi || pinValRaw < _pinValThreshLow) {
+            pinValRaw > pinValThreshHi || pinValRaw < pinValThreshLow) {
           // Perform voltage conversion if we need to
           if (_analog_input_pins[i].readMode ==
               wippersnapper_pin_v1_ConfigurePinRequest_AnalogReadMode_ANALOG_READ_MODE_PIN_VOLTAGE) {

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -57,8 +57,6 @@ public:
                   int pin);
   void disableAnalogInPin(int pin);
 
-  void calculateHysteresis(analogInputPin pin, uint16_t pinValRaw,
-                           uint16_t pinValThreshHi, uint16_t pinValThreshLow);
   uint16_t getPinValue(int pin);
   float getPinValueVolts(int pin);
 

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -58,7 +58,7 @@ public:
   void disableAnalogInPin(int pin);
 
   void calculateHysteresis(analogInputPin pin, uint16_t pinValRaw,
-                           uint16_t &_pinValThreshHi, uint16_t &_pinValThreshLow);
+                           uint16_t pinValThreshHi, uint16_t pinValThreshLow);
   uint16_t getPinValue(int pin);
   float getPinValueVolts(int pin);
 

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -63,7 +63,8 @@ public:
   void setADCResolution(int resolution);
   int getADCresolution();
   int getNativeResolution();
-  bool timerExpired(long currentTime, analogInputPin pin);
+  bool timerExpired(long currentTime, analogInputPin pin,
+                    long periodOffset = 0);
 
   void update();
   bool encodePinEvent(

--- a/src/components/analogIO/Wippersnapper_AnalogIO.h
+++ b/src/components/analogIO/Wippersnapper_AnalogIO.h
@@ -57,6 +57,8 @@ public:
                   int pin);
   void disableAnalogInPin(int pin);
 
+  void calculateHysteresis(analogInputPin pin, uint16_t pinValRaw,
+                           uint16_t &_pinValThreshHi, uint16_t &_pinValThreshLow);
   uint16_t getPinValue(int pin);
   float getPinValueVolts(int pin);
 


### PR DESCRIPTION
~~For CI assets, testing https://github.com/tyeth/Adafruit_Wippersnapper_Arduino/blob/50f17026832ba9a53d0f919a69b8e9106302fe55/src/components/analogIO/Wippersnapper_AnalogIO.cpp#L90~~

Combined PR including millivolt change and updated hysteresis method:

This PR now switches both periodic and on_change to use the same functions, along with using analogReadMilliVolts for ESP32 based boards.

Also this modifies the on_change event to use a sliding scale of hysteresis. Originally the code awaited a 2% change in the last raw value.
Now the scale is divided into thirds, with the lower third using the default hysteresis value of 2% applied to the whole 16bit max value (65k), which results in less bounce around 0 due to wifi / power fluctuations, the middle third using double that threshold change, and the last third quadruple that default hysteresis (where a 200mV spike was generally observed around 3.1v). There is also a 500ms anti-hammer situation on top of the hysteresis requirement.

Tested with a 10k stemma Potentiometer, and separately with a resistor divider to test stability.

It occurs to me that 500ms might be too long for some people, maybe it can be configurable in the future.