### PR TITLE
Added aht21 sensor to the drivers

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -217,6 +217,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
 
   uint16_t i2cAddress = (uint16_t)msgDeviceInitReq->i2c_device_address;
   if ((strcmp("aht20", msgDeviceInitReq->i2c_device_name) == 0) ||
+      (strcmp("aht21", msgDeviceInitReq->i2c_device_name) == 0) ||
       (strcmp("am2301b", msgDeviceInitReq->i2c_device_name) == 0) ||
       (strcmp("am2315c", msgDeviceInitReq->i2c_device_name) == 0) ||
       (strcmp("dht20", msgDeviceInitReq->i2c_device_name) == 0)) {


### PR DESCRIPTION
the aht21 uses the same library as the aht20, but a different i2c address is used so this needed to be added so the the aht21 sensor can be used. I am working on this within the Wippersnapper components.