### PR TITLE
Revert "use brentru SPIFLash fork"

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -522,7 +522,6 @@ jobs:
         run: |
           git clone --quiet https://github.com/pstolarz/OneWireNg.git /home/runner/Arduino/libraries/OneWireNg
           git clone --quiet https://github.com/pstolarz/Arduino-Temperature-Control-Library.git /home/runner/Arduino/libraries/Arduino-Temperature-Control-Library
-          git clone --quiet https://github.com/brentru/Adafruit_SPIFlash.git /home/runner/Arduino/libraries/Adafruit_SPIFlash
           git clone --quiet https://github.com/adafruit/Adafruit_TinyUSB_Arduino /home/runner/Arduino/libraries/Adafruit_TinyUSB_Arduino
       - name: Download stable Nanopb
         id: download-nanopb


### PR DESCRIPTION
This reverts commit cd5e7e01fb955ed6846463b4238448afbc3b7efe.

Now that upstream version of Adafruit SPIFlash has been updated to tie in with the SdFat - Adafruit Fork changes, we should switch back to upstream.