### PR TITLE
bme68x pressure units

### DIFF
--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME680.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_BME680.h
@@ -130,7 +130,7 @@ public:
   bool getEventPressure(sensors_event_t *pressureEvent) {
     if (!bmePerformReading())
       return false;
-    pressureEvent->pressure = (float)_bme->pressure;
+    pressureEvent->pressure = (float)_bme->pressure / 100.0;
     return true;
   }
 


### PR DESCRIPTION
bme68x is showing units as pascals (SI units) which the sensor puts out. 

bme28x shows units as hector pascals ( hPa or millibars ) which is the more common way to discuss pressure. 

This is a suggestion to stay with the BME28x hPA format which is nothing more than a divide by 100 for the BME68x to maintain consistency.

thread and images courtesy of wsquare58

[forum thread](https://forums.adafruit.com/viewtopic.php?t=215299) on the issue.

![IMG_2045](https://github.com/user-attachments/assets/1638ca9b-4bb5-4fe0-98c9-b5579911940f)

