### PR TITLE
Bump version to v1.0.0-beta.131 (ESP32 BSP upgrade to 3.3.10)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.130
+version=1.0.0-beta.131
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino application for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -167,7 +167,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.130" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-beta.131" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic


### PR DESCRIPTION
Adafruit/ci-arduino Branch ci-wippersnapper was updated to point esp32 based platforms / build targets at the adafruit/arduino-esp32 repo branch bsp-3-3-10.

This release contains no code changes apart from that.