### PR TITLE
Update ConfigJson.cpp - set default password to blank and ssid to unset-ssid

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.93
+version=1.0.0-beta.94
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino application for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -142,7 +142,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.93" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.94" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/provisioning/ConfigJson.cpp
+++ b/src/provisioning/ConfigJson.cpp
@@ -22,8 +22,8 @@ void convertToJson(const networkConfig &src, JsonVariant dst) {
 
 // Extracts a network configuration structure from a JSON variant
 void convertFromJson(JsonVariantConst src, networkConfig &dst) {
-  strlcpy(dst.ssid, src["network_ssid"] | "testvar", sizeof(dst.ssid));
-  strlcpy(dst.pass, src["network_password"] | "testvar", sizeof(dst.pass));
+  strlcpy(dst.ssid, src["network_ssid"] | "unset-ssid", sizeof(dst.ssid));
+  strlcpy(dst.pass, src["network_password"] | "", sizeof(dst.pass));
 }
 
 // Converts a secretsConfig structure to a JSON variant


### PR DESCRIPTION
This removes the testvar strings and replaces with more useful/informative values, "unset-ssid" for ssid, and "" for password allowing empty passwords to be used as defaults in alternative networks.

See https://forums.adafruit.com/viewtopic.php?p=1036696#p1036696