### PR TITLE
Add caching for nanopb

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -59,7 +59,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure() == 'true'
+      - if: ${{ failure() }}
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -68,7 +68,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: failure() =='false'
+      - if: ${{ success() }}
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -223,7 +223,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure() == 'true'
+      - if: ${{ failure() }}
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -232,7 +232,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: failure() =='false'
+      - if: ${{ success() }}
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -322,7 +322,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure() == 'true'
+      - if: ${{ failure() }}
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -331,7 +331,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: failure() =='false'
+      - if: ${{ success() }}
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -449,7 +449,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure() == 'true'
+      - if: ${{ failure() }}
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -458,7 +458,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: failure() =='false'
+      - if: ${{ success() }}
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -521,7 +521,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure() == 'true'
+      - if: ${{ failure() }}
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -530,7 +530,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: failure() =='false'
+      - if: ${{ success() }}
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -592,7 +592,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure() == 'true'
+      - if: ${{ failure() }}
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -601,7 +601,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: failure() =='false'
+      - if: ${{ success() }}
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -651,7 +651,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure() == 'true'
+      - if: ${{ failure() }}
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -660,7 +660,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: failure() =='false'
+      - if: ${{ success() }}
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -744,7 +744,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure() == 'true'
+      - if: ${{ failure() }}
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -753,7 +753,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: failure() =='false'
+      - if: ${{ success() }}
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -836,7 +836,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure() == 'true'
+      - if: ${{ failure() }}
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -845,7 +845,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: failure() =='false'
+      - if: ${{ success() }}
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -59,7 +59,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure()
+      - if: failure() == 'true'
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -68,7 +68,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: !failure()
+      - if: failure() =='false'
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -223,7 +223,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure()
+      - if: failure() == 'true'
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -232,7 +232,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: !failure()
+      - if: failure() =='false'
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -322,7 +322,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure()
+      - if: failure() == 'true'
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -331,7 +331,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: !failure()
+      - if: failure() =='false'
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -449,7 +449,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure()
+      - if: failure() == 'true'
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -458,7 +458,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: !failure()
+      - if: failure() =='false'
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -521,7 +521,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure()
+      - if: failure() == 'true'
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -530,7 +530,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: !failure()
+      - if: failure() =='false'
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -592,7 +592,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure()
+      - if: failure() == 'true'
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -601,7 +601,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: !failure()
+      - if: failure() =='false'
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -651,7 +651,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure()
+      - if: failure() == 'true'
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -660,7 +660,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: !failure()
+      - if: failure() =='false'
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -744,7 +744,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure()
+      - if: failure() == 'true'
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -753,7 +753,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: !failure()
+      - if: failure() =='false'
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4
@@ -836,7 +836,7 @@ jobs:
         continue-on-error: true
         run: |
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
-      - if: failure()
+      - if: failure() == 'true'
         name: Restore cached nanopb
         id: cache-nanopb-restore
         uses: actions/cache/restore@v4
@@ -845,7 +845,7 @@ jobs:
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: !failure()
+      - if: failure() =='false'
         name: Save nanopb to cache
         id: cache-nanopb-save
         uses: actions/cache/save@v4

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -55,18 +55,28 @@ jobs:
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
           git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
           git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-      - name: Cache nanopb
-        id: cache-nanopb
-        uses: actions/cache@v4
+      - name: Download stable Nanopb
+        continue-on-error: true
+        run: |
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: failure()
+        name: Restore cached nanopb
+        id: cache-nanopb-restore
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-node-modules
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
-        name: Download stable Nanopb
-        run: |
-          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: !failure()
+        name: Save nanopb to cache
+        id: cache-nanopb-save
+        uses: actions/cache/save@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
       - name: Install stable Nanopb
         run: |
           tar -xf nanopb-0.4.8.tar.gz
@@ -209,18 +219,28 @@ jobs:
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
           git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
           git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-      - name: Cache nanopb
-        id: cache-nanopb
-        uses: actions/cache@v4
+      - name: Download stable Nanopb
+        continue-on-error: true
+        run: |
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: failure()
+        name: Restore cached nanopb
+        id: cache-nanopb-restore
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-node-modules
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
-        name: Download stable Nanopb
-        run: |
-          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: !failure()
+        name: Save nanopb to cache
+        id: cache-nanopb-save
+        uses: actions/cache/save@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
       - name: Install stable Nanopb
         run: |
           tar -xf nanopb-0.4.8.tar.gz
@@ -298,18 +318,28 @@ jobs:
         run: |
           git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
-      - name: Cache nanopb
-        id: cache-nanopb
-        uses: actions/cache@v4
+      - name: Download stable Nanopb
+        continue-on-error: true
+        run: |
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: failure()
+        name: Restore cached nanopb
+        id: cache-nanopb-restore
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-node-modules
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
-        name: Download stable Nanopb
-        run: |
-          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: !failure()
+        name: Save nanopb to cache
+        id: cache-nanopb-save
+        uses: actions/cache/save@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
       - name: Install stable Nanopb
         run: |
           tar -xf nanopb-0.4.8.tar.gz
@@ -415,18 +445,28 @@ jobs:
           git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
-      - name: Cache nanopb
-        id: cache-nanopb
-        uses: actions/cache@v4
+      - name: Download stable Nanopb
+        continue-on-error: true
+        run: |
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: failure()
+        name: Restore cached nanopb
+        id: cache-nanopb-restore
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-node-modules
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
-        name: Download stable Nanopb
-        run: |
-          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: !failure()
+        name: Save nanopb to cache
+        id: cache-nanopb-save
+        uses: actions/cache/save@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
       - name: Install stable Nanopb
         run: |
           tar -xf nanopb-0.4.8.tar.gz
@@ -477,18 +517,28 @@ jobs:
           git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
           git clone --quiet https://github.com/pstolarz/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
-      - name: Cache nanopb
-        id: cache-nanopb
-        uses: actions/cache@v4
+      - name: Download stable Nanopb
+        continue-on-error: true
+        run: |
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: failure()
+        name: Restore cached nanopb
+        id: cache-nanopb-restore
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-node-modules
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
-        name: Download stable Nanopb
-        run: |
-          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: !failure()
+        name: Save nanopb to cache
+        id: cache-nanopb-save
+        uses: actions/cache/save@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
       - name: Install stable Nanopb
         run: |
           tar -xf nanopb-0.4.8.tar.gz
@@ -538,18 +588,28 @@ jobs:
           git clone --quiet https://github.com/arduino-libraries/Servo.git /home/runner/Arduino/libraries/Servo
           git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-      - name: Cache nanopb
-        id: cache-nanopb
-        uses: actions/cache@v4
+      - name: Download stable Nanopb
+        continue-on-error: true
+        run: |
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: failure()
+        name: Restore cached nanopb
+        id: cache-nanopb-restore
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-node-modules
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
-        name: Download stable Nanopb
-        run: |
-          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: !failure()
+        name: Save nanopb to cache
+        id: cache-nanopb-save
+        uses: actions/cache/save@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
       - name: Install stable Nanopb
         run: |
           tar -xf nanopb-0.4.8.tar.gz
@@ -587,18 +647,28 @@ jobs:
         run: |
           git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-      - name: Cache nanopb
-        id: cache-nanopb
-        uses: actions/cache@v4
+      - name: Download stable Nanopb
+        continue-on-error: true
+        run: |
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: failure()
+        name: Restore cached nanopb
+        id: cache-nanopb-restore
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-node-modules
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
-        name: Download stable Nanopb
-        run: |
-          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: !failure()
+        name: Save nanopb to cache
+        id: cache-nanopb-save
+        uses: actions/cache/save@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
       - name: Install stable Nanopb
         run: |
           tar -xf nanopb-0.4.8.tar.gz
@@ -670,18 +740,28 @@ jobs:
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
           git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
           git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-      - name: Cache nanopb
-        id: cache-nanopb
-        uses: actions/cache@v4
+      - name: Download stable Nanopb
+        continue-on-error: true
+        run: |
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: failure()
+        name: Restore cached nanopb
+        id: cache-nanopb-restore
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-node-modules
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
-        name: Download stable Nanopb
-        run: |
-          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: !failure()
+        name: Save nanopb to cache
+        id: cache-nanopb-save
+        uses: actions/cache/save@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
       - name: Install stable Nanopb
         run: |
           tar -xf nanopb-0.4.8.tar.gz
@@ -752,18 +832,28 @@ jobs:
         run: |
           git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
-      - name: Cache nanopb
-        id: cache-nanopb
-        uses: actions/cache@v4
+      - name: Download stable Nanopb
+        continue-on-error: true
+        run: |
+          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: failure()
+        name: Restore cached nanopb
+        id: cache-nanopb-restore
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-node-modules
         with:
           path: ./nanopb-0.4.8.tar.gz
           key: nanopb-0.4.8.tar.gz
-      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
-        name: Download stable Nanopb
-        run: |
-          wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - if: !failure()
+        name: Save nanopb to cache
+        id: cache-nanopb-save
+        uses: actions/cache/save@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
       - name: Install stable Nanopb
         run: |
           tar -xf nanopb-0.4.8.tar.gz

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -57,7 +57,7 @@ jobs:
           git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
       - name: Cache nanopb
         id: cache-nanopb
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -211,7 +211,7 @@ jobs:
           git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
       - name: Cache nanopb
         id: cache-nanopb
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -300,7 +300,7 @@ jobs:
           git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
       - name: Cache nanopb
         id: cache-nanopb
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -417,7 +417,7 @@ jobs:
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
       - name: Cache nanopb
         id: cache-nanopb
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -479,7 +479,7 @@ jobs:
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
       - name: Cache nanopb
         id: cache-nanopb
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -540,7 +540,7 @@ jobs:
           git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
       - name: Cache nanopb
         id: cache-nanopb
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -589,7 +589,7 @@ jobs:
           git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
       - name: Cache nanopb
         id: cache-nanopb
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -672,7 +672,7 @@ jobs:
           git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
       - name: Cache nanopb
         id: cache-nanopb
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -754,7 +754,7 @@ jobs:
           git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
       - name: Cache nanopb
         id: cache-nanopb
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -55,10 +55,20 @@ jobs:
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
           git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
           git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-      - name: Download and install stable Nanopb
+      - name: Cache nanopb
+        id: cache-nanopb
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
+      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
+        name: Download stable Nanopb
         run: |
-          # Download and extract nanopb
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - name: Install stable Nanopb
+        run: |
           tar -xf nanopb-0.4.8.tar.gz
           # Copy files to WipperSnapper's src/nanopb directory
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
@@ -199,10 +209,20 @@ jobs:
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
           git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
           git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-      - name: Download and install stable Nanopb
+      - name: Cache nanopb
+        id: cache-nanopb
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
+      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
+        name: Download stable Nanopb
         run: |
-          # Download and extract nanopb
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - name: Install stable Nanopb
+        run: |
           tar -xf nanopb-0.4.8.tar.gz
           # Copy files to WipperSnapper's src/nanopb directory
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
@@ -278,10 +298,20 @@ jobs:
         run: |
           git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
-      - name: Download and install stable Nanopb
+      - name: Cache nanopb
+        id: cache-nanopb
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
+      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
+        name: Download stable Nanopb
         run: |
-          # Download and extract nanopb
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - name: Install stable Nanopb
+        run: |
           tar -xf nanopb-0.4.8.tar.gz
           # Copy files to WipperSnapper's src/nanopb directory
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
@@ -385,10 +415,20 @@ jobs:
           git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
-      - name: Download and install stable Nanopb
+      - name: Cache nanopb
+        id: cache-nanopb
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
+      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
+        name: Download stable Nanopb
         run: |
-          # Download and extract nanopb
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - name: Install stable Nanopb
+        run: |
           tar -xf nanopb-0.4.8.tar.gz
           # Copy files to WipperSnapper's src/nanopb directory
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
@@ -437,10 +477,20 @@ jobs:
           git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
           git clone --quiet https://github.com/pstolarz/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
-      - name: Download and install stable Nanopb
+      - name: Cache nanopb
+        id: cache-nanopb
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
+      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
+        name: Download stable Nanopb
         run: |
-          # Download and extract nanopb
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - name: Install stable Nanopb
+        run: |
           tar -xf nanopb-0.4.8.tar.gz
           # Copy files to WipperSnapper's src/nanopb directory
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
@@ -488,10 +538,20 @@ jobs:
           git clone --quiet https://github.com/arduino-libraries/Servo.git /home/runner/Arduino/libraries/Servo
           git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-      - name: Download and install stable Nanopb
+      - name: Cache nanopb
+        id: cache-nanopb
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
+      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
+        name: Download stable Nanopb
         run: |
-          # Download and extract nanopb
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - name: Install stable Nanopb
+        run: |
           tar -xf nanopb-0.4.8.tar.gz
           # Copy files to WipperSnapper's src/nanopb directory
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
@@ -527,10 +587,20 @@ jobs:
         run: |
           git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/PaulStoffregen/OneWire.git /home/runner/Arduino/libraries/OneWire
-      - name: Download and install stable Nanopb
+      - name: Cache nanopb
+        id: cache-nanopb
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
+      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
+        name: Download stable Nanopb
         run: |
-          # Download and extract nanopb
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - name: Install stable Nanopb
+        run: |
           tar -xf nanopb-0.4.8.tar.gz
           # Copy files to WipperSnapper's src/nanopb directory
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
@@ -600,10 +670,20 @@ jobs:
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
           git clone --depth 1 --branch wippersnapper https://github.com/brentru/lvgl.git /home/runner/Arduino/libraries/lvgl
           git clone --depth 1 --branch development https://github.com/brentru/Adafruit_LvGL_Glue.git /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library
-      - name: Download and install stable Nanopb
+      - name: Cache nanopb
+        id: cache-nanopb
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
+      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
+        name: Download stable Nanopb
         run: |
-          # Download and extract nanopb
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - name: Install stable Nanopb
+        run: |
           tar -xf nanopb-0.4.8.tar.gz
           # Copy files to WipperSnapper's src/nanopb directory
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
@@ -672,10 +752,20 @@ jobs:
         run: |
           git clone --quiet https://github.com/milesburton/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
           git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
-      - name: Download and install stable Nanopb
+      - name: Cache nanopb
+        id: cache-nanopb
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./nanopb-0.4.8.tar.gz
+          key: nanopb-0.4.8.tar.gz
+      - if: ${{ steps.cache-nanopb.outputs.cache-hit != 'true' }}
+        name: Download stable Nanopb
         run: |
-          # Download and extract nanopb
           wget https://jpa.kapsi.fi/nanopb/download/nanopb-0.4.8.tar.gz
+      - name: Install stable Nanopb
+        run: |
           tar -xf nanopb-0.4.8.tar.gz
           # Copy files to WipperSnapper's src/nanopb directory
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb


### PR DESCRIPTION
Caches are based on the current ref, or a parent ref / base branch, as well as key.
When we update nanopb we'll need to update the cache key too, it's obvious as there are a few lines mentioning the version number.

This has now run once, causing a cached item to appear under the ref/pulls/this-one cache, and the second run has used that cached item for all the jobs.
Once we get it into main then one run will generate a cached item in the main cache which other things can utilise.