### PR TITLE
Fix LEDC PWM DutyCycle

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.100
+version=1.0.0-beta.101
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino application for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -142,7 +142,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.100" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.101" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/components/ledc/ws_ledc.cpp
+++ b/src/components/ledc/ws_ledc.cpp
@@ -54,8 +54,8 @@ bool ws_ledc::analogWrite(uint8_t pin, int value) {
 
   // Calculate duty cycle for the `value` passed in
   // (assumes 12-bit resolution, 2^12)
-  //uint32_t dutyCycle = (4095 / 255) * min(value, 255);
-  uint32_t dutyCycle =(uint32_t)(((double)4095 / 255.0) * min((uint32_t)value, (uint32_t)255));
+  uint32_t dutyCycle =
+      (uint32_t)(((double)4095 / 255.0) * min((uint32_t)value, (uint32_t)255));
 
   // Call duty cycle write
   return setDuty(pin, dutyCycle);

--- a/src/components/ledc/ws_ledc.cpp
+++ b/src/components/ledc/ws_ledc.cpp
@@ -55,7 +55,7 @@ bool ws_ledc::analogWrite(uint8_t pin, int value) {
   // Calculate duty cycle for the `value` passed in
   // (assumes 12-bit resolution, 2^12)
   //uint32_t dutyCycle = (4095 / 255) * min(value, 255);
-  uint32_t dutyCycle =(uint32_t)(((double)12 / 255.0) * min(value, (uint32_t)255));
+  uint32_t dutyCycle =(uint32_t)(((double)4095 / 255.0) * min((uint32_t)value, (uint32_t)255));
 
   // Call duty cycle write
   return setDuty(pin, dutyCycle);

--- a/src/components/ledc/ws_ledc.cpp
+++ b/src/components/ledc/ws_ledc.cpp
@@ -54,7 +54,8 @@ bool ws_ledc::analogWrite(uint8_t pin, int value) {
 
   // Calculate duty cycle for the `value` passed in
   // (assumes 12-bit resolution, 2^12)
-  uint32_t dutyCycle = (4095 / 255) * min(value, 255);
+  //uint32_t dutyCycle = (4095 / 255) * min(value, 255);
+  uint32_t dutyCycle =(uint32_t)(((double)12 / 255.0) * min(value, (uint32_t)255));
 
   // Call duty cycle write
   return setDuty(pin, dutyCycle);


### PR DESCRIPTION
This pull request updates the `analogWrite` function in `src/components/ledc/ws_ledc.cpp` to correct the calculation of the duty cycle for 12-bit resolution.

### Key change:
* Updated the duty cycle calculation to use a more precise formula with type casting and floating-point arithmetic, ensuring accurate scaling for 12-bit resolution. The new formula replaces the integer division with floating-point division and casts `value` to `uint32_t` for consistency.