### PR TITLE
CI: Move "Doxygen and Clang" step

### DIFF
--- a/.github/workflows/build-clang-doxy.yml
+++ b/.github/workflows/build-clang-doxy.yml
@@ -1087,14 +1087,6 @@ jobs:
   clang_and_doxy:
     name: 🔎Clang & Doxygen
     runs-on: ubuntu-latest
-    needs:
-      [
-        build-samd,
-        build-esp32,
-        build-esp32sx,
-        build-esp8266,
-        build-rp2040,
-      ]
     steps:
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This pull request modifies the workflow configuration in `.github/workflows/build-clang-doxy.yml` by removing the dependency on several build jobs for the `clang_and_doxy` job. Now, `clang_and_doxy` will run independently and no longer wait for the completion of the `build-samd`, `build-esp32`, `build-esp32sx`, `build-esp8266`, and `build-rp2040` jobs.