### PR TITLE
Stop blinding status lights

### DIFF
--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -138,14 +138,11 @@ void WipperSnapper_LittleFS::parseSecrets() {
            "credentials!\n");
   }
 
-  if (doc["status_pixel_brightness"]) {
-    // check it casts to float and support user specifying 0.0f which is
-    // default, by using the |operator instead of .as
-    // https://arduinojson.org/v7/api/jsonvariant/or/
-    if ((doc["status_pixel_brightness"] | -1.0f) != -1.0f) {
-      WS.status_pixel_brightness = doc["status_pixel_brightness"].as<float>();
-    }
-  }
+  // specify type of value for json key, by using the |operator to include
+  // a typed default value equivalent of with .as<float> w/ default value
+  // https://arduinojson.org/v7/api/jsonvariant/or/
+  WS._config.status_pixel_brightness =
+      doc["status_pixel_brightness"] | (float)STATUS_PIXEL_BRIGHTNESS_DEFAULT;
 
   // Close the file
   secretsFile.close();

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -138,6 +138,15 @@ void WipperSnapper_LittleFS::parseSecrets() {
            "credentials!\n");
   }
 
+  if (doc["status_pixel_brightness"]) {
+    // check it casts to float and support user specifying 0.0f which is
+    // default, by using the |operator instead of .as
+    // https://arduinojson.org/v7/api/jsonvariant/or/
+    if ((doc["status_pixel_brightness"] | -1.0f) != -1.0f) {
+      WS.status_pixel_brightness = doc["status_pixel_brightness"].as<float>();
+    }
+  }
+
   // Close the file
   secretsFile.close();
 

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -452,6 +452,14 @@ void Wippersnapper_FS::parseSecrets() {
            "credentials!");
   }
 
+  if (doc["status_pixel_brightness"]){
+    // check it casts to float and support user specifying 0.0f which is default,
+    // by using the |operator instead of .as https://arduinojson.org/v7/api/jsonvariant/or/
+    if ((doc["status_pixel_brightness"] | -1.0f) != -1.0f) {
+      WS.status_pixel_brightness = doc["status_pixel_brightness"].as<float>();
+    }
+  }
+
   // Close secrets.json file
   secretsFile.close();
 }

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -325,7 +325,7 @@ void Wippersnapper_FS::createSecretsFile() {
   strcpy(secretsConfig.aio_key, "YOUR_IO_KEY_HERE");
   strcpy(secretsConfig.network.ssid, "YOUR_WIFI_SSID_HERE");
   strcpy(secretsConfig.network.pass, "YOUR_WIFI_PASS_HERE");
-  secretsConfig.status_pixel_brightness = 0.2;
+  secretsConfig.status_pixel_brightness = STATUS_PIXEL_BRIGHTNESS_DEFAULT;
 
   // Serialize the struct to a JSON document
   JsonDocument doc;
@@ -452,13 +452,11 @@ void Wippersnapper_FS::parseSecrets() {
            "credentials!");
   }
 
-  if (doc["status_pixel_brightness"]){
-    // check it casts to float and support user specifying 0.0f which is default,
-    // by using the |operator instead of .as https://arduinojson.org/v7/api/jsonvariant/or/
-    if ((doc["status_pixel_brightness"] | -1.0f) != -1.0f) {
-      WS.status_pixel_brightness = doc["status_pixel_brightness"].as<float>();
-    }
-  }
+  // specify type of value for json key, by using the |operator to include
+  // a typed default value equivalent of with .as<float> w/ default value
+  // https://arduinojson.org/v7/api/jsonvariant/or/
+  WS._config.status_pixel_brightness =
+      doc["status_pixel_brightness"] | (float)STATUS_PIXEL_BRIGHTNESS_DEFAULT;
 
   // Close secrets.json file
   secretsFile.close();


### PR DESCRIPTION
The Neopixel brightness has been ignored for a while, and I've been meaning to take a look, but I'm only reminded in serious testing phases. This resolves the issue (only tested with tinyusb devices, but littlefs will be identical)