### PR TITLE
fix(CI): make git version work on forks

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -55,9 +55,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get WipperSnapper version
         run: |
-          git fetch --prune --unshallow --tags
-          git describe --dirty --tags
-          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          git remote add adafruit https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git || true
+          git fetch --prune --unshallow --all --tags
+          WS_VERSION="unknown"
+          if git describe --dirty --tags >/dev/null 2>&1; then
+            WS_VERSION=$(git describe --dirty --tags)
+            echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          else
+            # Fallback for forks: 1.0.0-{owner}-{short-sha}
+            REPO_OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            WS_VERSION="1.0.0-${REPO_OWNER}-${SHORT_SHA}"
+            echo >>$GITHUB_ENV WS_VERSION="1.0.0-${REPO_OWNER}-${SHORT_SHA}"
+          fi
+          echo "WS_VERSION: $WS_VERSION"
       - uses: actions/checkout@v4
         with:
           repository: adafruit/ci-arduino
@@ -272,9 +283,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get WipperSnapper version
         run: |
-          git fetch --prune --unshallow --tags
-          git describe --dirty --tags
-          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          git remote add adafruit https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git || true
+          git fetch --prune --unshallow --all --tags
+          if git describe --dirty --tags >/dev/null 2>&1; then
+            echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          else
+            # Fallback for forks: 1.0.0-{owner}-{short-sha}
+            REPO_OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo >>$GITHUB_ENV WS_VERSION="1.0.0-${REPO_OWNER}-${SHORT_SHA}"
+          fi
+          echo "WS_VERSION: $WS_VERSION"
       - uses: actions/checkout@v4
         with:
           repository: adafruit/ci-arduino
@@ -388,9 +407,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get WipperSnapper version
         run: |
-          git fetch --prune --unshallow --tags
-          git describe --dirty --tags
-          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          git remote add adafruit https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git || true
+          git fetch --prune --unshallow --all --tags
+          if git describe --dirty --tags >/dev/null 2>&1; then
+            echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          else
+            # Fallback for forks: 1.0.0-{owner}-{short-sha}
+            REPO_OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo >>$GITHUB_ENV WS_VERSION="1.0.0-${REPO_OWNER}-${SHORT_SHA}"
+          fi
+          echo "WS_VERSION: $WS_VERSION"
       - uses: actions/checkout@v4
         with:
           repository: adafruit/ci-arduino
@@ -526,9 +553,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get WipperSnapper version
         run: |
-          git fetch --prune --unshallow --tags
-          git describe --dirty --tags
-          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          git remote add adafruit https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git || true
+          git fetch --prune --unshallow --all --tags
+          if git describe --dirty --tags >/dev/null 2>&1; then
+            echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          else
+            # Fallback for forks: 1.0.0-{owner}-{short-sha}
+            REPO_OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo >>$GITHUB_ENV WS_VERSION="1.0.0-${REPO_OWNER}-${SHORT_SHA}"
+          fi
+          echo "WS_VERSION: $WS_VERSION"
       - uses: actions/checkout@v4
         with:
           repository: adafruit/ci-arduino
@@ -608,9 +643,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get WipperSnapper version
         run: |
-          git fetch --prune --unshallow --tags
-          git describe --dirty --tags
-          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          git remote add adafruit https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git || true
+          git fetch --prune --unshallow --all --tags
+          if git describe --dirty --tags >/dev/null 2>&1; then
+            echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          else
+            # Fallback for forks: 1.0.0-{owner}-{short-sha}
+            REPO_OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo >>$GITHUB_ENV WS_VERSION="1.0.0-${REPO_OWNER}-${SHORT_SHA}"
+          fi
+          echo "WS_VERSION: $WS_VERSION"
       - uses: actions/checkout@v4
         with:
           repository: adafruit/ci-arduino
@@ -687,9 +730,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get WipperSnapper version
         run: |
-          git fetch --prune --unshallow --tags
-          git describe --dirty --tags
-          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          git remote add adafruit https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git || true
+          git fetch --prune --unshallow --all --tags
+          if git describe --dirty --tags >/dev/null 2>&1; then
+            echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          else
+            # Fallback for forks: 1.0.0-{owner}-{short-sha}
+            REPO_OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo >>$GITHUB_ENV WS_VERSION="1.0.0-${REPO_OWNER}-${SHORT_SHA}"
+          fi
+          echo "WS_VERSION: $WS_VERSION"
       - uses: actions/checkout@v4
         with:
           repository: adafruit/ci-arduino
@@ -784,9 +835,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get WipperSnapper version
         run: |
-          git fetch --prune --unshallow --tags
-          git describe --dirty --tags
-          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          git remote add adafruit https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git || true
+          git fetch --prune --unshallow --all --tags
+          if git describe --dirty --tags >/dev/null 2>&1; then
+            echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          else
+            # Fallback for forks: 1.0.0-{owner}-{short-sha}
+            REPO_OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo >>$GITHUB_ENV WS_VERSION="1.0.0-${REPO_OWNER}-${SHORT_SHA}"
+          fi
+          echo "WS_VERSION: $WS_VERSION"
       - uses: actions/checkout@v4
         with:
           repository: adafruit/ci-arduino
@@ -888,9 +947,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get WipperSnapper version
         run: |
-          git fetch --prune --unshallow --tags
-          git describe --dirty --tags
-          echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          git remote add adafruit https://github.com/adafruit/Adafruit_Wippersnapper_Arduino.git || true
+          git fetch --prune --unshallow --all --tags
+          if git describe --dirty --tags >/dev/null 2>&1; then
+            echo >>$GITHUB_ENV WS_VERSION=$(git describe --dirty --tags)
+          else
+            # Fallback for forks: 1.0.0-{owner}-{short-sha}
+            REPO_OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            echo >>$GITHUB_ENV WS_VERSION="1.0.0-${REPO_OWNER}-${SHORT_SHA}"
+          fi
+          echo "WS_VERSION: $WS_VERSION"
       - uses: actions/checkout@v4
         with:
           repository: adafruit/ci-arduino


### PR DESCRIPTION
The CI jobs should be able to run successfully in peoples forks of our repo, but currently the get version step fails due to missing tags.

This step resolves that, fetching all tags (i.e. not just the fork), and then falling back to 1.0.0-${REPO_OWNER}-${COMMIT_REF}