### PR TITLE
Update release task to use nested build-files assets

### DIFF
--- a/.github/workflows/release-callee.yml
+++ b/.github/workflows/release-callee.yml
@@ -22,6 +22,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-                  wippersnapper.*.uf2
-                  wippersnapper.*.bin
-                  wippersnapper.*.zip
+                  build-files/wippersnapper.*.uf2
+                  build-files/wippersnapper.*.bin
+                  build-files/wippersnapper.*.zip


### PR DESCRIPTION
This is untested, but going on the ls from the last release attempt there is clearly one folder per zip/group of assets
https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/actions/runs/11443957387/job/31839330119#step:3:5

