### PR TITLE
Add TMP119 I2C driver

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -657,6 +657,17 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _tmp117->configureDriver(msgDeviceInitReq);
     drivers.push_back(_tmp117);
     WS_DEBUG_PRINTLN("TMP117 Initialized Successfully!");
+  } else if (strcmp("tmp119", msgDeviceInitReq->i2c_device_name) == 0) {
+    _tmp119 = new WipperSnapper_I2C_Driver_TMP119(this->_i2c, i2cAddress);
+    if (!_tmp119->begin()) {
+      WS_DEBUG_PRINTLN("ERROR: Failed to initialize TMP119!");
+      _busStatusResponse =
+          wippersnapper_i2c_v1_BusResponse_BUS_RESPONSE_DEVICE_INIT_FAIL;
+      return false;
+    }
+    _tmp119->configureDriver(msgDeviceInitReq);
+    drivers.push_back(_tmp119);
+    WS_DEBUG_PRINTLN("TMP119 Initialized Successfully!");
   } else if (strcmp("tsl2591", msgDeviceInitReq->i2c_device_name) == 0) {
     _tsl2591 = new WipperSnapper_I2C_Driver_TSL2591(this->_i2c, i2cAddress);
     if (!_tsl2591->begin()) {

--- a/src/components/i2c/WipperSnapper_I2C.h
+++ b/src/components/i2c/WipperSnapper_I2C.h
@@ -80,6 +80,7 @@
 #include "drivers/WipperSnapper_I2C_Driver_SPA06_003.h"
 #include "drivers/WipperSnapper_I2C_Driver_STEMMA_Soil_Sensor.h"
 #include "drivers/WipperSnapper_I2C_Driver_TMP117.h"
+#include "drivers/WipperSnapper_I2C_Driver_TMP119.h"
 #include "drivers/WipperSnapper_I2C_Driver_TSL2591.h"
 #include "drivers/WipperSnapper_I2C_Driver_VCNL4020.h"
 #include "drivers/WipperSnapper_I2C_Driver_VCNL4040.h"
@@ -196,6 +197,7 @@ private:
   WipperSnapper_I2C_Driver_MS8607 *_ms8607 = nullptr;
   WipperSnapper_I2C_Driver_NAU7802 *_nau7802 = nullptr;
   WipperSnapper_I2C_Driver_TMP117 *_tmp117 = nullptr;
+  WipperSnapper_I2C_Driver_TMP119 *_tmp119 = nullptr;
   WipperSnapper_I2C_Driver_TSL2591 *_tsl2591 = nullptr;
   WipperSnapper_I2C_Driver_VCNL4020 *_vcnl4020 = nullptr;
   WipperSnapper_I2C_Driver_VCNL4040 *_vcnl4040 = nullptr;

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_TMP119.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_TMP119.h
@@ -1,0 +1,116 @@
+/*!
+ * @file WipperSnapper_I2C_Driver_TMP119.h
+ *
+ * Device driver for the TMP119 high-precision temperature sensor.
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) Tyeth Gundry 2026 for Adafruit Industries.
+ *
+ * MIT license, all text here must be included in any redistribution.
+ *
+ */
+#ifndef WipperSnapper_I2C_Driver_TMP119_H
+#define WipperSnapper_I2C_Driver_TMP119_H
+
+#include "WipperSnapper_I2C_Driver.h"
+#include <Adafruit_TMP119.h>
+
+/**************************************************************************/
+/*!
+    @brief  Class that provides a driver interface for a TMP119 sensor.
+*/
+/**************************************************************************/
+class WipperSnapper_I2C_Driver_TMP119 : public WipperSnapper_I2C_Driver {
+public:
+  /*******************************************************************************/
+  /*!
+      @brief    Constructor for a TMP119 sensor.
+      @param    i2c
+                The I2C interface.
+      @param    sensorAddress
+                7-bit device address.
+  */
+  /*******************************************************************************/
+  WipperSnapper_I2C_Driver_TMP119(TwoWire *i2c, uint16_t sensorAddress)
+      : WipperSnapper_I2C_Driver(i2c, sensorAddress) {
+    _i2c = i2c;
+    _sensorAddress = sensorAddress;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Destructor for a TMP119 sensor.
+  */
+  /*******************************************************************************/
+  ~WipperSnapper_I2C_Driver_TMP119() {
+    // Called when a TMP119 component is deleted.
+    delete _tmp119;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Initializes the TMP119 sensor and begins I2C.
+      @returns  True if initialized successfully, False otherwise.
+  */
+  /*******************************************************************************/
+  bool begin() {
+    _tmp119 = new Adafruit_TMP119();
+    if (!_tmp119->begin((uint8_t)_sensorAddress, _i2c))
+      return false;
+
+    // Explicitly configure measurement mode and averaging per library defaults
+    // to ensure WipperSnapper behavior is independent of library updates
+    _tmp119->setMeasurementMode(TMP117_MODE_CONTINUOUS);
+    _tmp119->setAveragedSampleCount(TMP117_AVERAGE_8X);
+
+    return true;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the TMP119's current temperature in Celsius.
+      @param    tempEvent
+                Pointer to an Adafruit_Sensor event.
+      @returns  True if the temperature was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventAmbientTemp(sensors_event_t *tempEvent) {
+    if (!_readSensor())
+      return false;
+    *tempEvent = _cachedTemp;
+    return true;
+  }
+
+protected:
+  Adafruit_TMP119 *_tmp119; ///< Pointer to TMP119 temperature sensor object
+
+  // Cached readings and time guard
+  sensors_event_t _cachedTemp = {0};
+  unsigned long _lastRead = 0;
+
+  /*******************************************************************************/
+  /*!
+      @brief    Reads sensor data, with 1-second cache to avoid redundant
+                I2C reads when multiple getEvent*() calls occur per cycle
+                (e.g. °C then °F). The calling order of getEvent methods is not
+                guaranteed, so every method must go through this function.
+      @returns  True if cached data is available or a fresh read succeeded.
+  */
+  /*******************************************************************************/
+  bool _readSensor() {
+    if (_lastRead != 0 && millis() - _lastRead < 1000)
+      return true; // use cached values
+
+    if (!_tmp119->getEvent(&_cachedTemp))
+      return false;
+
+    _lastRead = millis();
+    return true;
+  }
+};
+
+#endif // WipperSnapper_I2C_Driver_TMP119_H


### PR DESCRIPTION
## Summary
Implements driver support for the TMP119 high-precision temperature sensor.

- **Driver Class:** WipperSnapper_I2C_Driver_TMP119
- **Device Name:** tmp119
- **I2C Addresses:** 0x48, 0x49, 0x4A, 0x4B (configurable via ADDR pin)
- **Library:** Adafruit_TMP117 (existing dependency)

## Features
- Explicit measurement mode and averaging configuration to ensure consistent behavior
- Caching pattern for multi-call optimization (°C then °F calls)
- Full Doxygen documentation compliance
- Follows existing driver patterns (based on TMP117)

## Testing
- Code follows exact patterns from WipperSnapper_I2C_Driver_TMP117
- Applied clang-format for style consistency
- Registered in alphabetical order alongside other drivers

## Related PR
Component definition: https://github.com/adafruit/Wippersnapper_Components/pull/299

🤖 Generated with [Claude Code](https://claude.com/claude-code)