### PR TITLE
fix(pixels): initialise all members of strands array

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.129
+version=1.0.0-beta.130
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino application for Adafruit.io WipperSnapper

--- a/platformio.ini
+++ b/platformio.ini
@@ -417,6 +417,26 @@ build_flags = -DARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM
 board_build.partitions = tinyuf2-partitions-8MB.csv
 extra_scripts = pre:rename_usb_config.py
 
+; Adafruit QT Py ESP32-S3 NO PSRAM DEBUG
+[env:adafruit_qtpy_esp32s3_nopsram_debug]
+extends = common:esp32
+board = adafruit_qtpy_esp32s3_nopsram
+build_type = debug
+debug_tool = esp-builtin
+board_build.partitions = min_spiffs.csv
+# board_build.partitions = tinyuf2-partitions-8MB.csv
+build_flags =
+    -DARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM
+    # -DUSE_TINYUSB=1
+    -DESP_LOG_LEVEL=5
+    -DARDUINO_LOG_LEVEL=5
+    -DCORE_DEBUG_LEVEL=5
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    ; cdc + usb otg (tinyusb)
+    ; -DARDUINO_USB_MODE=0
+    ; hwcdc jtag
+    -DARDUINO_USB_MODE=1
+
 ; Adafruit QT Py ESP32-S3 with PSRAM
 [env:adafruit_qtpy_esp32s3_with_psram]
 extends = common:esp32

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -61,6 +61,9 @@ Wippersnapper::Wippersnapper() {
   WS._pwmComponent = new ws_pwm();
 #endif
 
+  // Pixels
+  WS._pixelsComponent = new ws_pixels();
+
   // Servo
   WS._servoComponent = new ws_servo();
 
@@ -1329,7 +1332,7 @@ bool cbDecodePixelsMsg(pb_istream_t *stream, const pb_field_t *field,
     }
 
     // Add a new strand
-    return WS._ws_pixelsComponent->addStrand(&msgPixelsCreateReq);
+    return WS._pixelsComponent->addStrand(&msgPixelsCreateReq);
   } else if (field->tag ==
              wippersnapper_signal_v1_PixelsRequest_req_pixels_delete_tag) {
     WS_DEBUG_PRINTLN(
@@ -1348,7 +1351,7 @@ bool cbDecodePixelsMsg(pb_istream_t *stream, const pb_field_t *field,
     }
 
     // delete strand
-    WS._ws_pixelsComponent->deleteStrand(&msgPixelsDeleteReq);
+    WS._pixelsComponent->deleteStrand(&msgPixelsDeleteReq);
   } else if (field->tag ==
              wippersnapper_signal_v1_PixelsRequest_req_pixels_write_tag) {
     WS_DEBUG_PRINTLN(
@@ -1366,7 +1369,7 @@ bool cbDecodePixelsMsg(pb_istream_t *stream, const pb_field_t *field,
     }
 
     // fill strand
-    WS._ws_pixelsComponent->fillStrand(&msgPixelsWritereq);
+    WS._pixelsComponent->fillStrand(&msgPixelsWritereq);
   } else {
     WS_DEBUG_PRINTLN("ERROR: Pixels message type not found!");
     return false;

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -383,7 +383,7 @@ public:
   Wippersnapper_FS *_fileSystem; ///< Instance of Filesystem (native USB)
   WipperSnapper_LittleFS
       *_littleFS; ///< Instance of LittleFS Filesystem (non-native USB)
-  ws_pixels *_ws_pixelsComponent; ///< ptr to instance of ws_pixels class
+  ws_pixels *_pixelsComponent; ///< ptr to instance of ws_pixels class
   ws_pwm *_pwmComponent;          ///< Instance of pwm class
   ws_servo *_servoComponent;      ///< Instance of servo class
   ws_ds18x20 *_ds18x20Component;  ///< Instance of DS18x20 class

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -167,7 +167,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.129" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.130" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -383,11 +383,11 @@ public:
   Wippersnapper_FS *_fileSystem; ///< Instance of Filesystem (native USB)
   WipperSnapper_LittleFS
       *_littleFS; ///< Instance of LittleFS Filesystem (non-native USB)
-  ws_pixels *_pixelsComponent; ///< ptr to instance of ws_pixels class
-  ws_pwm *_pwmComponent;          ///< Instance of pwm class
-  ws_servo *_servoComponent;      ///< Instance of servo class
-  ws_ds18x20 *_ds18x20Component;  ///< Instance of DS18x20 class
-  ws_uart *_uartComponent;        ///< Instance of UART class
+  ws_pixels *_pixelsComponent;   ///< ptr to instance of ws_pixels class
+  ws_pwm *_pwmComponent;         ///< Instance of pwm class
+  ws_servo *_servoComponent;     ///< Instance of servo class
+  ws_ds18x20 *_ds18x20Component; ///< Instance of DS18x20 class
+  ws_uart *_uartComponent;       ///< Instance of UART class
   DisplayController
       *_displayController; ///< Instance of display controller class
 

--- a/src/components/pixels/ws_pixels.cpp
+++ b/src/components/pixels/ws_pixels.cpp
@@ -412,7 +412,7 @@ uint32_t ws_pixels::getGammaCorrectedColor(uint32_t pixel_color,
 void ws_pixels::fillStrand(
     wippersnapper_pixels_v1_PixelsWriteRequest *pixelsWriteMsg) {
   WS_DEBUG_PRINT("Filling strand on ");
-  WS_DEBUG_PRINTVAR(pixelsWriteMsg->pixels_pin_data);
+  WS_DEBUG_PRINTLNVAR(pixelsWriteMsg->pixels_pin_data);
   // Get index of pixel strand
   int strandIdx = getStrandIdx(atoi(pixelsWriteMsg->pixels_pin_data + 1),
                                pixelsWriteMsg->pixels_type);

--- a/src/components/pixels/ws_pixels.cpp
+++ b/src/components/pixels/ws_pixels.cpp
@@ -26,16 +26,15 @@ strand_s strands[MAX_PIXEL_STRANDS]; ///< Contains all pixel strands used by Wip
 ws_pixels::ws_pixels() {
   // Initialize all strands to default values
   for (size_t i = 0; i < sizeof(strands) / sizeof(strands[0]); i++) {
-    strands[i] = {
-        nullptr,
-        nullptr,
-        wippersnapper_pixels_v1_PixelsType_PIXELS_TYPE_UNSPECIFIED,
-        0,
-        0,
-        wippersnapper_pixels_v1_PixelsOrder_PIXELS_ORDER_UNSPECIFIED,
-        -1,
-        -1,
-        -1};
+    strands[i] = {nullptr,
+                  nullptr,
+                  wippersnapper_pixels_v1_PixelsType_PIXELS_TYPE_UNSPECIFIED,
+                  0,
+                  0,
+                  wippersnapper_pixels_v1_PixelsOrder_PIXELS_ORDER_UNSPECIFIED,
+                  -1,
+                  -1,
+                  -1};
   }
 }
 

--- a/src/components/pixels/ws_pixels.cpp
+++ b/src/components/pixels/ws_pixels.cpp
@@ -16,16 +16,28 @@
  */
 #include "ws_pixels.h"
 
-strand_s strands[MAX_PIXEL_STRANDS]{
-    nullptr,
-    nullptr,
-    wippersnapper_pixels_v1_PixelsType_PIXELS_TYPE_UNSPECIFIED,
-    0,
-    0,
-    wippersnapper_pixels_v1_PixelsOrder_PIXELS_ORDER_UNSPECIFIED,
-    -1,
-    -1,
-    -1}; ///< Contains all pixel strands used by WipperSnapper
+strand_s strands[MAX_PIXEL_STRANDS]; ///< Contains all pixel strands used by WipperSnapper
+
+/**************************************************************************/
+/*!
+    @brief  Constructor
+*/
+/******************************************************************************/
+ws_pixels::ws_pixels() {
+  // Initialize all strands to default values
+  for (size_t i = 0; i < sizeof(strands) / sizeof(strands[0]); i++) {
+    strands[i] = {
+        nullptr,
+        nullptr,
+        wippersnapper_pixels_v1_PixelsType_PIXELS_TYPE_UNSPECIFIED,
+        0,
+        0,
+        wippersnapper_pixels_v1_PixelsOrder_PIXELS_ORDER_UNSPECIFIED,
+        -1,
+        -1,
+        -1};
+  }
+}
 
 /**************************************************************************/
 /*!

--- a/src/components/pixels/ws_pixels.cpp
+++ b/src/components/pixels/ws_pixels.cpp
@@ -16,13 +16,13 @@
  */
 #include "ws_pixels.h"
 
-strand_s strands[MAX_PIXEL_STRANDS]; ///< Contains all pixel strands used by WipperSnapper
+strand_s strands[MAX_PIXEL_STRANDS]; ///< Contains all usable pixel strands
 
 /**************************************************************************/
 /*!
     @brief  Constructor
 */
-/******************************************************************************/
+/**************************************************************************/
 ws_pixels::ws_pixels() {
   // Initialize all strands to default values
   for (size_t i = 0; i < sizeof(strands) / sizeof(strands[0]); i++) {

--- a/src/components/pixels/ws_pixels.cpp
+++ b/src/components/pixels/ws_pixels.cpp
@@ -16,7 +16,7 @@
  */
 #include "ws_pixels.h"
 
-strand_s strands[MAX_PIXEL_STRANDS] = {0}; ///< Contains all usable pixel strands
+strand_s strands[MAX_PIXEL_STRANDS] = {0}; ///< Contains all pixel strands
 
 /**************************************************************************/
 /*!
@@ -345,9 +345,16 @@ int ws_pixels::getStrandIdx(int16_t dataPin,
   WS_DEBUG_PRINTLNVAR(dataPin);
   for (size_t strandIdx = 0; strandIdx < sizeof(strands) / sizeof(strands[0]);
        strandIdx++) {
-    WS_DEBUG_PRINT("Checking strandIdx ");    WS_DEBUG_PRINTVAR(strandIdx);
-    WS_DEBUG_PRINT(" (Neo D"); WS_DEBUG_PRINTVAR(strands[strandIdx].pinNeoPixel); WS_DEBUG_PRINT(")");
-    WS_DEBUG_PRINT(" (Dot D"); WS_DEBUG_PRINTVAR(strands[strandIdx].pinDotStarData); WS_DEBUG_PRINT(" C"); WS_DEBUG_PRINTVAR(strands[strandIdx].pinDotStarClock); WS_DEBUG_PRINTLN(")");
+    WS_DEBUG_PRINT("Checking strandIdx ");
+    WS_DEBUG_PRINTVAR(strandIdx);
+    WS_DEBUG_PRINT(" (Neo D");
+    WS_DEBUG_PRINTVAR(strands[strandIdx].pinNeoPixel);
+    WS_DEBUG_PRINT(")");
+    WS_DEBUG_PRINT(" (Dot D");
+    WS_DEBUG_PRINTVAR(strands[strandIdx].pinDotStarData);
+    WS_DEBUG_PRINT(" C");
+    WS_DEBUG_PRINTVAR(strands[strandIdx].pinDotStarClock);
+    WS_DEBUG_PRINTLN(")");
     if (type == wippersnapper_pixels_v1_PixelsType_PIXELS_TYPE_NEOPIXEL &&
         strands[strandIdx].pinNeoPixel == dataPin)
       return strandIdx;

--- a/src/components/pixels/ws_pixels.cpp
+++ b/src/components/pixels/ws_pixels.cpp
@@ -16,7 +16,7 @@
  */
 #include "ws_pixels.h"
 
-strand_s strands[MAX_PIXEL_STRANDS]; ///< Contains all usable pixel strands
+strand_s strands[MAX_PIXEL_STRANDS] = {0}; ///< Contains all usable pixel strands
 
 /**************************************************************************/
 /*!
@@ -341,8 +341,13 @@ bool ws_pixels::addStrand(
 /**************************************************************************/
 int ws_pixels::getStrandIdx(int16_t dataPin,
                             wippersnapper_pixels_v1_PixelsType type) {
+  WS_DEBUG_PRINT("Searching for strand with data pin GPIO #");
+  WS_DEBUG_PRINTLNVAR(dataPin);
   for (size_t strandIdx = 0; strandIdx < sizeof(strands) / sizeof(strands[0]);
        strandIdx++) {
+    WS_DEBUG_PRINT("Checking strandIdx ");    WS_DEBUG_PRINTVAR(strandIdx);
+    WS_DEBUG_PRINT(" (Neo D"); WS_DEBUG_PRINTVAR(strands[strandIdx].pinNeoPixel); WS_DEBUG_PRINT(")");
+    WS_DEBUG_PRINT(" (Dot D"); WS_DEBUG_PRINTVAR(strands[strandIdx].pinDotStarData); WS_DEBUG_PRINT(" C"); WS_DEBUG_PRINTVAR(strands[strandIdx].pinDotStarClock); WS_DEBUG_PRINTLN(")");
     if (type == wippersnapper_pixels_v1_PixelsType_PIXELS_TYPE_NEOPIXEL &&
         strands[strandIdx].pinNeoPixel == dataPin)
       return strandIdx;
@@ -411,7 +416,8 @@ uint32_t ws_pixels::getGammaCorrectedColor(uint32_t pixel_color,
 /**************************************************************************/
 void ws_pixels::fillStrand(
     wippersnapper_pixels_v1_PixelsWriteRequest *pixelsWriteMsg) {
-
+  WS_DEBUG_PRINT("Filling strand on ");
+  WS_DEBUG_PRINTVAR(pixelsWriteMsg->pixels_pin_data);
   // Get index of pixel strand
   int strandIdx = getStrandIdx(atoi(pixelsWriteMsg->pixels_pin_data + 1),
                                pixelsWriteMsg->pixels_type);

--- a/src/components/pixels/ws_pixels.cpp
+++ b/src/components/pixels/ws_pixels.cpp
@@ -341,20 +341,8 @@ bool ws_pixels::addStrand(
 /**************************************************************************/
 int ws_pixels::getStrandIdx(int16_t dataPin,
                             wippersnapper_pixels_v1_PixelsType type) {
-  WS_DEBUG_PRINT("Searching for strand with data pin GPIO #");
-  WS_DEBUG_PRINTLNVAR(dataPin);
   for (size_t strandIdx = 0; strandIdx < sizeof(strands) / sizeof(strands[0]);
        strandIdx++) {
-    WS_DEBUG_PRINT("Checking strandIdx ");
-    WS_DEBUG_PRINTVAR(strandIdx);
-    WS_DEBUG_PRINT(" (Neo D");
-    WS_DEBUG_PRINTVAR(strands[strandIdx].pinNeoPixel);
-    WS_DEBUG_PRINT(")");
-    WS_DEBUG_PRINT(" (Dot D");
-    WS_DEBUG_PRINTVAR(strands[strandIdx].pinDotStarData);
-    WS_DEBUG_PRINT(" C");
-    WS_DEBUG_PRINTVAR(strands[strandIdx].pinDotStarClock);
-    WS_DEBUG_PRINTLN(")");
     if (type == wippersnapper_pixels_v1_PixelsType_PIXELS_TYPE_NEOPIXEL &&
         strands[strandIdx].pinNeoPixel == dataPin)
       return strandIdx;


### PR DESCRIPTION
Fixes #926

Previously the strands array was only initialising the first member with the supplied initialiser (and the remainder zero initialised rather than using the supplied values):
```
strand_s strands[MAX_PIXEL_STRANDS]{
    nullptr,
    nullptr,
    wippersnapper_pixels_v1_PixelsType_PIXELS_TYPE_UNSPECIFIED,
    0,
    0,
    wippersnapper_pixels_v1_PixelsOrder_PIXELS_ORDER_UNSPECIFIED,
    -1,
    -1,
    -1};
```

This meant the safety check of getStrandIndex(atoi(pin)) did a check on the first element and was fine, but would presumably crash because the pins being checked were not -1 when iterating over further strands array elements, allowing the write to proceed on an unsetup PWM channel.

Change is to do the default intialising of all members in a new constructor.