### PR TITLE
SGP30 / SGP40 background sampling

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -1032,7 +1032,7 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _drivers_out.push_back(_ssd1306);
     WS_DEBUG_PRINTLN("SSD1306 display initialized Successfully!");
   } else {
-    WS_DEBUG_PRINTLN("ERROR: I2C device type not found!")
+    WS_DEBUG_PRINTLN("ERROR: I2C device type not found!");
     _busStatusResponse =
         wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_UNSUPPORTED_SENSOR;
     return false;

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -1349,7 +1349,8 @@ void WipperSnapper_Component_I2C::update() {
 
   // one fast pass for all drivers every update() call
   for (auto *drv : drivers) {
-    if (drv) drv->fastTick();
+    if (drv)
+      drv->fastTick();
   }
 
   long curTime;

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -1347,6 +1347,11 @@ void WipperSnapper_Component_I2C::update() {
   msgi2cResponse.which_payload =
       wippersnapper_signal_v1_I2CResponse_resp_i2c_device_event_tag;
 
+  // one fast pass for all drivers every update() call
+  for (auto *drv : drivers) {
+    if (drv) drv->fastTick();
+  }
+
   long curTime;
   bool sensorsReturningFalse = true;
   int retries = 3;
@@ -1354,6 +1359,7 @@ void WipperSnapper_Component_I2C::update() {
   while (sensorsReturningFalse && retries > 0) {
     sensorsReturningFalse = false;
     retries--;
+    curTime = millis();
 
     std::vector<WipperSnapper_I2C_Driver *>::iterator iter, end;
     for (iter = drivers.begin(), end = drivers.end(); iter != end; ++iter) {

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -1347,12 +1347,6 @@ void WipperSnapper_Component_I2C::update() {
   msgi2cResponse.which_payload =
       wippersnapper_signal_v1_I2CResponse_resp_i2c_device_event_tag;
 
-  // one fast pass for all drivers every update() call
-  for (auto *drv : drivers) {
-    if (drv)
-      drv->fastTick();
-  }
-
   long curTime;
   bool sensorsReturningFalse = true;
   int retries = 3;
@@ -1364,6 +1358,9 @@ void WipperSnapper_Component_I2C::update() {
 
     std::vector<WipperSnapper_I2C_Driver *>::iterator iter, end;
     for (iter = drivers.begin(), end = drivers.end(); iter != end; ++iter) {
+      // Per-driver fast tick (non-blocking)
+      (*iter)->fastTick();
+
       // Number of events which occurred for this driver
       msgi2cResponse.payload.resp_i2c_device_event.sensor_event_count = 0;
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -1413,8 +1413,8 @@ protected:
   long _ambientTempFPeriod = 0L; ///< The time period between reading the
                                  ///< ambient temp. (°F) sensor's value.
   long _ambientTempFPeriodPrv =
-      PERIOD_24HRS_AGO_MILLIS;  ///< The time when the ambient temp. (°F) sensor
-                                ///< was last read.
+      PERIOD_24HRS_AGO_MILLIS; ///< The time when the ambient temp. (°F) sensor
+                               ///< was last read.
   long _objectTempFPeriod = 0L; ///< The time period between reading the object
                                 ///< temp. (°F) sensor's value.
   long _objectTempFPeriodPrv =

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -1414,8 +1414,8 @@ protected:
   long _ambientTempFPeriod = 0L; ///< The time period between reading the
                                  ///< ambient temp. (°F) sensor's value.
   long _ambientTempFPeriodPrv =
-      PERIOD_24HRS_AGO_MILLIS;  ///< The time when the ambient temp. (°F) sensor
-                                ///< was last read.
+      PERIOD_24HRS_AGO_MILLIS; ///< The time when the ambient temp. (°F) sensor
+                               ///< was last read.
   long _objectTempFPeriod = 0L; ///< The time period between reading the object
                                 ///< temp. (°F) sensor's value.
   long _objectTempFPeriodPrv =

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -1414,8 +1414,8 @@ protected:
   long _ambientTempFPeriod = 0L; ///< The time period between reading the
                                  ///< ambient temp. (°F) sensor's value.
   long _ambientTempFPeriodPrv =
-      PERIOD_24HRS_AGO_MILLIS; ///< The time when the ambient temp. (°F) sensor
-                               ///< was last read.
+      PERIOD_24HRS_AGO_MILLIS;  ///< The time when the ambient temp. (°F) sensor
+                                ///< was last read.
   long _objectTempFPeriod = 0L; ///< The time period between reading the object
                                 ///< temp. (°F) sensor's value.
   long _objectTempFPeriodPrv =

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -34,7 +34,7 @@ class WipperSnapper_I2C_Driver {
 public:
   /*******************************************************************************/
   /*!
-      @brief    Instanciates an I2C sensor.
+      @brief    Instanctiates an I2C sensor.
       @param    i2c
                 The I2C hardware interface, default is Wire.
       @param    sensorAddress
@@ -52,6 +52,20 @@ public:
   */
   /*******************************************************************************/
   virtual ~WipperSnapper_I2C_Driver() {}
+
+  /*******************************************************************************/
+  /*!
+      @brief    Per-update background hook for drivers that need faster internal
+                sampling than the user publish interval.
+                Default is a no-op; override in concrete drivers (e.g., SGP30/40)
+                to maintain required ~1 Hz reads and accumulate/condition
+                values for later publish.
+      @note     Call site: WipperSnapper_Component_I2C::update() will invoke
+                this once per loop for each driver. Implementations must be
+                non-blocking (do not delay); use millis()-based timing.
+  */
+  /*******************************************************************************/
+  virtual void fastTick() {}
 
   /*******************************************************************************/
   /*!
@@ -1312,7 +1326,7 @@ public:
       @brief    Updates the properties of a proximity sensor.
       @param    period
                 The time interval at which to return new data from the
-                proimity sensor.
+                proximity sensor.
   */
   /*******************************************************************************/
   virtual void updateSensorProximity(float period) {

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -34,7 +34,7 @@ class WipperSnapper_I2C_Driver {
 public:
   /*******************************************************************************/
   /*!
-      @brief    Instanctiates an I2C sensor.
+      @brief    Instantiates an I2C sensor.
       @param    i2c
                 The I2C hardware interface, default is Wire.
       @param    sensorAddress
@@ -55,14 +55,15 @@ public:
 
   /*******************************************************************************/
   /*!
-      @brief    Per-update background hook for drivers that need faster internal
-                sampling than the user publish interval.
-                Default is a no-op; override in concrete drivers (e.g.,
-     SGP30/40) to maintain required ~1 Hz reads and accumulate/condition values
-     for later publish.
-      @note     Call site: WipperSnapper_Component_I2C::update() will invoke
-                this once per loop for each driver. Implementations must be
-                non-blocking (do not delay); use millis()-based timing.
+      @brief    Lightweight, per-update background hook for drivers that need
+                more frequent internal polling than the publish interval.
+                Default is a no-op; concrete drivers (e.g., SGP30/40) may
+                override this to perform a single non-blocking read and cache
+                results for later retrieval by getEvent*().
+      @note     Call site: WipperSnapper_Component_I2C::update() invokes this
+                once per loop for each driver. Implementations must be
+                non-blocking (do not delay); use millis()-based timing if
+                cadence is required.
   */
   /*******************************************************************************/
   virtual void fastTick() {}
@@ -1413,8 +1414,8 @@ protected:
   long _ambientTempFPeriod = 0L; ///< The time period between reading the
                                  ///< ambient temp. (°F) sensor's value.
   long _ambientTempFPeriodPrv =
-      PERIOD_24HRS_AGO_MILLIS; ///< The time when the ambient temp. (°F) sensor
-                               ///< was last read.
+      PERIOD_24HRS_AGO_MILLIS;  ///< The time when the ambient temp. (°F) sensor
+                                ///< was last read.
   long _objectTempFPeriod = 0L; ///< The time period between reading the object
                                 ///< temp. (°F) sensor's value.
   long _objectTempFPeriodPrv =

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -57,9 +57,9 @@ public:
   /*!
       @brief    Per-update background hook for drivers that need faster internal
                 sampling than the user publish interval.
-                Default is a no-op; override in concrete drivers (e.g., SGP30/40)
-                to maintain required ~1 Hz reads and accumulate/condition
-                values for later publish.
+                Default is a no-op; override in concrete drivers (e.g.,
+     SGP30/40) to maintain required ~1 Hz reads and accumulate/condition values
+     for later publish.
       @note     Call site: WipperSnapper_Component_I2C::update() will invoke
                 this once per loop for each driver. Implementations must be
                 non-blocking (do not delay); use millis()-based timing.
@@ -1413,8 +1413,8 @@ protected:
   long _ambientTempFPeriod = 0L; ///< The time period between reading the
                                  ///< ambient temp. (°F) sensor's value.
   long _ambientTempFPeriodPrv =
-      PERIOD_24HRS_AGO_MILLIS; ///< The time when the ambient temp. (°F) sensor
-                               ///< was last read.
+      PERIOD_24HRS_AGO_MILLIS;  ///< The time when the ambient temp. (°F) sensor
+                                ///< was last read.
   long _objectTempFPeriod = 0L; ///< The time period between reading the object
                                 ///< temp. (°F) sensor's value.
   long _objectTempFPeriodPrv =

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
@@ -94,12 +94,24 @@ public:
 protected:
   Adafruit_SGP30 *_sgp30; ///< Pointer to SGP30 sensor object
 
-  // Fast sampling state
+  /** Millis timestamp of last 1 Hz background read. */
   uint32_t _lastFastMs = 0;
+
+  /** Number of samples accumulated since last publish. */
   uint32_t _n = 0;
+
+  /** Running sum of eCO2 samples for averaging. */
   uint32_t _eco2Sum = 0;
+
+  /** Running sum of TVOC samples for averaging. */
   uint32_t _tvocSum = 0;
 
+  /*******************************************************************************/
+  /*!
+      @brief  Returns whether IAQ background sampling should be active.
+      @return True if either eCO2 or TVOC metrics are configured to publish.
+  */
+  /*******************************************************************************/
   inline bool iaqEnabled() {
     // Enable IAQ background reads if either metric is requested
     return (getSensorECO2Period() > 0) || (getSensorTVOCPeriod() > 0);

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
@@ -63,21 +63,21 @@ public:
     return true;
   }
 
-/*******************************************************************************/
-/*!
-    @brief    Gets the most recently cached eCO2 reading.
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the most recently cached eCO2 reading.
 
-              This value is updated in `fastTick()` at a ~1 Hz cadence
-              and returned directly here without re-triggering an I2C
-              transaction.
+                This value is updated in `fastTick()` at a ~1 Hz cadence
+                and returned directly here without re-triggering an I2C
+                transaction.
 
-    @param    senseEvent
-              Pointer to an Adafruit Sensor event that will be populated
-              with the cached eCO2 value (in ppm).
+      @param    senseEvent
+                Pointer to an Adafruit_Sensor event that will be populated
+                with the cached eCO2 value (in ppm).
 
-    @returns  True if a cached value is available, False otherwise.
-*/
-/*******************************************************************************/
+      @returns  True if a cached value is available, False otherwise.
+  */
+  /*******************************************************************************/
   bool getEventECO2(sensors_event_t *senseEvent) override {
     if (!_sgp30)
       return false;
@@ -85,21 +85,21 @@ public:
     return true;
   }
 
-/*******************************************************************************/
-/*!
-    @brief    Gets the most recently cached TVOC reading.
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the most recently cached TVOC reading.
 
-              This value is updated in `fastTick()` at a ~1 Hz cadence
-              and returned directly here without re-triggering an I2C
-              transaction.
+                This value is updated in `fastTick()` at a ~1 Hz cadence
+                and returned directly here without re-triggering an I2C
+                transaction.
 
-    @param    senseEvent
-              Pointer to an Adafruit Sensor event that will be populated
-              with the cached TVOC value (in ppb).
+      @param    senseEvent
+                Pointer to an Adafruit_Sensor event that will be populated
+                with the cached TVOC value (in ppb).
 
-    @returns  True if a cached value is available, False otherwise.
-*/
-/*******************************************************************************/
+      @returns  True if a cached value is available, False otherwise.
+  */
+  /*******************************************************************************/
   bool getEventTVOC(sensors_event_t *senseEvent) override {
     if (!_sgp30)
       return false;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
@@ -49,27 +49,31 @@ public:
   bool begin() {
     _sgp30 = new Adafruit_SGP30();
     if (!_sgp30->begin(_i2c)) {
-      delete _sgp30;          // avoid leak on init failure
+      delete _sgp30; // avoid leak on init failure
       _sgp30 = nullptr;
       return false;
     }
-    _sgp30->IAQinit();           // start IAQ algorithm
+    _sgp30->IAQinit();            // start IAQ algorithm
     _lastFastMs = millis();       // reset fast sampler
     _n = _eco2Sum = _tvocSum = 0; // clear accumulators
     return true;
   }
 
   bool getEventECO2(sensors_event_t *senseEvent) override {
-    if (!_sgp30) return false;
+    if (!_sgp30)
+      return false;
     bool ok = _sgp30->IAQmeasure();
-    if (ok) senseEvent->eCO2 = _sgp30->eCO2;
+    if (ok)
+      senseEvent->eCO2 = _sgp30->eCO2;
     return ok;
   }
 
   bool getEventTVOC(sensors_event_t *senseEvent) override {
-    if (!_sgp30) return false;
+    if (!_sgp30)
+      return false;
     bool ok = _sgp30->IAQmeasure();
-    if (ok) senseEvent->tvoc = _sgp30->TVOC;
+    if (ok)
+      senseEvent->tvoc = _sgp30->TVOC;
     return ok;
   }
 
@@ -79,8 +83,8 @@ public:
     uint32_t now = millis();
     if (now - _lastFastMs >= 1000) { // ~1 Hz cadence
       if (_sgp30 && _sgp30->IAQmeasure()) {
-        _eco2Sum += _sgp30->eCO2;   // uint16_t in library
-        _tvocSum += _sgp30->TVOC;   // uint16_t in library
+        _eco2Sum += _sgp30->eCO2; // uint16_t in library
+        _tvocSum += _sgp30->TVOC; // uint16_t in library
         _n++;
       }
       _lastFastMs = now;
@@ -88,7 +92,6 @@ public:
   }
 
 protected:
-
   Adafruit_SGP30 *_sgp30; ///< Pointer to SGP30 sensor object
 
   // Fast sampling state

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
@@ -24,6 +24,7 @@ public:
       : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
     _i2c = i2c;
     _sensorAddress = sensorAddress;
+    _sgp30 = nullptr;
   }
 
   /*******************************************************************************/
@@ -31,9 +32,12 @@ public:
       @brief    Destructor for an SGP30 sensor.
   */
   /*******************************************************************************/
-  ~WipperSnapper_I2C_Driver_SGP30() {
+  ~WipperSnapper_I2C_Driver_SGP30() override {
     // Called when a SGP30 component is deleted.
-    delete _sgp30;
+    if (_sgp30) {
+      delete _sgp30;
+      _sgp30 = nullptr;
+    }
   }
 
   /*******************************************************************************/
@@ -42,29 +46,60 @@ public:
       @returns  True if initialized successfully, False otherwise.
   */
   /*******************************************************************************/
-  bool begin() {
+  bool begin() override {
     _sgp30 = new Adafruit_SGP30();
-    return _sgp30->begin(_i2c);
+    if (!_sgp30->begin(_i2c)) {
+      delete _sgp30;          // avoid leak on init failure
+      _sgp30 = nullptr;
+      return false;
+    }
+    _sgp30->IAQinit();           // start IAQ algorithm
+    _lastFastMs = millis();       // reset fast sampler
+    _n = _eco2Sum = _tvocSum = 0; // clear accumulators
+    return true;
   }
 
-  bool getEventECO2(sensors_event_t *senseEvent) {
-    bool result = _sgp30->IAQmeasure();
-    if (result) {
-      senseEvent->eCO2 = _sgp30->eCO2;
-    }
-    return result;
+  bool getEventECO2(sensors_event_t *senseEvent) override {
+    if (!_sgp30) return false;
+    bool ok = _sgp30->IAQmeasure();
+    if (ok) senseEvent->eCO2 = _sgp30->eCO2;
+    return ok;
   }
 
-  bool getEventTVOC(sensors_event_t *senseEvent) {
-    bool result = _sgp30->IAQmeasure();
-    if (result) {
-      senseEvent->tvoc = _sgp30->TVOC;
+  bool getEventTVOC(sensors_event_t *senseEvent) override {
+    if (!_sgp30) return false;
+    bool ok = _sgp30->IAQmeasure();
+    if (ok) senseEvent->tvoc = _sgp30->TVOC;
+    return ok;
+  }
+
+  void fastTick() override {
+    if (!iaqEnabled())
+      return; // nothing enabled, save cycles
+    uint32_t now = millis();
+    if (now - _lastFastMs >= 1000) { // ~1 Hz cadence
+      if (_sgp30 && _sgp30->IAQmeasure()) {
+        _eco2Sum += _sgp30->eCO2;   // uint16_t in library
+        _tvocSum += _sgp30->TVOC;   // uint16_t in library
+        _n++;
+      }
+      _lastFastMs = now;
     }
-    return result;
   }
 
 protected:
-  Adafruit_SGP30 *_sgp30; ///< Pointer to SGP30 temperature sensor object
+  Adafruit_SGP30 *_sgp30; ///< Pointer to SGP30 sensor object
+
+  // Fast sampling state
+  uint32_t _lastFastMs = 0;
+  uint32_t _n = 0;
+  uint32_t _eco2Sum = 0;
+  uint32_t _tvocSum = 0;
+
+  inline bool iaqEnabled() const {
+    // Enable IAQ background reads if either metric is requested
+    return (getSensorECO2Period() > 0) || (getSensorTVOCPeriod() > 0);
+  }
 };
 
 #endif // WipperSnapper_I2C_Driver_SGP30

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
@@ -59,23 +59,33 @@ public:
     return true;
   }
 
-  bool getEventECO2(sensors_event_t *senseEvent) override {
-    if (!_sgp30)
-      return false;
-    bool ok = _sgp30->IAQmeasure();
-    if (ok)
-      senseEvent->eCO2 = _sgp30->eCO2;
-    return ok;
+bool getEventECO2(sensors_event_t *senseEvent) override {
+  if (!_sgp30) return false;
+  if (_n > 0) {
+    senseEvent->eCO2 = (uint16_t)(_eco2Sum / _n);
+    _eco2Sum = 0; _tvocSum = 0; _n = 0;
+    return true;
   }
+  if (_sgp30->IAQmeasure()) {
+    senseEvent->eCO2 = (uint16_t)_sgp30->eCO2;
+    return true;
+  }
+  return false;
+}
 
-  bool getEventTVOC(sensors_event_t *senseEvent) override {
-    if (!_sgp30)
-      return false;
-    bool ok = _sgp30->IAQmeasure();
-    if (ok)
-      senseEvent->tvoc = _sgp30->TVOC;
-    return ok;
+bool getEventTVOC(sensors_event_t *senseEvent) override {
+  if (!_sgp30) return false;
+  if (_n > 0) {
+    senseEvent->tvoc = (uint16_t)(_tvocSum / _n);
+    _eco2Sum = 0; _tvocSum = 0; _n = 0;
+    return true;
   }
+  if (_sgp30->IAQmeasure()) {
+    senseEvent->tvoc = (uint16_t)_sgp30->TVOC;
+    return true;
+  }
+  return false;
+}
 
   void fastTick() override {
     if (!iaqEnabled())

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
@@ -46,7 +46,7 @@ public:
       @returns  True if initialized successfully, False otherwise.
   */
   /*******************************************************************************/
-  bool begin() override {
+  bool begin() {
     _sgp30 = new Adafruit_SGP30();
     if (!_sgp30->begin(_i2c)) {
       delete _sgp30;          // avoid leak on init failure
@@ -88,6 +88,7 @@ public:
   }
 
 protected:
+
   Adafruit_SGP30 *_sgp30; ///< Pointer to SGP30 sensor object
 
   // Fast sampling state
@@ -96,7 +97,7 @@ protected:
   uint32_t _eco2Sum = 0;
   uint32_t _tvocSum = 0;
 
-  inline bool iaqEnabled() const {
+  inline bool iaqEnabled() {
     // Enable IAQ background reads if either metric is requested
     return (getSensorECO2Period() > 0) || (getSensorTVOCPeriod() > 0);
   }

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
@@ -59,33 +59,39 @@ public:
     return true;
   }
 
-bool getEventECO2(sensors_event_t *senseEvent) override {
-  if (!_sgp30) return false;
-  if (_n > 0) {
-    senseEvent->eCO2 = (uint16_t)(_eco2Sum / _n);
-    _eco2Sum = 0; _tvocSum = 0; _n = 0;
-    return true;
+  bool getEventECO2(sensors_event_t *senseEvent) override {
+    if (!_sgp30)
+      return false;
+    if (_n > 0) {
+      senseEvent->eCO2 = (uint16_t)(_eco2Sum / _n);
+      _eco2Sum = 0;
+      _tvocSum = 0;
+      _n = 0;
+      return true;
+    }
+    if (_sgp30->IAQmeasure()) {
+      senseEvent->eCO2 = (uint16_t)_sgp30->eCO2;
+      return true;
+    }
+    return false;
   }
-  if (_sgp30->IAQmeasure()) {
-    senseEvent->eCO2 = (uint16_t)_sgp30->eCO2;
-    return true;
-  }
-  return false;
-}
 
-bool getEventTVOC(sensors_event_t *senseEvent) override {
-  if (!_sgp30) return false;
-  if (_n > 0) {
-    senseEvent->tvoc = (uint16_t)(_tvocSum / _n);
-    _eco2Sum = 0; _tvocSum = 0; _n = 0;
-    return true;
+  bool getEventTVOC(sensors_event_t *senseEvent) override {
+    if (!_sgp30)
+      return false;
+    if (_n > 0) {
+      senseEvent->tvoc = (uint16_t)(_tvocSum / _n);
+      _eco2Sum = 0;
+      _tvocSum = 0;
+      _n = 0;
+      return true;
+    }
+    if (_sgp30->IAQmeasure()) {
+      senseEvent->tvoc = (uint16_t)_sgp30->TVOC;
+      return true;
+    }
+    return false;
   }
-  if (_sgp30->IAQmeasure()) {
-    senseEvent->tvoc = (uint16_t)_sgp30->TVOC;
-    return true;
-  }
-  return false;
-}
 
   void fastTick() override {
     if (!iaqEnabled())

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP30.h
@@ -34,7 +34,7 @@ public:
       @brief    Destructor for an SGP30 sensor.
   */
   /*******************************************************************************/
-  ~WipperSnapper_I2C_Driver_SGP30() override {
+  ~WipperSnapper_I2C_Driver_SGP30() {
     if (_sgp30) {
       delete _sgp30;
       _sgp30 = nullptr;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
@@ -147,13 +147,25 @@ public:
 
 protected:
   Adafruit_SGP40 *_sgp40; ///< SGP40
-  // background accumulation state
+
+  /** Millis timestamp of last 1 Hz background read. */
   uint32_t _lastFastMs = 0;
+
+  /** Number of samples accumulated since last publish. */
   uint32_t _n = 0;
+
+  /** Running sum of VOC index samples for averaging. */
   float _vocSum = 0.0f;
+
+  /** Running sum of raw samples for averaging. */
   uint32_t _rawSum = 0;
 
-  // enable fast sampling if either output is requested
+  /*******************************************************************************/
+  /*!
+      @brief  Returns whether VOC background sampling should be active.
+      @return True if either VOC Index or raw value is configured to publish.
+  */
+  /*******************************************************************************/
   inline bool vocEnabled() {
     return (getSensorVOCIndexPeriod() > 0) || (getSensorRawPeriod() > 0);
   }

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
@@ -87,7 +87,8 @@ public:
   */
   /*******************************************************************************/
   bool getEventRaw(sensors_event_t *rawEvent) override {
-    if (!_sgp40) return false;
+    if (!_sgp40)
+      return false;
     if (_n > 0) {
       rawEvent->data[0] = (float)_rawSum / (float)_n;
       _rawSum = 0;
@@ -109,7 +110,8 @@ public:
   */
   /*******************************************************************************/
   bool getEventVOCIndex(sensors_event_t *vocIndexEvent) override {
-    if (!_sgp40) return false;
+    if (!_sgp40)
+      return false;
     if (_n > 0) {
       vocIndexEvent->voc_index = _vocSum / (float)_n;
       _rawSum = 0;
@@ -129,8 +131,10 @@ public:
   */
   /*******************************************************************************/
   void fastTick() override {
-    if (!_sgp40) return;
-    if (!vocEnabled()) return;
+    if (!_sgp40)
+      return;
+    if (!vocEnabled())
+      return;
 
     uint32_t now = millis();
     if (now - _lastFastMs >= 1000) {
@@ -142,7 +146,6 @@ public:
   }
 
 protected:
-
   Adafruit_SGP40 *_sgp40; ///< SGP40
   // background accumulation state
   uint32_t _lastFastMs = 0;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
@@ -113,13 +113,13 @@ public:
     if (!_sgp40)
       return false;
     if (_n > 0) {
-      vocIndexEvent->voc_index = _vocSum / (float)_n;
+      vocIndexEvent->voc_index = (uint16_t)(_vocSum / (float)_n);
       _rawSum = 0;
       _vocSum = 0.0f;
       _n = 0;
       return true;
     }
-    vocIndexEvent->voc_index = (float)_sgp40->measureVocIndex();
+    vocIndexEvent->voc_index = (uint16_t)_sgp40->measureVocIndex();
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
@@ -52,7 +52,7 @@ public:
                 when the driver is destroyed.
   */
   /*******************************************************************************/
-  ~WipperSnapper_I2C_Driver_SGP40() override {
+  ~WipperSnapper_I2C_Driver_SGP40() {
     if (_sgp40) {
       delete _sgp40;
       _sgp40 = nullptr;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
@@ -131,7 +131,7 @@ protected:
 
   /** Cached latest measurements (no averaging). */
   uint16_t _rawValue = 0;
-  uint16_t _vocIdx = 0; ///< Index for the VOC (volatile organic compounds) sensor reading
+  uint16_t _vocIdx = 0; ///< VOC index value (0–500)
 
   /*******************************************************************************/
   /*!

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
@@ -63,7 +63,7 @@ public:
       @returns  True if initialized successfully, False otherwise.
   */
   /*******************************************************************************/
-  bool begin() override {
+  bool begin() {
     _sgp40 = new Adafruit_SGP40();
     if (!_sgp40 || !_sgp40->begin(_i2c)) {
       delete _sgp40;
@@ -142,6 +142,7 @@ public:
   }
 
 protected:
+
   Adafruit_SGP40 *_sgp40; ///< SGP40
   // background accumulation state
   uint32_t _lastFastMs = 0;
@@ -150,7 +151,7 @@ protected:
   uint32_t _rawSum = 0;
 
   // enable fast sampling if either output is requested
-  inline bool vocEnabled() const {
+  inline bool vocEnabled() {
     return (getSensorVOCIndexPeriod() > 0) || (getSensorRawPeriod() > 0);
   }
 };

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_SGP40.h
@@ -131,7 +131,7 @@ protected:
 
   /** Cached latest measurements (no averaging). */
   uint16_t _rawValue = 0;
-  uint16_t _vocIdx = 0;
+  uint16_t _vocIdx = 0; ///< Index for the VOC (volatile organic compounds) sensor reading
 
   /*******************************************************************************/
   /*!


### PR DESCRIPTION
Add SGP30 / SGP40 background sampling. Requires frequently 1s polling or returns 0 values.

Untested and only a proof of concept for feedback. This adds fastTick() polling to keep the SGPxx sensors producing usable data. Thanks @Timeline for the key insight of 1s polling being needed.

Difference observed between 15min polling versus 1s with the SGP40.

<img width="1624" height="778" alt="Screenshot 2025-09-12 at 9 39 50 AM" src="https://github.com/user-attachments/assets/6f643fcd-1dc1-4380-a1f6-ce568c356a16" />


Address issue [732](https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/732) 

Forum issues:

[SGP30 issue with WipperSnapper](https://forums.adafruit.com/viewtopic.php?t=220078)
[SGP40 Air Quality](https://forums.adafruit.com/viewtopic.php?t=218524)