### PR TITLE
[Offline Mode] Fix Config file deletion, RTC initialization failure

### DIFF
--- a/.github/workflows/release-offline.yml
+++ b/.github/workflows/release-offline.yml
@@ -7,6 +7,9 @@ on:
       branches:
         - offline-mode
         - offline-mode-*
+    pull_request:
+      branches:
+          - offline-mode
     release:
       types: [published]
       branches:

--- a/src/components/i2c/controller.cpp
+++ b/src/components/i2c/controller.cpp
@@ -881,7 +881,19 @@ bool I2cController::ScanI2cBus(bool default_bus = true) {
   }
 }
 
+/***********************************************************************/
+/*!
+    @brief    Returns the I2C bus object.
+    @param    is_alt_bus
+                True if the alternative I2C bus is being used, False
+                otherwise.
+    @returns  A pointer to the I2C bus object.
+*/
+/***********************************************************************/
 TwoWire *I2cController::GetI2cBus(bool is_alt_bus) {
+    if (is_alt_bus) {
+        return _i2c_bus_alt->GetBus();
+    }
     return _i2c_bus_default->GetBus();
 }
 

--- a/src/components/i2c/controller.cpp
+++ b/src/components/i2c/controller.cpp
@@ -891,10 +891,10 @@ bool I2cController::ScanI2cBus(bool default_bus = true) {
 */
 /***********************************************************************/
 TwoWire *I2cController::GetI2cBus(bool is_alt_bus) {
-    if (is_alt_bus) {
-        return _i2c_bus_alt->GetBus();
-    }
-    return _i2c_bus_default->GetBus();
+  if (is_alt_bus) {
+    return _i2c_bus_alt->GetBus();
+  }
+  return _i2c_bus_default->GetBus();
 }
 
 /***********************************************************************/

--- a/src/components/i2c/controller.cpp
+++ b/src/components/i2c/controller.cpp
@@ -881,6 +881,10 @@ bool I2cController::ScanI2cBus(bool default_bus = true) {
   }
 }
 
+TwoWire *I2cController::GetI2cBus(bool is_alt_bus) {
+    return _i2c_bus_default->GetBus();
+}
+
 /***********************************************************************/
 /*!
     @brief    Checks if a device was found on the i2c bus. MUST be called

--- a/src/components/i2c/controller.cpp
+++ b/src/components/i2c/controller.cpp
@@ -862,11 +862,23 @@ bool I2cController::Handle_I2cDeviceAddOrReplace(pb_istream_t *stream) {
 */
 /***********************************************************************/
 bool I2cController::ScanI2cBus(bool default_bus = true) {
-  _i2c_bus_default->InitBus(default_bus);
+  // zero-out the scan I2cBusScanned message before attempting a scan
   _scan_results = wippersnapper_i2c_I2cBusScanned_init_zero;
-  if (!default_bus)
+
+  // Scan the desired i2c bus
+  if (default_bus) {
+    if (_i2c_bus_default->GetBusStatus() !=
+        wippersnapper_i2c_I2cBusStatus_I2C_BUS_STATUS_SUCCESS) {
+      _i2c_bus_default->InitBus(default_bus);
+    }
+    return _i2c_bus_default->ScanBus(&_scan_results);
+  } else {
+    if (_i2c_bus_alt->GetBusStatus() !=
+        wippersnapper_i2c_I2cBusStatus_I2C_BUS_STATUS_SUCCESS) {
+      _i2c_bus_alt->InitBus(default_bus);
+    }
     return _i2c_bus_alt->ScanBus(&_scan_results);
-  return _i2c_bus_default->ScanBus(&_scan_results);
+  }
 }
 
 /***********************************************************************/

--- a/src/components/i2c/controller.h
+++ b/src/components/i2c/controller.h
@@ -109,7 +109,8 @@ public:
   size_t GetScanDeviceCount();
   bool
   IsDriverInitialized(wippersnapper_i2c_I2cDeviceDescriptor &device_descriptor);
-  TwoWire *GetI2cBus(bool is_alt_bus=false);
+  TwoWire *GetI2cBus(bool is_alt_bus = false);
+
 private:
   I2cModel *_i2c_model;                ///< Pointer to an I2C model object
   I2cHardware *_i2c_bus_default;       ///< Pointer to the default I2C bus

--- a/src/components/i2c/controller.h
+++ b/src/components/i2c/controller.h
@@ -109,7 +109,7 @@ public:
   size_t GetScanDeviceCount();
   bool
   IsDriverInitialized(wippersnapper_i2c_I2cDeviceDescriptor &device_descriptor);
-
+  TwoWire *GetI2cBus(bool is_alt_bus=false);
 private:
   I2cModel *_i2c_model;                ///< Pointer to an I2C model object
   I2cHardware *_i2c_bus_default;       ///< Pointer to the default I2C bus

--- a/src/components/i2c/hardware.cpp
+++ b/src/components/i2c/hardware.cpp
@@ -71,7 +71,6 @@ void I2cHardware::InitBus(bool is_default, const char *sda, const char *scl) {
 // to the i2c bus. If the pin is defined, turn the power to the i2c bus on.
 #if defined(PIN_I2C_POWER) || defined(TFT_I2C_POWER) ||                        \
     defined(NEOPIXEL_I2C_POWER)
-  WS_DEBUG_PRINTLN("[i2c] Powering on I2C bus...");
   TogglePowerPin();
 #endif
 

--- a/src/components/i2c/hardware.cpp
+++ b/src/components/i2c/hardware.cpp
@@ -71,6 +71,7 @@ void I2cHardware::InitBus(bool is_default, const char *sda, const char *scl) {
 // to the i2c bus. If the pin is defined, turn the power to the i2c bus on.
 #if defined(PIN_I2C_POWER) || defined(TFT_I2C_POWER) ||                        \
     defined(NEOPIXEL_I2C_POWER)
+  WS_DEBUG_PRINTLN("[i2c] Powering on I2C bus...");
   TogglePowerPin();
 #endif
 

--- a/src/provisioning/sdcard/ws_sdcard.cpp
+++ b/src/provisioning/sdcard/ws_sdcard.cpp
@@ -7,7 +7,7 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Copyright (c) Brent Rubell 2024 for Adafruit Industries.
+ * Copyright (c) Brent Rubell 2024-2025 for Adafruit Industries.
  *
  * BSD license, all text here must be included in any redistribution.
  *
@@ -165,17 +165,15 @@ bool ws_sdcard::InitDS3231() {
 */
 /**************************************************************************/
 bool ws_sdcard::InitPCF8523() {
-
-  // TODO: Check if we can see the PCF8523 after
-  // the initial i2c scan
   WsV2._i2c_controller->ScanI2cBus(true);
   WS_DEBUG_PRINT("[sd] Scanned I2C Devices: ")
   WS_DEBUG_PRINTLN(WsV2._i2c_controller->GetScanDeviceCount());
   WS_DEBUG_PRINT("Was Device Found? ");
   WS_DEBUG_PRINTLN(WsV2._i2c_controller->WasDeviceScanned(0x68));
 
+
   _rtc_pcf8523 = new RTC_PCF8523();
-  if (!_rtc_pcf8523->begin()) {
+  if (!_rtc_pcf8523->begin(WsV2._i2c_controller->GetI2cBus())) {
     WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize PCF8523 RTC on WIRE");
     if (!_rtc_pcf8523->begin(&Wire1)) {
       WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize PCF8523 RTC on WIRE1");
@@ -706,6 +704,8 @@ bool ws_sdcard::ParseExportedFromDevice(JsonDocument &doc) {
 
   // Configures RTC
   const char *rtc_type = exportedFromDevice["rtc"] | "SOFT";
+  // wait 9 seconds
+  delay(9000);
   if (!ConfigureRTC(rtc_type)) {
     WS_DEBUG_PRINTLN("[SD] Error: Failed to to configure a RTC!");
     return false;

--- a/src/provisioning/sdcard/ws_sdcard.cpp
+++ b/src/provisioning/sdcard/ws_sdcard.cpp
@@ -121,9 +121,10 @@ void ws_sdcard::ConfigureSDCard() {
 /**************************************************************************/
 bool ws_sdcard::InitDS1307() {
   _rtc_ds1307 = new RTC_DS1307();
-  if (!_rtc_ds1307->begin()) {
-    if (!_rtc_ds1307->begin(&Wire1)) {
-      WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize DS1307 RTC");
+  if (!_rtc_ds1307->begin(WsV2._i2c_controller->GetI2cBus())) {
+    WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize DS1307 RTC on WIRE");
+    if (!_rtc_ds1307->begin(WsV2._i2c_controller->GetI2cBus(true))) {
+      WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize DS1307 RTC on WIRE1");
       delete _rtc_ds1307;
       return false;
     }
@@ -144,9 +145,10 @@ bool ws_sdcard::InitDS1307() {
 bool ws_sdcard::InitDS3231() {
   WS_DEBUG_PRINTLN("Begin DS3231 init");
   _rtc_ds3231 = new RTC_DS3231();
-  if (!_rtc_ds3231->begin(&Wire)) {
-    if (!_rtc_ds3231->begin(&Wire1)) {
-      WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize DS3231 RTC");
+  if (!_rtc_ds3231->begin(WsV2._i2c_controller->GetI2cBus())) {
+    WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize DS3231 RTC on WIRE");
+    if (!_rtc_ds3231->begin(WsV2._i2c_controller->GetI2cBus(true))) {
+        WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize DS3231 RTC on WIRE1");
       delete _rtc_ds3231;
       return false;
     }
@@ -165,17 +167,10 @@ bool ws_sdcard::InitDS3231() {
 */
 /**************************************************************************/
 bool ws_sdcard::InitPCF8523() {
-  WsV2._i2c_controller->ScanI2cBus(true);
-  WS_DEBUG_PRINT("[sd] Scanned I2C Devices: ")
-  WS_DEBUG_PRINTLN(WsV2._i2c_controller->GetScanDeviceCount());
-  WS_DEBUG_PRINT("Was Device Found? ");
-  WS_DEBUG_PRINTLN(WsV2._i2c_controller->WasDeviceScanned(0x68));
-
-
   _rtc_pcf8523 = new RTC_PCF8523();
   if (!_rtc_pcf8523->begin(WsV2._i2c_controller->GetI2cBus())) {
     WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize PCF8523 RTC on WIRE");
-    if (!_rtc_pcf8523->begin(&Wire1)) {
+    if (!_rtc_pcf8523->begin(WsV2._i2c_controller->GetI2cBus(true))) {
       WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize PCF8523 RTC on WIRE1");
       delete _rtc_pcf8523;
       return false;

--- a/src/provisioning/sdcard/ws_sdcard.cpp
+++ b/src/provisioning/sdcard/ws_sdcard.cpp
@@ -699,8 +699,6 @@ bool ws_sdcard::ParseExportedFromDevice(JsonDocument &doc) {
 
   // Configures RTC
   const char *rtc_type = exportedFromDevice["rtc"] | "SOFT";
-  // wait 9 seconds
-  delay(9000);
   if (!ConfigureRTC(rtc_type)) {
     WS_DEBUG_PRINTLN("[SD] Error: Failed to to configure a RTC!");
     return false;
@@ -719,9 +717,6 @@ bool ws_sdcard::ParseExportedFromDevice(JsonDocument &doc) {
 /**************************************************************************/
 bool ws_sdcard::ParseFileConfig() {
   DeserializationError error;
-
-  // delay 6 seconds
-  delay(6000);
 
 #ifndef OFFLINE_MODE_DEBUG
   WS_DEBUG_PRINTLN("[SD] Deserializing config.json...");

--- a/src/provisioning/sdcard/ws_sdcard.cpp
+++ b/src/provisioning/sdcard/ws_sdcard.cpp
@@ -148,7 +148,7 @@ bool ws_sdcard::InitDS3231() {
   if (!_rtc_ds3231->begin(WsV2._i2c_controller->GetI2cBus())) {
     WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize DS3231 RTC on WIRE");
     if (!_rtc_ds3231->begin(WsV2._i2c_controller->GetI2cBus(true))) {
-        WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize DS3231 RTC on WIRE1");
+      WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize DS3231 RTC on WIRE1");
       delete _rtc_ds3231;
       return false;
     }

--- a/src/provisioning/sdcard/ws_sdcard.cpp
+++ b/src/provisioning/sdcard/ws_sdcard.cpp
@@ -165,8 +165,17 @@ bool ws_sdcard::InitDS3231() {
 */
 /**************************************************************************/
 bool ws_sdcard::InitPCF8523() {
+
+  // TODO: Check if we can see the PCF8523 after
+  // the initial i2c scan
+  WsV2._i2c_controller->ScanI2cBus(true);
+  WS_DEBUG_PRINT("[sd] Scanned I2C Devices: ")
+  WS_DEBUG_PRINTLN(WsV2._i2c_controller->GetScanDeviceCount());
+  WS_DEBUG_PRINT("Was Device Found? ");
+  WS_DEBUG_PRINTLN(WsV2._i2c_controller->WasDeviceScanned(0x68));
+
   _rtc_pcf8523 = new RTC_PCF8523();
-  if (!_rtc_pcf8523->begin(&Wire)) {
+  if (!_rtc_pcf8523->begin()) {
     WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize PCF8523 RTC on WIRE");
     if (!_rtc_pcf8523->begin(&Wire1)) {
       WS_DEBUG_PRINTLN("[SD] Error: Failed to initialize PCF8523 RTC on WIRE1");
@@ -701,6 +710,7 @@ bool ws_sdcard::ParseExportedFromDevice(JsonDocument &doc) {
     WS_DEBUG_PRINTLN("[SD] Error: Failed to to configure a RTC!");
     return false;
   }
+
   return true;
 }
 
@@ -714,6 +724,9 @@ bool ws_sdcard::ParseExportedFromDevice(JsonDocument &doc) {
 /**************************************************************************/
 bool ws_sdcard::ParseFileConfig() {
   DeserializationError error;
+
+  // delay 6 seconds
+  delay(6000);
 
 #ifndef OFFLINE_MODE_DEBUG
   WS_DEBUG_PRINTLN("[SD] Deserializing config.json...");

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -381,9 +381,14 @@ void Wippersnapper_FS::CreateFileConfig() {
     File32 file_cfg = wipperFatFs_v2.open("/config.json", FILE_READ);
     if (file_cfg) {
       DeserializationError error = deserializeJson(_doc_cfg, file_cfg);
-      //  if (error)
-      //  HaltFilesystem("Error unable to parse config.json on WIPPER drive!");
-      // Remove config from the filesystem
+      if (error) {
+        // If we can't deserialize, just raise
+        HaltFilesystem(
+            "[fs] Error: Unable to deserialize config.json, is it corrupted?");
+      }
+      // We are going to parse the in-memory object, _doc_cfg, rather
+      // than the file. So, let's remove the ctg file since we'll replace
+      // it with a new cfg file later on
       file_cfg.close();
       wipperFatFs_v2.remove("/config.json");
       flash_v2.syncBlocks();
@@ -404,6 +409,7 @@ void Wippersnapper_FS::CreateFileConfig() {
         // Build components array
         _doc_cfg["components"].to<JsonArray>();
       }
+
       return;
     }
   }

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -386,13 +386,7 @@ void Wippersnapper_FS::CreateFileConfig() {
         HaltFilesystem(
             "[fs] Error: Unable to deserialize config.json, is it corrupted?");
       }
-      // We are going to parse the in-memory object, _doc_cfg, rather
-      // than the file. So, let's remove the ctg file since we'll replace
-      // it with a new cfg file later on
       file_cfg.close();
-      wipperFatFs_v2.remove("/config.json");
-      flash_v2.syncBlocks();
-
       // Check if the config.json file has the required keys
       if (!_doc_cfg.containsKey("exportedFromDevice")) {
         // Build exportedFromDevice object
@@ -412,6 +406,7 @@ void Wippersnapper_FS::CreateFileConfig() {
 
       return;
     }
+    file_cfg.close();
   }
 
   // Create a default configConfig structure in a new doc
@@ -478,6 +473,14 @@ void Wippersnapper_FS::AddI2cDeviceToFileConfig(
 */
 /**************************************************************************/
 bool Wippersnapper_FS::WriteFileConfig() {
+  // If it exists, remove the existing config.json file
+  // as we're about to write the new one into memory
+  if (wipperFatFs_v2.exists("/config.json")) {
+    wipperFatFs_v2.remove("/config.json");
+    flash_v2.syncBlocks();
+    delay(500);
+  }
+
   // Write the document to the filesystem
   File32 file_cfg = wipperFatFs_v2.open("/config.json", FILE_WRITE);
   if (!file_cfg) {


### PR DESCRIPTION
Resolves: https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/735

This pull request:
* Improved error handling in `Wippersnapper_FS::CreateFileConfig` by raising an error if `config.json` cannot be deserialized, instead of silently removing it. (`src/provisioning/tinyusb/Wippersnapper_FS.cpp`)
* Ensured proper cleanup of the old `config.json` file before writing a new one in `Wippersnapper_FS::WriteFileConfig`. This prevents potential conflicts or corruption. (`src/provisioning/tinyusb/Wippersnapper_FS.cpp`)
* Uses the proper I2C bus when initializing the RTC chip by getting a ptr to the bus from the controller rather than assuming a default.