### PR TITLE
add(type): implement Lux sensor type, migrate MAX44009 + VEML7700

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -1340,6 +1340,7 @@ void WipperSnapper_Component_I2C::displayDeviceEventMessage(
                (unsigned int)sensorAddress, value);
       break;
     case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LIGHT:
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LUX:
       snprintf(buffer, 100, "[I2C: %x] Read: %0.3f lux\n",
                (unsigned int)sensorAddress, value);
       break;
@@ -1581,6 +1582,16 @@ void WipperSnapper_Component_I2C::update() {
                       &WipperSnapper_I2C_Driver::setSensorLightPeriodPrv,
                       wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LIGHT,
                       "Light", " lux", event, &sensors_event_t::light,
+                      sensorsReturningFalse, retries);
+
+      // Lux sensor
+      sensorEventRead(iter, curTime, &msgi2cResponse,
+                      &WipperSnapper_I2C_Driver::getEventLux,
+                      &WipperSnapper_I2C_Driver::getSensorLuxPeriod,
+                      &WipperSnapper_I2C_Driver::getSensorLuxPeriodPrv,
+                      &WipperSnapper_I2C_Driver::setSensorLuxPeriodPrv,
+                      wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LUX,
+                      "Lux", " lux", event, &sensors_event_t::light,
                       sensorsReturningFalse, retries);
 
       // PM10_STD sensor

--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -1590,8 +1590,8 @@ void WipperSnapper_Component_I2C::update() {
                       &WipperSnapper_I2C_Driver::getSensorLuxPeriod,
                       &WipperSnapper_I2C_Driver::getSensorLuxPeriodPrv,
                       &WipperSnapper_I2C_Driver::setSensorLuxPeriodPrv,
-                      wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LUX,
-                      "Lux", " lux", event, &sensors_event_t::light,
+                      wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LUX, "Lux",
+                      " lux", event, &sensors_event_t::light,
                       sensorsReturningFalse, retries);
 
       // PM10_STD sensor

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -605,9 +605,9 @@ public:
   @param    period
   The time when the light sensor was queried last.
   */
- /*******************************************************************************/
- virtual void setSensorLightPeriodPrv(long period) {
-   _lightSensorPeriodPrv = period;
+  /*******************************************************************************/
+  virtual void setSensorLightPeriodPrv(long period) {
+    _lightSensorPeriodPrv = period;
   }
 
   /*******************************************************************************/
@@ -625,7 +625,7 @@ public:
                       // function.
     return false;
   }
-  
+
   /**************************** SENSOR_TYPE: LUX
    * ****************************/
   /*********************************************************************************/
@@ -672,7 +672,7 @@ public:
   /*******************************************************************************/
   virtual bool getEventLux(sensors_event_t *luxEvent) {
     (void)luxEvent; // Parameter is intentionally unused in this virtual
-                     // function.
+                    // function.
     return false;
   }
 
@@ -1435,9 +1435,8 @@ protected:
                                ///< read.
   long _luxSensorPeriod =
       0L; ///< The time period between reading the lux sensor's value.
-  long _luxSensorPeriodPrv =
-      PERIOD_24HRS_AGO_MILLIS; ///< The time when the lux sensor was last
-                               ///< read.
+  long _luxSensorPeriodPrv = PERIOD_24HRS_AGO_MILLIS; ///< The time when the lux
+                                                      ///< sensor was last read.
   long _PM10SensorPeriod =
       0L; ///< The time period between reading the pm25 sensor's value.
   long _PM10SensorPeriodPrv =

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver.h
@@ -118,6 +118,9 @@ public:
     case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LIGHT:
       _lightSensorPeriod = sensorPeriod;
       break;
+    case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_LUX:
+      _luxSensorPeriod = sensorPeriod;
+      break;
     case wippersnapper_i2c_v1_SensorType_SENSOR_TYPE_PM10_STD:
       _PM10SensorPeriod = sensorPeriod;
       break;
@@ -597,14 +600,14 @@ public:
 
   /*******************************************************************************/
   /*!
-      @brief    Sets a timestamp for when the light sensor
-                was queried.
-      @param    period
-                The time when the light sensor was queried last.
+  @brief    Sets a timestamp for when the light sensor
+  was queried.
+  @param    period
+  The time when the light sensor was queried last.
   */
-  /*******************************************************************************/
-  virtual void setSensorLightPeriodPrv(long period) {
-    _lightSensorPeriodPrv = period;
+ /*******************************************************************************/
+ virtual void setSensorLightPeriodPrv(long period) {
+   _lightSensorPeriodPrv = period;
   }
 
   /*******************************************************************************/
@@ -612,7 +615,7 @@ public:
       @brief    Base implementation - Reads a object light sensor and
                 converts the reading into the expected SI unit.
       @param    lightEvent
-                Light sensor reading, in meters.
+                Light sensor reading (raw).
       @returns  True if the sensor event was obtained successfully, False
                 otherwise.
   */
@@ -620,6 +623,56 @@ public:
   virtual bool getEventLight(sensors_event_t *lightEvent) {
     (void)lightEvent; // Parameter is intentionally unused in this virtual
                       // function.
+    return false;
+  }
+  
+  /**************************** SENSOR_TYPE: LUX
+   * ****************************/
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the object lux sensor's
+     period, if set.
+      @returns  Time when the object lux sensor should be polled, in
+     seconds.
+  */
+  /*********************************************************************************/
+  virtual long getSensorLuxPeriod() { return _luxSensorPeriod; }
+
+  /*********************************************************************************/
+  /*!
+      @brief    Base implementation - Returns the previous time interval at
+                    which the lux sensor was queried last.
+      @returns  Time when the lux sensor was last queried,
+                in seconds.
+  */
+  /*********************************************************************************/
+  virtual long getSensorLuxPeriodPrv() { return _luxSensorPeriodPrv; }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Sets a timestamp for when the lux sensor
+                was queried.
+      @param    period
+                The time when the lux sensor was queried last.
+  */
+  /*******************************************************************************/
+  virtual void setSensorLuxPeriodPrv(long period) {
+    _luxSensorPeriodPrv = period;
+  }
+
+  /*******************************************************************************/
+  /*!
+      @brief    Base implementation - Reads a object Light(lux) sensor and
+                converts the reading into the expected SI unit.
+      @param    luxEvent
+                Light sensor reading, in lux.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  virtual bool getEventLux(sensors_event_t *luxEvent) {
+    (void)luxEvent; // Parameter is intentionally unused in this virtual
+                     // function.
     return false;
   }
 
@@ -1379,6 +1432,11 @@ protected:
       0L; ///< The time period between reading the light sensor's value.
   long _lightSensorPeriodPrv =
       PERIOD_24HRS_AGO_MILLIS; ///< The time when the light sensor was last
+                               ///< read.
+  long _luxSensorPeriod =
+      0L; ///< The time period between reading the lux sensor's value.
+  long _luxSensorPeriodPrv =
+      PERIOD_24HRS_AGO_MILLIS; ///< The time when the lux sensor was last
                                ///< read.
   long _PM10SensorPeriod =
       0L; ///< The time period between reading the pm25 sensor's value.

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX44009.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_MAX44009.h
@@ -7,7 +7,7 @@
  * please support Adafruit and open-source hardware by purchasing
  * products from Adafruit!
  *
- * Copyright (c) Tyeth Gundry 2025 for Adafruit Industries.
+ * Copyright (c) Tyeth Gundry 2026 for Adafruit Industries.
  *
  * MIT license, all text here must be included in any redistribution.
  *
@@ -96,17 +96,17 @@ public:
 
   /*******************************************************************************/
   /*!
-      @brief    Gets the MAX44009's current ambient light reading.
-      @param    lightEvent
+      @brief    Gets the MAX44009's current ambient light reading in lux.
+      @param    luxEvent
                 Light sensor reading, in lux.
       @returns  True if the sensor event was obtained successfully, False
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventLight(sensors_event_t *lightEvent) {
+  bool getEventLux(sensors_event_t *luxEvent) {
     if (!_readSensor())
       return false;
-    *lightEvent = _cachedLight;
+    *luxEvent = _cachedLight;
     return true;
   }
 

--- a/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VEML7700.h
+++ b/src/components/i2c/drivers/WipperSnapper_I2C_Driver_VEML7700.h
@@ -73,7 +73,22 @@ public:
   bool getEventLight(sensors_event_t *lightEvent) {
     // Get sensor event populated in lux via AUTO integration and gain
     lightEvent->light = _veml->readLux(VEML_LUX_AUTO);
+    return true;
+  }
 
+  /*******************************************************************************/
+  /*!
+      @brief    Gets the VEML7700's current ambient light reading in lux.
+      @param    luxEvent
+                Light sensor reading, in lux.
+      @returns  True if the sensor event was obtained successfully, False
+                otherwise.
+  */
+  /*******************************************************************************/
+  bool getEventLux(sensors_event_t *luxEvent) {
+    if (!_veml)
+      return false;
+    luxEvent->light = _veml->readLux(VEML_LUX_AUTO);
     return true;
   }
 


### PR DESCRIPTION
While adding the MAX44009 sensor (wide range lux), it was identified that in theory we support both light (unitless) and lux in wippersnapper.

In practise there were a bunch of unimplemented pieces, but the key components were there.

This PR adds the missing base methods, backing fields, and polling in update loop.

Finally it migrates the MAX44009 to lux (only used by me so far as released last fortnight), and adds the lux endpoint for the VEML7700, but **does not migrate the VEML7700** due to an issue migrating feed names (via sensor type migration).

See related issue: https://github.com/adafruit/Wippersnapper_Components/issues/322#issuecomment-4391402144