### PR TITLE
Fix C6 Build

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -264,8 +264,8 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: brentru/ci-arduino
-          ref: debug-c6
+          repository: adafruit/ci-arduino
+          ref: ci-wippersnapper
           path: ci
       - name: Checkout Board Definitions
         uses: actions/checkout@v4

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -291,7 +291,7 @@ jobs:
           mv nanopb/pb.h src/nanopb/nanopb.pb.h
       - name: Install Dependencies
         run: |
-          pip3 install esptool
+          pip install esptool==4.6
       - name: build ESP32 platforms
         run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
       - name: Check artifacts

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -342,7 +342,7 @@ jobs:
             --flash_size keep \
             --fill-flash-size 4MB \
             -o wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.combined.bin \
-            ${{ matrix.offset }} wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
+            0x0 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
             0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \
             0xe000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin \
             0x10000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -244,8 +244,7 @@ jobs:
             "feather_esp32_v2",
             "itsybitsy_esp32",
             "wippersnapper_qtpy_esp32c3",
-            "wippersnapper_feather_esp32c6",
-            "wippersnapper_feather_esp32c6_debug"
+            "wippersnapper_feather_esp32c6"
           ]
         include:
           - offset: "0x1000"
@@ -253,8 +252,6 @@ jobs:
             arduino-platform: "wippersnapper_qtpy_esp32c3"
           - offset: "0x0"
             arduino-platform: "wippersnapper_feather_esp32c6"
-          - offset: "0x0"
-            arduino-platform: "wippersnapper_feather_esp32c6_debug"
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -329,9 +326,6 @@ jobs:
             echo $content
             echo EOF
           } >> "$GITHUB_OUTPUT"
-      - name: Print matrix offset
-        run: |
-          echo "Matrix offset: ${{ matrix.offset }}"
       - name: Create combined binary using Esptool merge_bin
         run: |
           echo ${{ steps.get_board_json.outputs.boardJson }}
@@ -341,7 +335,7 @@ jobs:
             --flash_freq ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashFreq}} \
             --flash_size ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashSize}} \
             -o wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.combined.bin \
-            0x0 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
+            ${{ matrix.offset }} wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
             0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \
             0xe000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin \
             0x10000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -329,6 +329,9 @@ jobs:
             echo $content
             echo EOF
           } >> "$GITHUB_OUTPUT"
+      - name: Print matrix offset
+        run: |
+          echo "Matrix offset: ${{ matrix.offset }}"
       - name: Create combined binary using Esptool merge_bin
         run: |
           echo ${{ steps.get_board_json.outputs.boardJson }}

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -340,6 +340,7 @@ jobs:
             --flash_mode ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashMode}} \
             --flash_freq ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashFreq}} \
             --flash_size ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashSize}} \
+            --fill-flash-size ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashSize}} \
             -o wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.combined.bin \
             ${{ matrix.offset }} wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
             0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -251,6 +251,10 @@ jobs:
           - offset: "0x1000"
           - offset: "0x0"
             arduino-platform: "wippersnapper_qtpy_esp32c3"
+          - offset: "0x0"
+            arduino-platform: "wippersnapper_feather_esp32c6"
+          - offset: "0x0"
+            arduino-platform: "wippersnapper_feather_esp32c6_debug"
     steps:
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -341,7 +341,7 @@ jobs:
             --flash_freq ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashFreq}} \
             --flash_size ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashSize}} \
             -o wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.combined.bin \
-            ${{ matrix.offset }} wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
+            0x0 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
             0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \
             0xe000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin \
             0x10000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -245,13 +245,12 @@ jobs:
             "itsybitsy_esp32",
             "wippersnapper_qtpy_esp32c3",
             "wippersnapper_feather_esp32c6",
+            "wippersnapper_feather_esp32c6_debug"
           ]
         include:
           - offset: "0x1000"
           - offset: "0x0"
             arduino-platform: "wippersnapper_qtpy_esp32c3"
-          - offset: "0x0"
-            arduino-platform: "wippersnapper_feather_esp32c6"
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -264,8 +263,8 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: tyeth/ci-arduino
-          ref: WS_ARDUINO_598-preprocessor-script-for-printing-the-library-versions-to-boot_outtxt
+          repository: brentru/ci-arduino
+          ref: debug-c6
           path: ci
       - name: Checkout Board Definitions
         uses: actions/checkout@v4
@@ -290,7 +289,7 @@ jobs:
         run: |
           pip3 install esptool
       - name: build ESP32 platforms
-        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000 --include_print_dependencies_header ./src/print_dependencies.h
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
       - name: Check artifacts
         run: |
           ls examples/Wippersnapper_demo/build/*

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -337,12 +337,11 @@ jobs:
           echo ${{ steps.get_board_json.outputs.boardJson }}
           echo ${{ fromJson(steps.get_board_json.outputs.boardJson) }}
           python3 -m esptool --chip ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.chip}} merge_bin \
-            --flash_mode keep \
-            --flash_freq keep \
-            --flash_size keep \
-            --fill-flash-size 4MB \
+            --flash_mode ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashMode}} \
+            --flash_freq ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashFreq}} \
+            --flash_size ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashSize}} \
             -o wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.combined.bin \
-            0x0 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
+            ${{ matrix.offset }} wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
             0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \
             0xe000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.boot_app0.bin \
             0x10000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bin

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -337,10 +337,10 @@ jobs:
           echo ${{ steps.get_board_json.outputs.boardJson }}
           echo ${{ fromJson(steps.get_board_json.outputs.boardJson) }}
           python3 -m esptool --chip ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.chip}} merge_bin \
-            --flash_mode ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashMode}} \
-            --flash_freq ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashFreq}} \
-            --flash_size ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashSize}} \
-            --fill-flash-size ${{fromJson(steps.get_board_json.outputs.boardJson).esptool.flashSize}} \
+            --flash_mode keep \
+            --flash_freq keep \
+            --flash_size keep \
+            --fill-flash-size 4MB \
             -o wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.combined.bin \
             ${{ matrix.offset }} wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.bootloader.bin \
             0x8000 wippersnapper.${{ matrix.arduino-platform }}.littlefs.${{ env.WS_VERSION }}.partitions.bin \


### PR DESCRIPTION
This pull request updates to the `.github/workflows/build-clang-doxy.yml` file to resolve the bootloop for the ESP32-C6 
build.

Repository and dependency updates:
* Changed the repository reference from `tyeth/ci-arduino` to `adafruit/ci-arduino` and updated the branch reference to `ci-wippersnapper` (`.github/workflows/build-clang-doxy.yml`).
* Updated the `pip` command to install a specific version of `esptool` (`esptool==4.6`) instead of the latest version (`.github/workflows/build-clang-doxy.yml`).

Resolves: #636 


