### PR TITLE
fix(i2c): v2 scans reach the STEMMA (Wire1) bus + fix Probe/Add oneof decode

### DIFF
--- a/src/components/i2c/controller.cpp
+++ b/src/components/i2c/controller.cpp
@@ -574,23 +574,25 @@ size_t I2cController::GetDecodedSettingsCount() {
    the wanted field and decoding a STANDALONE message keeps caller-installed
    callbacks intact.
     @param    stream    The B2D envelope stream.
-    @param    want_tag  The B2D payload field tag (e.g. ws_i2c_B2D_probe_tag).
+    @param    member_tag_to_decode  The B2D payload field tag to read (e.g.
+   ws_i2c_B2D_probe_tag).
     @param    fields    The sub-message's nanopb field descriptor.
-    @param    dest      The sub-message struct to decode into (callbacks
-   pre-set).
+    @param    dest_msg  The standalone sub-message struct to decode into, with
+   its decode callbacks already installed by the caller.
     @returns  True if the field was found and decoded, False otherwise.
 */
-static bool decodeI2cB2DMember(pb_istream_t *stream, uint32_t want_tag,
-                               const pb_msgdesc_t *fields, void *dest) {
+static bool decodeI2cB2DMember(pb_istream_t *stream,
+                               uint32_t member_tag_to_decode,
+                               const pb_msgdesc_t *fields, void *dest_msg) {
   pb_wire_type_t wire_type;
   uint32_t tag;
   bool eof = false;
   while (pb_decode_tag(stream, &wire_type, &tag, &eof) && !eof) {
-    if (tag == want_tag && wire_type == PB_WT_STRING) {
+    if (tag == member_tag_to_decode && wire_type == PB_WT_STRING) {
       pb_istream_t substream;
       if (!pb_make_string_substream(stream, &substream))
         return false;
-      bool ok = ws_pb_decode(&substream, fields, dest);
+      bool ok = ws_pb_decode(&substream, fields, dest_msg);
       if (!pb_close_string_substream(stream, &substream))
         return false;
       return ok;
@@ -1251,15 +1253,15 @@ I2cHardware *I2cController::findOrCreateBus(uint32_t pin_scl,
   WS_DEBUG_PRINT("SDA Pin: ");
   WS_DEBUG_PRINTLNVAR(pin_sda);
 
+  uint8_t bus_instance = 0;
+#ifdef I2C_STEMMA_WIRE1
   // On boards whose STEMMA QT / Qwiic connector is wired to the secondary I2C
   // peripheral (Wire1), ws_boards.h defines I2C_STEMMA_WIRE1. Use bus instance
   // 1 so probes/devices reach the STEMMA bus instead of the (empty) primary
   // Wire.
-  uint8_t instance = 0;
-#ifdef I2C_STEMMA_WIRE1
-  instance = 1;
+  bus_instance = 1;
 #endif
-  I2cHardware *new_bus = new I2cHardware(pin_sda, pin_scl, instance);
+  I2cHardware *new_bus = new I2cHardware(pin_sda, pin_scl, bus_instance);
   if (!new_bus->begin()) {
     WS_DEBUG_PRINTLN("[i2c] ERROR: Failed to initialize I2C bus!");
     delete new_bus;

--- a/src/components/i2c/controller.cpp
+++ b/src/components/i2c/controller.cpp
@@ -565,6 +565,43 @@ size_t I2cController::GetDecodedSettingsCount() {
 /******************************************************************************/
 
 /*!
+    @brief  Decode a single length-delimited sub-message out of a ws_i2c_B2D
+            envelope by its field tag, WITHOUT decoding through the B2D oneof.
+    @details  ws_i2c_B2D is a nanopb STATIC oneof: when pb_decode encounters a
+              payload field it zero-inits the union member first, which wipes
+   any decode callbacks pre-set on that member (the bug that silently made I2C
+   Probe scans return 0 address-spaces and Add drop its settings). Hand-reading
+   the wanted field and decoding a STANDALONE message keeps caller-installed
+   callbacks intact.
+    @param    stream    The B2D envelope stream.
+    @param    want_tag  The B2D payload field tag (e.g. ws_i2c_B2D_probe_tag).
+    @param    fields    The sub-message's nanopb field descriptor.
+    @param    dest      The sub-message struct to decode into (callbacks
+   pre-set).
+    @returns  True if the field was found and decoded, False otherwise.
+*/
+static bool decodeI2cB2DMember(pb_istream_t *stream, uint32_t want_tag,
+                               const pb_msgdesc_t *fields, void *dest) {
+  pb_wire_type_t wire_type;
+  uint32_t tag;
+  bool eof = false;
+  while (pb_decode_tag(stream, &wire_type, &tag, &eof) && !eof) {
+    if (tag == want_tag && wire_type == PB_WT_STRING) {
+      pb_istream_t substream;
+      if (!pb_make_string_substream(stream, &substream))
+        return false;
+      bool ok = ws_pb_decode(&substream, fields, dest);
+      if (!pb_close_string_substream(stream, &substream))
+        return false;
+      return ok;
+    }
+    if (!pb_skip_field(stream, wire_type))
+      return false;
+  }
+  return false;
+}
+
+/*!
     @brief  Routes messages using the i2c.proto API to the
             appropriate controller functions.
     @param  stream
@@ -594,17 +631,17 @@ bool I2cController::Router(pb_istream_t *stream) {
     res = Handle_Probe(&saved_stream);
     break;
   case ws_i2c_B2D_add_tag: {
-    // Re-decode from saved stream with settings callbacks wired up,
-    // same pattern as Handle_Probe.
-    ws_i2c_B2D b2d_add = ws_i2c_B2D_init_zero;
-    _i2c_model->SetupAddDecodeCallbacks(&b2d_add.payload.add);
-    if (!ws_pb_decode(&saved_stream, ws_i2c_B2D_fields, &b2d_add)) {
+    // Decode the Add sub-message DIRECTLY (not via the B2D oneof) so its
+    // settings decode callback survives — see decodeI2cB2DMember.
+    ws_i2c_Add add = ws_i2c_Add_init_zero;
+    _i2c_model->SetupAddDecodeCallbacks(&add);
+    if (!decodeI2cB2DMember(&saved_stream, ws_i2c_B2D_add_tag,
+                            ws_i2c_Add_fields, &add)) {
       Ws.error_handler->publishComponentError(
-          b2d_add.payload.add.descriptor,
-          "Failed to decode I2C add message settings!");
+          add.descriptor, "Failed to decode I2C add message settings!");
       return false;
     }
-    res = Handle_Add(&b2d_add.payload.add);
+    res = Handle_Add(&add);
     break;
   }
   case ws_i2c_B2D_remove_tag:
@@ -783,13 +820,14 @@ bool I2cController::Handle_Add(ws_i2c_Add *msg) {
     @returns  True if probe completed and results published, False otherwise.
 */
 bool I2cController::Handle_Probe(pb_istream_t *stream) {
-  // Decode B2D with probe callbacks — safe to write to the probe union
-  // member here because we know the payload IS a probe.
-  ws_i2c_B2D b2d = ws_i2c_B2D_init_zero;
-  _i2c_model->SetupProbeDecodeCallbacks(&b2d.payload.probe);
-  if (!ws_pb_decode(stream, ws_i2c_B2D_fields, &b2d)) {
-    Ws.error_handler->publishComponentError(ws_i2c_Descriptor{},
-                                            "Failed to decode Probe message!");
+  // Decode the Probe sub-message DIRECTLY (not via the ws_i2c_B2D oneof) so its
+  // address_spaces/addresses decode callbacks survive — see decodeI2cB2DMember.
+  ws_i2c_Probe probe = ws_i2c_Probe_init_zero;
+  _i2c_model->SetupProbeDecodeCallbacks(&probe);
+  if (!decodeI2cB2DMember(stream, ws_i2c_B2D_probe_tag, ws_i2c_Probe_fields,
+                          &probe)) {
+    Ws.error_handler->publishComponentError(
+        ws_i2c_Descriptor{}, "Failed to decode I2C Probe message!");
     return false;
   }
 
@@ -1213,7 +1251,15 @@ I2cHardware *I2cController::findOrCreateBus(uint32_t pin_scl,
   WS_DEBUG_PRINT("SDA Pin: ");
   WS_DEBUG_PRINTLNVAR(pin_sda);
 
-  I2cHardware *new_bus = new I2cHardware(pin_sda, pin_scl);
+  // On boards whose STEMMA QT / Qwiic connector is wired to the secondary I2C
+  // peripheral (Wire1), ws_boards.h defines I2C_STEMMA_WIRE1. Use bus instance
+  // 1 so probes/devices reach the STEMMA bus instead of the (empty) primary
+  // Wire.
+  uint8_t instance = 0;
+#ifdef I2C_STEMMA_WIRE1
+  instance = 1;
+#endif
+  I2cHardware *new_bus = new I2cHardware(pin_sda, pin_scl, instance);
   if (!new_bus->begin()) {
     WS_DEBUG_PRINTLN("[i2c] ERROR: Failed to initialize I2C bus!");
     delete new_bus;

--- a/src/components/i2c/hardware.cpp
+++ b/src/components/i2c/hardware.cpp
@@ -14,10 +14,6 @@
  */
 #include "hardware.h"
 
-/// Standard-mode I2C clock for ESP32 buses. 100 kHz; a slower 50 kHz failed to
-/// detect some devices on the STEMMA bus during HIL testing.
-#define I2C_STD_CLOCK_HZ 100000
-
 /*!
     @brief  Default I2C bus hardware class constructor
 */

--- a/src/components/i2c/hardware.cpp
+++ b/src/components/i2c/hardware.cpp
@@ -14,6 +14,10 @@
  */
 #include "hardware.h"
 
+/// Standard-mode I2C clock for ESP32 buses. 100 kHz; a slower 50 kHz failed to
+/// detect some devices on the STEMMA bus during HIL testing.
+#define I2C_STD_CLOCK_HZ 100000
+
 /*!
     @brief  Default I2C bus hardware class constructor
 */
@@ -103,8 +107,7 @@ bool I2cHardware::begin() {
     _bus_init = false;
     return false;
   }
-  _bus->setClock(
-      100000); // 100 kHz standard mode (50 kHz failed to detect devices)
+  _bus->setClock(I2C_STD_CLOCK_HZ); // standard mode
 #elif defined(ARDUINO_ARCH_ESP8266)
   // NOTE: Wire on ESP8266 has only one instance
   _bus = new TwoWire();

--- a/src/components/i2c/hardware.cpp
+++ b/src/components/i2c/hardware.cpp
@@ -96,12 +96,15 @@ bool I2cHardware::begin() {
 // NOTE: Each platform has a slightly different bus initialization routine
 #ifdef ARDUINO_ARCH_ESP32
   _bus = new TwoWire(_instance);
-  _bus->setPins(_sda, _scl); // TODO: This is possibly not required due to ctor
+  // setPins IS required for a secondary bus (Wire1) so the peripheral binds the
+  // requested SDA/SCL before begin().
+  _bus->setPins(_sda, _scl);
   if (!_bus->begin(_sda, _scl)) {
     _bus_init = false;
     return false;
   }
-  _bus->setClock(50000);
+  _bus->setClock(
+      100000); // 100 kHz standard mode (50 kHz failed to detect devices)
 #elif defined(ARDUINO_ARCH_ESP8266)
   // NOTE: Wire on ESP8266 has only one instance
   _bus = new TwoWire();

--- a/src/components/i2c/hardware.h
+++ b/src/components/i2c/hardware.h
@@ -22,6 +22,10 @@
 #define WIRE Wire
 #endif
 
+
+/// Standard-mode I2C clock for ESP32 buses. 100 kHz; a slower 50 kHz failed to
+/// detect some devices on the STEMMA bus during HIL testing.
+#define I2C_STD_CLOCK_HZ 100000
 #define I2C_WDT_TIMEOUT_MS 50
 #define MAX_I2C_ADDRESSES 112 ///< 128 total 7-bit addresses minus 16 reserved
 

--- a/src/components/i2c/hardware.h
+++ b/src/components/i2c/hardware.h
@@ -25,7 +25,7 @@
 /// Standard-mode I2C clock for ESP32 buses. 100 kHz; a slower 50 kHz failed to
 /// detect some devices on the STEMMA bus during HIL testing.
 #define I2C_STD_CLOCK_HZ 100000
-#define I2C_WDT_TIMEOUT_MS 50
+#define I2C_WDT_TIMEOUT_MS 50 ///< I2C timeout
 #define MAX_I2C_ADDRESSES 112 ///< 128 total 7-bit addresses minus 16 reserved
 
 /*!

--- a/src/components/i2c/hardware.h
+++ b/src/components/i2c/hardware.h
@@ -22,7 +22,6 @@
 #define WIRE Wire
 #endif
 
-
 /// Standard-mode I2C clock for ESP32 buses. 100 kHz; a slower 50 kHz failed to
 /// detect some devices on the STEMMA bus during HIL testing.
 #define I2C_STD_CLOCK_HZ 100000

--- a/src/ws_boards.h
+++ b/src/ws_boards.h
@@ -128,7 +128,7 @@
 #define STATUS_NEOPIXEL_PIN PIN_NEOPIXEL
 #define STATUS_NEOPIXEL_NUM 1
 #define USE_PSRAM ///< Board has PSRAM, use it for dynamic memory allocation
-#define I2c_STEMMA_WIRE1
+#define I2C_STEMMA_WIRE1
 #define BOOT_BUTTON 0
 #elif defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_NOPSRAM)
 #define BOARD_ID "qtpy-esp32s3"
@@ -136,7 +136,7 @@
 #define USE_STATUS_NEOPIXEL
 #define STATUS_NEOPIXEL_NUM 1
 #define STATUS_NEOPIXEL_PIN PIN_NEOPIXEL
-#define I2c_STEMMA_WIRE1
+#define I2C_STEMMA_WIRE1
 #define BOOT_BUTTON 0
 #elif defined(ARDUINO_ADAFRUIT_QTPY_ESP32S3_N4R2)
 #define BOARD_ID "qtpy-esp32s3-n4r2"
@@ -145,7 +145,7 @@
 #define STATUS_NEOPIXEL_PIN PIN_NEOPIXEL
 #define STATUS_NEOPIXEL_NUM 1
 #define USE_PSRAM ///< Board has PSRAM, use it for dynamic memory allocation
-#define I2c_STEMMA_WIRE1
+#define I2C_STEMMA_WIRE1
 #define BOOT_BUTTON 0
 #elif defined(ARDUINO_ADAFRUIT_QTPY_ESP32C3)
 #define BOARD_ID "qtpy-esp32c3"
@@ -190,7 +190,7 @@
 #define STATUS_NEOPIXEL_PIN PIN_NEOPIXEL
 #define STATUS_NEOPIXEL_NUM 1
 #define USE_PSRAM ///< Board has PSRAM, use it for dynamic memory allocation
-#define I2c_STEMMA_WIRE1
+#define I2C_STEMMA_WIRE1
 #elif defined(ARDUINO_SAMD_NANO_33_IOT)
 #define BOARD_ID "nano-33-iot"
 #define USE_STATUS_LED


### PR DESCRIPTION
## Summary

On the QT Py ESP32-S3 (and S2 / Pico) the STEMMA QT / Qwiic connector is wired to the **secondary I2C peripheral (Wire1)**, and v2 component scans came back **empty on real hardware**. Three issues, all HIL-confirmed on a QT Py ESP32-S3 N4R2 with a TCA9548A + sensor string (the PR #933 driver set), driven over protomq:

1. **STEMMA bus → Wire1.** `ws_boards.h` defined `I2c_STEMMA_WIRE1` for these boards but **nothing consumed it** — `findOrCreateBus` always opened bus instance 0 (the empty breakout pads). Now it uses TwoWire **instance 1** when the macro is defined. (Also normalises the macro casing `I2c_` → `I2C_`.)

2. **I2C clock 50 kHz → 100 kHz.** The ESP32 path forced `setClock(50000)`, which failed device detection on this board; v1 runs at the 100 kHz default. `setPins` is kept (required so a *secondary* bus binds the requested SDA/SCL before `begin()`).

3. **Root cause of the empty scans — Probe/Add never decoded their callback fields.** `ws_i2c_B2D` is a nanopb **static `oneof`**, so `pb_decode` zero-inits the union member when it decodes the `probe`/`add` field — **wiping the decode callbacks** that were just set on `b2d.payload.probe`/`.add`. `Probe` then decoded **zero** `address_spaces`/`addresses` (every scan empty) and `Add` silently dropped its `settings`. Fix: decode the sub-message **directly** via a shared `decodeI2cB2DMember()` helper (hand-read the B2D field, then `pb_decode` a *standalone* message whose callbacks survive). Checkin's `component_adds` already uses the correct `cb_payload` pre-decode pattern and is unaffected.

## HIL verification (over protomq, full TCA9548A sensor string)

| bus / channel | addresses found | sensors (beyond the direct bus) |
|---|---|---|
| direct bus | `0x12 0x58 0x77` | PMSA003I, SGP30, TCA9548A |
| **ch0** | `0x52 0x59 0x61 0x74 0x76` (+direct) | APDS9999, SGP40, SCD30, AS7331, BME280 |
| **ch1** | `0x48 0x53` (+direct) | TMP119, ENS160 |
| ch2–7 | (direct only) | empty |

Before this fix every probe returned an empty `Probed` (`spaces_count=0`); after, the bare-bus and each mux channel enumerate correctly and `SelectMuxChannel` isolates each channel.

## Notes
- The underlying Probe/Add decode bug and the Wire1/clock issues also exist on the `migrate-api-v2` base; this PR targets the PR #933 branch so the backported drivers are testable, and the fix rides along when #933 merges.
- `0x59` is shared by SGP40/SGP41; the device on the bench is an SGP40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
