### PR TITLE
Arduino-ESP32 3.2.0 IDF 5.4

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ lib_deps =
     ;;;;;;;;;;;  FunHouse / LVGL Boards uncomment these   ;;;;;;;;;;;;;;
     ; https://github.com/adafruit/Adafruit_HX8357_Library.git
     ; https://github.com/adafruit/Adafruit_ILI9341.git
-    ; https://github.com/adafruit/Adafruit_STMPE610.git 
+    ; https://github.com/adafruit/Adafruit_STMPE610.git
     ; https://github.com/adafruit/Adafruit-ST7735-Library.git
     ; https://github.com/adafruit/Adafruit_TouchScreen.git
     ; https://github.com/brentru/lvgl.git#wippersnapper
@@ -96,7 +96,7 @@ lib_deps =
 
 ; Common build environment for ESP32 platform
 [common:esp32]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/54.03.20/platform-espressif32.zip
 ; This is needed for occasional new features and bug fixes
 ; platform = https://github.com/pioarduino/platform-espressif32#develop
 lib_ignore = WiFiNINA, WiFi101, OneWire
@@ -291,7 +291,7 @@ extra_scripts =  pre:rename_usb_config.py
 [env:adafruit_funhouse_esp32s2_debug]
 extends = common:esp32
 board = adafruit_funhouse_esp32s2
-;lib_extra_dirs = 
+;lib_extra_dirs =
 build_type = debug
 build_flags =
     -DARDUINO_FUNHOUSE
@@ -506,7 +506,7 @@ extends = common:rp2040
 
 [env:raspberypi_picow_debug_port_only]
 extends = common:rp2040
-build_flags = 
+build_flags =
     -DUSE_TINYUSB
     -DDEBUG_RP2040_PORT=Serial
 
@@ -558,7 +558,7 @@ platform = https://github.com/maxgerhardt/platform-raspberrypi.git#develop
 platform_packages =
    framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git
 board = rpipico2w
-build_flags = 
+build_flags =
     -DWIFICC=CYW43_COUNTRY_UK
     -DUSE_TINYUSB
     ; -DARDUINO_ARCH_RP2040


### PR DESCRIPTION
The build targets in **ci-arduino** are updated to use adafruit/arduino-esp32#wipper-3.2.0-idf-5.4