### PR TITLE
Reduce connection errors on QT Py ESP32-Sx due to 3D Antennas

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -33,8 +33,8 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: tyeth/ci-arduino
-          ref: WS_ARDUINO_598-preprocessor-script-for-printing-the-library-versions-to-boot_outtxt
+          repository: adafruit/ci-arduino
+          ref: ci-wippersnapper
           path: ci
       - name: Checkout Board Definitions
         uses: actions/checkout@v4
@@ -73,7 +73,7 @@ jobs:
         run: |
           pip3 install esptool
       - name: Build for ESP32-SX (esptool)
-        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000 --include_print_dependencies_header ./src/print_dependencies.h
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
       - name: list files
         run: |
           ls -Rla examples/
@@ -182,8 +182,8 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: tyeth/ci-arduino
-          ref: WS_ARDUINO_598-preprocessor-script-for-printing-the-library-versions-to-boot_outtxt
+          repository: adafruit/ci-arduino
+          ref: ci-wippersnapper
           path: ci
       - name: Install CI-Arduino
         run: bash ci/actions_install.sh
@@ -215,7 +215,7 @@ jobs:
           cp /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library/lv_conf.h /home/runner/Arduino/libraries
       - name: Build for ESP32-SX
         run: |
-          python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000 --include_print_dependencies_header ./src/print_dependencies.h
+          python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
       - name: list files (tree)
         run: |
           tree
@@ -373,8 +373,8 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: tyeth/ci-arduino
-          ref: WS_ARDUINO_598-preprocessor-script-for-printing-the-library-versions-to-boot_outtxt
+          repository: adafruit/ci-arduino
+          ref: ci-wippersnapper
           path: ci
       - name: Install CI-Arduino
         run: bash ci/actions_install.sh
@@ -394,7 +394,7 @@ jobs:
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
           mv nanopb/pb.h src/nanopb/nanopb.pb.h
       - name: build SAMD platforms
-        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000 --include_print_dependencies_header ./src/print_dependencies.h
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
       - name: Rename build artifacts to reflect the platform name
         run: |
           mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
@@ -426,8 +426,8 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: tyeth/ci-arduino
-          ref: WS_ARDUINO_598-preprocessor-script-for-printing-the-library-versions-to-boot_outtxt
+          repository: adafruit/ci-arduino
+          ref: ci-wippersnapper
           path: ci
       - name: Install CI-Arduino
         run: bash ci/actions_install.sh
@@ -446,7 +446,7 @@ jobs:
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
           mv nanopb/pb.h src/nanopb/nanopb.pb.h
       - name: build RP2040 platforms
-        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000 --include_print_dependencies_header ./src/print_dependencies.h
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
       - name: Rename build artifacts to reflect the platform name
         run: |
           mv examples/*/build/*/Wippersnapper_demo.ino.uf2 wippersnapper.${{ matrix.arduino-platform }}.${{ env.WS_VERSION }}.uf2
@@ -477,8 +477,8 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: tyeth/ci-arduino
-          ref: WS_ARDUINO_598-preprocessor-script-for-printing-the-library-versions-to-boot_outtxt
+          repository: adafruit/ci-arduino
+          ref: ci-wippersnapper
           path: ci
       - name: Install CI-Arduino
         run: bash ci/actions_install.sh
@@ -497,7 +497,7 @@ jobs:
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
           mv nanopb/pb.h src/nanopb/nanopb.pb.h
       - name: build SAMD (no-FS) platforms
-        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000 --include_print_dependencies_header ./src/print_dependencies.h
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
 
   build-esp8266:
     name: 🏗️ESP8266
@@ -518,8 +518,8 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: tyeth/ci-arduino
-          ref: WS_ARDUINO_598-preprocessor-script-for-printing-the-library-versions-to-boot_outtxt
+          repository: adafruit/ci-arduino
+          ref: ci-wippersnapper
           path: ci
       - name: Install CI-Arduino
         run: bash ci/actions_install.sh
@@ -536,7 +536,7 @@ jobs:
           cp nanopb/pb_common.* nanopb/pb_encode.* nanopb/pb_decode.* src/nanopb
           mv nanopb/pb.h src/nanopb/nanopb.pb.h
       - name: build ESP8266 platforms
-        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000 --include_print_dependencies_header ./src/print_dependencies.h
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
       - name: list build artifacts
         run: |
           ls
@@ -583,8 +583,8 @@ jobs:
           echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
       - uses: actions/checkout@v4
         with:
-          repository: tyeth/ci-arduino
-          ref: WS_ARDUINO_598-preprocessor-script-for-printing-the-library-versions-to-boot_outtxt
+          repository: adafruit/ci-arduino
+          ref: ci-wippersnapper
           path: ci
       - name: Install CI-Arduino
         run: bash ci/actions_install.sh
@@ -615,7 +615,7 @@ jobs:
         run: |
           cp /home/runner/Arduino/libraries/Adafruit_LittlevGL_Glue_Library/lv_conf.h /home/runner/Arduino/libraries
       - name: Build for ESP32-SX
-        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000 --include_print_dependencies_header ./src/print_dependencies.h
+        run: python3 ci/build_platform.py ${{ matrix.arduino-platform }} --build_timeout 48000
       - name: list
         run: |
           ls
@@ -659,8 +659,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: adafruit/ci-arduino
-          path: ci
           ref: ci-wippersnapper
+          path: ci
       - name: Checkout Board Definitions
         uses: actions/checkout@v4
         with:
@@ -792,6 +792,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: adafruit/ci-arduino
+          ref: ci-wippersnapper
           path: ci
       - name: pre-install
         run: bash ci/actions_install.sh

--- a/platformio.ini
+++ b/platformio.ini
@@ -90,7 +90,7 @@ lib_deps =
 
 ; Common build environment for ESP32 platform
 [common:esp32]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.05/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.07/platform-espressif32.zip
 ; This is needed for occasional new features and bug fixes
 ; platform = https://github.com/pioarduino/platform-espressif32#develop
 lib_ignore = WiFiNINA, WiFi101, OneWire
@@ -331,6 +331,7 @@ extra_scripts =  pre:rename_usb_config.py
 extends = common:esp32
 board = adafruit_qtpy_esp32s3_nopsram
 build_flags = -DARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM
+board_build.partitions = tinyuf2-partitions-4MB.csv
 extra_scripts = pre:rename_usb_config.py
 
 ; Adafruit QT Py ESP32-S3 with PSRAM

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -103,7 +103,15 @@ public:
     WiFi.disconnect();
     delay(100);
 
+// For boards with a "3D Antenna", we need to reduce the TX power
+// to prevent flaky operation.
+// NOTE: This is a known issue with the QT Py series of boards.
+#ifdef ARDUINO_ADAFRUIT_QTPY_ESP32S2 ||                                        \
+    ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM ||                                   \
+    ARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2 || ARDUINO_ADAFRUIT_QTPY_ESP32C3 ||     \
+    ARDUINO_ADAFRUIT_QTPY_ESP32_PICO
     WiFi.setTxPower(WIFI_POWER_15dBm);
+#endif
 
     // Perform a network scan
     int n = WiFi.scanNetworks();

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -103,6 +103,8 @@ public:
     WiFi.disconnect();
     delay(100);
 
+    WiFi.setTxPower(WIFI_POWER_15dBm);
+
     // Perform a network scan
     int n = WiFi.scanNetworks();
     if (n == 0) {


### PR DESCRIPTION
The PR's change sets the WiFi transmission power to a reduced dBm before performing a network scan.

We are doing this to match CircuitPython (discussion https://github.com/adafruit/circuitpython/issues/9235) and reduce connection errors - https://github.com/adafruit/circuitpython/pull/9369/files

- [x] Test a few different power increments (-5, -3 dBM from standard 18dBm)
- [x] Add inclusion guards, add this for all QT Py boards since they share the same 3D antenna.