### PR TITLE
Update WipperSnapper_I2C_Driver_SCD4X.h - renamed include

### DIFF
--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
@@ -145,7 +145,7 @@ public:
   }
 
 protected:
-  SensirionI2CScd4x *_scd; ///< SCD4x driver object
+  SensirionI2cScd4x *_scd; ///< SCD4x driver object
   uint16_t _co2;           ///< SCD4x co2 reading
   float _temperature;      ///< SCD4x temperature reading
   float _humidity;         ///< SCD4x humidity reading

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
@@ -52,7 +52,7 @@ public:
   /*******************************************************************************/
   bool begin() {
     _scd = new SensirionI2cScd4x();
-    _scd->begin(*_i2c);
+    _scd->begin(*_i2c, _sensorAddress);
 
     // stop previously started measurement
     if (_scd->stopPeriodicMeasurement())
@@ -78,7 +78,7 @@ public:
     delay(100);
 
     // Check if data is ready
-    error = _scd->getDataReadyFlag(isDataReady);
+    error = _scd->getDataReadyStatus(isDataReady);
     if (error || !isDataReady)
       return false;
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
@@ -51,7 +51,7 @@ public:
   */
   /*******************************************************************************/
   bool begin() {
-    _scd = new SensirionI2CScd4x();
+    _scd = new SensirionI2cScd4x();
     _scd->begin(*_i2c);
 
     // stop previously started measurement

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SCD4X.h
@@ -18,7 +18,7 @@
 #define WipperSnapper_I2C_Driver_SCD4X_H
 
 #include "WipperSnapper_I2C_Driver.h"
-#include <SensirionI2CScd4x.h>
+#include <SensirionI2cScd4x.h>
 #include <Wire.h>
 
 /**************************************************************************/

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -106,9 +106,10 @@ public:
 // For boards with a "3D Antenna", we need to reduce the TX power
 // to prevent flaky operation.
 // NOTE: This is a known issue with the QT Py series of boards.
-#if defined(ARDUINO_ADAFRUIT_QTPY_ESP32S2) ||                                                \
-    defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM) ||                                        \
-    defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2) || defined(ARDUINO_ADAFRUIT_QTPY_ESP32C3) || \
+#if defined(ARDUINO_ADAFRUIT_QTPY_ESP32S2) ||                                  \
+    defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM) ||                          \
+    defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2) ||                             \
+    defined(ARDUINO_ADAFRUIT_QTPY_ESP32C3) ||                                  \
     defined(ARDUINO_ADAFRUIT_QTPY_ESP32_PICO)
     WiFi.setTxPower(WIFI_POWER_15dBm);
 #endif

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -106,10 +106,10 @@ public:
 // For boards with a "3D Antenna", we need to reduce the TX power
 // to prevent flaky operation.
 // NOTE: This is a known issue with the QT Py series of boards.
-#ifdef ARDUINO_ADAFRUIT_QTPY_ESP32S2 ||                                        \
-    ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM ||                                   \
-    ARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2 || ARDUINO_ADAFRUIT_QTPY_ESP32C3 ||     \
-    ARDUINO_ADAFRUIT_QTPY_ESP32_PICO
+#if defined(ARDUINO_ADAFRUIT_QTPY_ESP32S2) ||                                                \
+    defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM) ||                                        \
+    defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2) || defined(ARDUINO_ADAFRUIT_QTPY_ESP32C3) || \
+    defined(ARDUINO_ADAFRUIT_QTPY_ESP32_PICO)
     WiFi.setTxPower(WIFI_POWER_15dBm);
 #endif
 


### PR DESCRIPTION
v1.0.0 of the driver has been released, it renames the header (breaking) and alters the serial read function (not affected) along with a couple of other function names.

See https://github.com/Sensirion/arduino-i2c-scd4x/issues/45