### PR TITLE
Fix: I2C Scan on ESP32-S2

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -82,7 +82,6 @@ WipperSnapper_Component_I2C::WipperSnapper_Component_I2C(
     } else {
       _isInit = true; // if the peripheral was configured incorrectly
     }
-    _i2c->setClock(50000);
 #elif defined(ARDUINO_ARCH_ESP8266)
     _i2c = new TwoWire();
     _i2c->begin(msgInitRequest->i2c_pin_sda, msgInitRequest->i2c_pin_scl);
@@ -162,7 +161,7 @@ WipperSnapper_Component_I2C::scanAddresses() {
     uint8_t endTransmissionRC = _i2c->endTransmission();
 
     if (endTransmissionRC == 0) {
-      WS_DEBUG_PRINT("[i2c] Found Device");
+      WS_DEBUG_PRINTLN("[i2c] Found Device!");
       scanResp.addresses_found[scanResp.addresses_found_count] =
           (uint32_t)address;
       scanResp.addresses_found_count++;
@@ -170,34 +169,26 @@ WipperSnapper_Component_I2C::scanAddresses() {
 #if defined(ARDUINO_ARCH_ESP32)
     // Check endTransmission()'s return code (Arduino-ESP32 ONLY)
     else if (endTransmissionRC == 3) {
-      // NOTE: The printf below is commented out for performance, this is the
-      // default case and should typically be hit if the address is not found.
-      WS_DEBUG_PRINTLN("[i2c] ERROR: received NACK on transmit of data!");
+      WS_DEBUG_PRINTLN("[i2c] Did not find device: NACK on transmit of data!");
       continue;
     } else if (endTransmissionRC == 2) {
-      WS_DEBUG_PRINTLN("[i2c] ERROR: received NACK on transmit of address!");
-      scanResp.bus_response =
-          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_UNSPECIFIED;
+      WS_DEBUG_PRINTLN(
+          "[i2c] Did not find device: NACK on transmit of address!");
       continue;
     } else if (endTransmissionRC == 1) {
-      WS_DEBUG_PRINTLN("[i2c] ERROR: data too long to fit in transmit buffer!");
-      scanResp.bus_response =
-          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_UNSPECIFIED;
+      WS_DEBUG_PRINTLN(
+          "[i2c] Did not find device: data too long to fit in xmit buffer!");
       continue;
     } else if (endTransmissionRC == 4) {
-      WS_DEBUG_PRINTLN("[i2c] ERROR: Unspecified bus error occured!");
-      scanResp.bus_response =
-          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_UNSPECIFIED;
+      WS_DEBUG_PRINTLN(
+          "[i2c] Did not find device: Unspecified bus error occured!");
       continue;
     } else if (endTransmissionRC == 5) {
-      WS_DEBUG_PRINTLN("[i2c] ERROR: I2C Bus has timed out!");
-      scanResp.bus_response =
-          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_ERROR_HANG;
+      WS_DEBUG_PRINTLN("[i2c] Did not find device: Bus timed out!");
       continue;
     } else {
-      WS_DEBUG_PRINTLN("[i2c] ERROR: An unknown bus error has occured!");
-      scanResp.bus_response =
-          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_UNSPECIFIED;
+      WS_DEBUG_PRINTLN(
+          "[i2c] Did not find device: Unknown bus error has occured!");
       continue;
     }
 #endif

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -154,14 +154,15 @@ WipperSnapper_Component_I2C::scanAddresses() {
 
   // Scan all I2C addresses between 0x08 and 0x7F inclusive and return a list of
   // those that respond.
-  WS_DEBUG_PRINTLN("EXEC: I2C Scan");
+  WS_DEBUG_PRINTLN("[i2c]: Scanning I2C Bus for Devices...");
   for (uint8_t address = 1; address < 127; ++address) {
+    WS_DEBUG_PRINT("[i2c] Scanning Address: 0x");
+    WS_DEBUG_PRINTLN(address, HEX);
     _i2c->beginTransmission(address);
     uint8_t endTransmissionRC = _i2c->endTransmission();
 
     if (endTransmissionRC == 0) {
-      WS_DEBUG_PRINT("Found I2C Device at 0x");
-      WS_DEBUG_PRINTLN(address);
+      WS_DEBUG_PRINT("[i2c] Found Device");
       scanResp.addresses_found[scanResp.addresses_found_count] =
           (uint32_t)address;
       scanResp.addresses_found_count++;
@@ -208,8 +209,9 @@ WipperSnapper_Component_I2C::scanAddresses() {
   WS.feedWDT();
 #endif
 
-  WS_DEBUG_PRINT("I2C Devices Found: ")
-  WS_DEBUG_PRINTLN(scanResp.addresses_found_count);
+  WS_DEBUG_PRINT("[i2c] Scan Complete! Found: ")
+  WS_DEBUG_PRINT(scanResp.addresses_found_count);
+  WS_DEBUG_PRINTLN(" Devices on bus.");
 
   scanResp.bus_response = wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_SUCCESS;
   return scanResp;

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -171,14 +171,14 @@ WipperSnapper_Component_I2C::scanAddresses() {
     else if (endTransmissionRC == 3) {
       // NOTE: The printf below is commented out for performance, this is the
       // default case and should typically be hit if the address is not found.
-      // WS_DEBUG_PRINTLN("[i2c] ERROR: received NACK on transmit of data!");
+      WS_DEBUG_PRINTLN("[i2c] ERROR: received NACK on transmit of data!");
       continue;
     } else if (endTransmissionRC == 2) {
       WS_DEBUG_PRINTLN("[i2c] ERROR: received NACK on transmit of address!");
       scanResp.bus_response =
           wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_UNSPECIFIED;
       continue;
-    } else if (endTransmissionRC == 3) {
+    } else if (endTransmissionRC == 1) {
       WS_DEBUG_PRINTLN("[i2c] ERROR: data too long to fit in transmit buffer!");
       scanResp.bus_response =
           wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_UNSPECIFIED;


### PR DESCRIPTION
This pull request in conjunction with https://github.com/adafruit/ci-arduino/pull/210 should fix the broken I2C scanning present on ESP32-S2 platforms running WipperSnapper Beta 96 or Beta 97.

This pull request also:
* Refactors the loop within `scanAddresses` to match Espressif's I2C Scan Test
  * A little more performant as we check the best-case first, now.
* Adds handling for I2C transmission error codes (only for ESP32 I2C Scans)

Tested on Adafruit Feather ESP32-S2 w/BME280 

**Requires**  https://github.com/adafruit/ci-arduino/pull/210 **to be merged in and this PR to be rebuilt before testing again**


Resolves - https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/700