### PR TITLE
fix(ci): Replace curl with gh command to fetch release info

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -154,6 +154,8 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: fetch tinyuf2 combined.bin
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           BOARD_NAME="${{fromJson(steps.get_board_json.outputs.boardJson).bootloaderBoardName}}"
           set +e


### PR DESCRIPTION
Switches to using the built in github command line interface `gh` to fetch release info, as it's the most common failure. 
In theory it should be more resilient, and now that I've linked the token it shouldn't be rate limited as easily in the first place.