### PR TITLE
fix(fs): never auto-format on mount failure; gate format on a persistent NVS provisioned-marker

### DIFF
--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -1,0 +1,32 @@
+name: Native unit tests
+
+# Host-compiled, hardware-free unit tests for pure decision logic (e.g. the
+# filesystem (re)format policy). These exercise behaviour that the board build
+# matrix cannot: a compile proves the firmware links, not that the gating logic
+# is correct. Runs in seconds with no toolchain download.
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  native-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build & run native tests
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          tests=(test/native/*.cpp)
+          if [ ${#tests[@]} -eq 0 ]; then
+            echo "No native tests found under test/native/"; exit 1
+          fi
+          for t in "${tests[@]}"; do
+            echo "==== $t ===="
+            c++ -std=c++17 -Wall -Wextra -I src/provisioning/tinyusb \
+              "$t" -o /tmp/native_test
+            /tmp/native_test
+          done

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-pr931.4
+version=1.0.0-pr931.5
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino application for Adafruit.io WipperSnapper

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-beta.130
+version=1.0.0-pr931.3
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino application for Adafruit.io WipperSnapper

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WipperSnapper
-version=1.0.0-pr931.3
+version=1.0.0-pr931.4
 author=Adafruit
 maintainer=Adafruit <adafruitio@adafruit.com>
 sentence=Arduino application for Adafruit.io WipperSnapper

--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -2703,64 +2703,62 @@ void Wippersnapper::publish(const char *topic, uint8_t *payload, uint16_t bLen,
 #ifdef ARDUINO_ARCH_ESP32
 /**************************************************************/
 /*!
-    @brief    Prints string reset reason of ESP32
+    @brief    Maps an ESP32 reset-reason code to a human-readable string.
     @param    reason
-              The return code of rtc_get_reset_reason(coreNum)
+              The return code of rtc_get_reset_reason(coreNum).
+    @returns  A static, human-readable name for the reset reason (e.g.
+              "SW_CPU_RESET"), or "NO_MEAN" for an unrecognized code.
+*/
+/**************************************************************/
+// https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/ResetReason/ResetReason.ino
+const char *getResetReasonStr(int reason) {
+  switch (reason) {
+  case 1:
+    return "POWERON_RESET"; /**<1,  Vbat power on reset*/
+  case 3:
+    return "SW_RESET"; /**<3,  Software reset digital core*/
+  case 4:
+    return "OWDT_RESET"; /**<4,  Legacy watch dog reset digital core*/
+  case 5:
+    return "DEEPSLEEP_RESET"; /**<5,  Deep Sleep reset digital core*/
+  case 6:
+    return "SDIO_RESET"; /**<6,  Reset by SLC module, reset digital core*/
+  case 7:
+    return "TG0WDT_SYS_RESET"; /**<7,  Timer Group0 Watch dog reset*/
+  case 8:
+    return "TG1WDT_SYS_RESET"; /**<8,  Timer Group1 Watch dog reset*/
+  case 9:
+    return "RTCWDT_SYS_RESET"; /**<9,  RTC Watch dog Reset digital core*/
+  case 10:
+    return "INTRUSION_RESET"; /**<10, Instrusion tested to reset CPU*/
+  case 11:
+    return "TGWDT_CPU_RESET"; /**<11, Time Group reset CPU*/
+  case 12:
+    return "SW_CPU_RESET"; /**<12, Software reset CPU*/
+  case 13:
+    return "RTCWDT_CPU_RESET"; /**<13, RTC Watch dog Reset CPU*/
+  case 14:
+    return "EXT_CPU_RESET"; /**<14, for APP CPU, reset by PRO CPU*/
+  case 15:
+    return "RTCWDT_BROWN_OUT_RESET"; /**<15, Reset when vdd voltage unstable*/
+  case 16:
+    return "RTCWDT_RTC_RESET"; /**<16, RTC Watch dog reset core and rtc module*/
+  default:
+    return "NO_MEAN";
+  }
+}
+
+/**************************************************************/
+/*!
+    @brief    Prints the ESP32 reset reason and flags a brownout-caused reset.
+    @param    reason
+              The return code of rtc_get_reset_reason(coreNum).
 */
 /**************************************************************/
 void print_reset_reason(int reason) {
-  // //
-  // https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/ResetReason/ResetReason.ino
-  switch (reason) {
-  case 1:
-    WS_DEBUG_PRINTLN("POWERON_RESET");
-    break; /**<1,  Vbat power on reset*/
-  case 3:
-    WS_DEBUG_PRINTLN("SW_RESET");
-    break; /**<3,  Software reset digital core*/
-  case 4:
-    WS_DEBUG_PRINTLN("OWDT_RESET");
-    break; /**<4,  Legacy watch dog reset digital core*/
-  case 5:
-    WS_DEBUG_PRINTLN("DEEPSLEEP_RESET");
-    break; /**<5,  Deep Sleep reset digital core*/
-  case 6:
-    WS_DEBUG_PRINTLN("SDIO_RESET");
-    break; /**<6,  Reset by SLC module, reset digital core*/
-  case 7:
-    WS_DEBUG_PRINTLN("TG0WDT_SYS_RESET");
-    break; /**<7,  Timer Group0 Watch dog reset digital core*/
-  case 8:
-    WS_DEBUG_PRINTLN("TG1WDT_SYS_RESET");
-    break; /**<8,  Timer Group1 Watch dog reset digital core*/
-  case 9:
-    WS_DEBUG_PRINTLN("RTCWDT_SYS_RESET");
-    break; /**<9,  RTC Watch dog Reset digital core*/
-  case 10:
-    WS_DEBUG_PRINTLN("INTRUSION_RESET");
-    break; /**<10, Instrusion tested to reset CPU*/
-  case 11:
-    WS_DEBUG_PRINTLN("TGWDT_CPU_RESET");
-    break; /**<11, Time Group reset CPU*/
-  case 12:
-    WS_DEBUG_PRINTLN("SW_CPU_RESET");
-    break; /**<12, Software reset CPU*/
-  case 13:
-    WS_DEBUG_PRINTLN("RTCWDT_CPU_RESET");
-    break; /**<13, RTC Watch dog Reset CPU*/
-  case 14:
-    WS_DEBUG_PRINTLN("EXT_CPU_RESET");
-    break; /**<14, for APP CPU, reset by PRO CPU*/
-  case 15:
-    WS_DEBUG_PRINTLN("RTCWDT_BROWN_OUT_RESET");
+  WS_DEBUG_PRINTLNVAR(getResetReasonStr(reason));
+  if (reason == 15) // RTCWDT_BROWN_OUT_RESET
     WS.brownOutCausedReset = true;
-    break; /**<15, Reset when the vdd voltage is not stable*/
-  case 16:
-    WS_DEBUG_PRINTLN("RTCWDT_RTC_RESET");
-    break; /**<16, RTC Watch dog reset digital core and rtc module*/
-  default:
-    WS_DEBUG_PRINTLN("NO_MEAN");
-  }
 }
 
 #if CONFIG_IDF_TARGET_ESP32 // ESP32/PICO-D4
@@ -2790,6 +2788,20 @@ void print_reset_reason(int reason) {
 /**************************************************************************/
 void get_and_print_reset_reason_for_cpu(int cpuCore) {
   print_reset_reason(rtc_get_reset_reason(cpuCore));
+}
+
+/**************************************************************************/
+/*!
+    @brief    Returns the raw reset-reason code for the given CPU core, with no
+              side effects (does not touch brownOutCausedReset or print). Used
+              by the filesystem layer to report/persist the actual boot reason.
+    @param    cpuCore
+              The core number to read the reset reason for.
+    @returns  The rtc_get_reset_reason(cpuCore) code.
+*/
+/**************************************************************************/
+int getResetReasonCode(int cpuCore) {
+  return (int)rtc_get_reset_reason(cpuCore);
 }
 
 // end of ARDUINO_ARCH_ESP32

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -167,7 +167,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-beta.130" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-pr931.3" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -167,7 +167,16 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-pr931.4" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-pr931.5" ///< WipperSnapper app. version (semver-formatted)
+
+#ifdef ARDUINO_ARCH_ESP32
+// Reset-reason helpers (defined in Wippersnapper.cpp). Exposed so the
+// filesystem layer can surface the actual boot/reset reason in its protective
+// halt and persist it to NVS for diagnosis, instead of only inferring "likely a
+// brownout".
+const char *getResetReasonStr(int reason); ///< Reset-reason code -> string
+int getResetReasonCode(int cpuCore = 0);   ///< rtc_get_reset_reason(cpuCore)
+#endif
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -167,7 +167,7 @@
 #endif
 
 #define WS_VERSION                                                             \
-  "1.0.0-pr931.3" ///< WipperSnapper app. version (semver-formatted)
+  "1.0.0-pr931.4" ///< WipperSnapper app. version (semver-formatted)
 
 // Reserved Adafruit IO MQTT topics
 #define TOPIC_IO_THROTTLE "/throttle" ///< Adafruit IO Throttle MQTT Topic

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -95,6 +95,13 @@ bool setVolumeLabel() {
 // fact reliably outlives both a brownout and a FAT format.
 static const char *kWSFsNvsNamespace = "ws_fs";
 static const char *kWSFsProvisionedKey = "fs_ok";
+// Boot-reason diagnostics, persisted in the same NVS namespace (survives a
+// brownout and a FAT format). last_rst is updated every boot; fmt_rst/fmt_cnt
+// capture the reset reason in effect when a (re)format actually ran, so a
+// format that wiped data can be correlated with the reset that preceded it.
+static const char *kWSFsLastResetKey = "last_rst"; ///< reset code this boot
+static const char *kWSFsFormatResetKey = "fmt_rst"; ///< reset code at last format
+static const char *kWSFsFormatCountKey = "fmt_cnt"; ///< number of (re)formats
 #endif
 
 /**************************************************************************/
@@ -138,6 +145,79 @@ static void markFilesystemProvisioned() {
   if (!prefs.getBool(kWSFsProvisionedKey, false))
     prefs.putBool(kWSFsProvisionedKey, true);
   prefs.end();
+#endif
+}
+
+/**************************************************************************/
+/*!
+    @brief    Records the reset reason seen on this boot into NVS (last_rst),
+              so the actual boot reason is available for diagnosis even when the
+              board halts before the usual printDeviceInfo() reset-reason dump.
+              No-op on platforms without NVS / reset-reason support.
+*/
+/**************************************************************************/
+static void recordBootResetReason() {
+#ifdef ARDUINO_ARCH_ESP32
+  Preferences prefs;
+  if (!prefs.begin(kWSFsNvsNamespace, /*readOnly=*/false))
+    return;
+  prefs.putUChar(kWSFsLastResetKey, (uint8_t)getResetReasonCode(0));
+  prefs.end();
+#endif
+}
+
+/**************************************************************************/
+/*!
+    @brief    Records, into NVS, that a (re)format happened this boot and the
+              reset reason in effect when it ran (fmt_rst), plus a running count
+              (fmt_cnt). This is the "write the boot reason only after a format"
+              diagnostic: a format that erased data can later be correlated with
+              the reset that preceded it. No-op without NVS.
+*/
+/**************************************************************************/
+static void recordFormatEvent() {
+#ifdef ARDUINO_ARCH_ESP32
+  Preferences prefs;
+  if (!prefs.begin(kWSFsNvsNamespace, /*readOnly=*/false))
+    return;
+  prefs.putUChar(kWSFsFormatResetKey, (uint8_t)getResetReasonCode(0));
+  prefs.putUInt(kWSFsFormatCountKey, prefs.getUInt(kWSFsFormatCountKey, 0) + 1);
+  prefs.end();
+#endif
+}
+
+/**************************************************************************/
+/*!
+    @brief    Prints the persisted boot/format diagnostics (this boot's reset
+              reason, and - if any format has ever run - the count and the reset
+              reason at the last format) to the serial console. No-op without
+              NVS.
+*/
+/**************************************************************************/
+static void printFsDiagnostics() {
+#ifdef ARDUINO_ARCH_ESP32
+  Preferences prefs;
+  if (!prefs.begin(kWSFsNvsNamespace, /*readOnly=*/true))
+    return;
+  uint8_t lastRst = prefs.getUChar(kWSFsLastResetKey, 0);
+  uint8_t fmtRst = prefs.getUChar(kWSFsFormatResetKey, 0);
+  uint32_t fmtCnt = prefs.getUInt(kWSFsFormatCountKey, 0);
+  prefs.end();
+
+  WS_DEBUG_PRINT("[fs] boot reset reason: ");
+  WS_DEBUG_PRINTVAR((int)lastRst);
+  WS_DEBUG_PRINT(" (");
+  WS_DEBUG_PRINTVAR(getResetReasonStr(lastRst));
+  WS_DEBUG_PRINTLN(")");
+  if (fmtCnt > 0) {
+    WS_DEBUG_PRINT("[fs] filesystem (re)formats so far: ");
+    WS_DEBUG_PRINTLNVAR(fmtCnt);
+    WS_DEBUG_PRINT("[fs] reset reason at last format: ");
+    WS_DEBUG_PRINTVAR((int)fmtRst);
+    WS_DEBUG_PRINT(" (");
+    WS_DEBUG_PRINTVAR(getResetReasonStr(fmtRst));
+    WS_DEBUG_PRINTLN(")");
+  }
 #endif
 }
 
@@ -227,6 +307,11 @@ Wippersnapper_FS::Wippersnapper_FS() {
   // Wait for detach
   delay(500);
 
+  // Persist this boot's reset reason early, before any mount/format decision,
+  // so the actual boot reason is recoverable for diagnosis even if we halt here
+  // (the usual printDeviceInfo() reset-reason dump runs later, in connect()).
+  recordBootResetReason();
+
   // Attempt to mount the existing filesystem WITHOUT formatting. initFilesystem
   // (with force_format=false) no longer creates a filesystem on a mount
   // failure - it returns false and lets the gates below decide - so a
@@ -287,12 +372,19 @@ Wippersnapper_FS::Wippersnapper_FS() {
                    "Recharge/repower the board and reset.");
           }
         }
+        // Persist that a (re)format ran this boot and the reset reason behind
+        // it, so a format that wiped data can be correlated with its cause.
+        recordFormatEvent();
         break;
       case WsFsAction::Mounted:
         break; // unreachable: mount already failed above
       }
     }
   }
+
+  // Report the persisted boot/format diagnostics (this boot's reset reason,
+  // and any prior format + the reset reason that preceded it).
+  printFsDiagnostics();
 
   // Initialize USB-MSD
   initUSBMSC();
@@ -743,9 +835,23 @@ void Wippersnapper_FS::writeToBootOut(PGM_P str) {
 /**************************************************************************/
 void Wippersnapper_FS::fsHalt(String msg) {
   statusLEDSolid(WS_LED_STATUS_FS_WRITE);
+#ifdef ARDUINO_ARCH_ESP32
+  // Capture the actual reset reason once, so the halt reports the observed boot
+  // reason (e.g. "12 (SW_CPU_RESET)") rather than only inferring "likely a
+  // brownout" - a brownout is frequently not reported as a brownout reset.
+  int rstCode = getResetReasonCode(0);
+  const char *rstStr = getResetReasonStr(rstCode);
+#endif
   while (1) {
     WS_DEBUG_PRINTLN("Fatal Error: Halted execution!");
     WS_DEBUG_PRINTLN(msg.c_str());
+#ifdef ARDUINO_ARCH_ESP32
+    WS_DEBUG_PRINT("Boot/reset reason: ");
+    WS_DEBUG_PRINTVAR(rstCode);
+    WS_DEBUG_PRINT(" (");
+    WS_DEBUG_PRINTVAR(rstStr);
+    WS_DEBUG_PRINTLN(")");
+#endif
     delay(1000);
     yield();
   }

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -485,7 +485,32 @@ bool Wippersnapper_FS::initFilesystem(bool force_format) {
 
   // Check if secrets.json file already exists
   if (!configFileExists()) {
-    // Create new secrets.json file and halt
+    // configFileExists() returns false when secrets.json is absent OR when its
+    // first byte reads back 0x00/0xFF. That blank first byte is the same
+    // failed-flash-read a brownout produces (the SPI rail sags during
+    // power-loss recovery), so on a previously-provisioned board this is almost
+    // never a genuinely missing file - it is an intact secrets.json misread as
+    // empty. Recreating the template here would orphan the user's real
+    // credentials - observed on hardware: a drained MagTag mounted cleanly,
+    // peeked its intact secrets.json back blank, and this path replaced it with
+    // a placeholder, leaving the real file orphaned on flash.
+    //
+    // Gate the destructive recreate on the SAME persistent NVS provisioned
+    // marker parseSecrets() uses - NOT on WS.brownOutCausedReset, which
+    // routinely reports POWERON_RESET (not brownout) on a power-loss-recovery
+    // boot. A provisioned board that suddenly cannot read secrets.json must
+    // halt-and-protect; only a never-provisioned board may bootstrap one.
+    if (wasFilesystemProvisioned()) {
+      writeToBootOut("ERROR: secrets.json unreadable on a provisioned board - "
+                     "refusing to recreate (likely a brownout/power-loss "
+                     "misread). Recharge and reset.\n");
+      fsHalt("ERROR: secrets.json unreadable on a previously-provisioned board "
+             "- refusing to recreate it and erase your credentials. This is "
+             "almost always a brownout/power-loss misread of an intact file. "
+             "Recharge and reset; edit secrets.json by hand only if it "
+             "persists.");
+    }
+    // Never-provisioned board: genuinely bootstrapping a template is correct.
     createSecretsFile();
   }
 

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -45,12 +45,6 @@ Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
 // ESP32-S2 uses same flash device that stores code.
 // Therefore there is no need to specify the SPI and SS
 Adafruit_FlashTransport_ESP32 flashTransport;
-// The FAT user partition lives on the same on-chip flash as the ESP32
-// bootloader, partition table and NVS - so we can validate those known-good
-// structures to tell a blank/corrupt filesystem apart from unstable
-// (brownout) flash reads. See flashSafeToFormat().
-#define WS_USE_ESP32_INTERNAL_FLASH 1
-#include <esp_flash.h>
 #elif defined(ARDUINO_ARCH_RP2040)
 // RP2040 use same flash device that store code.
 // Therefore there is no need to specify the SPI and SS
@@ -93,71 +87,114 @@ bool setVolumeLabel() {
   return true;
 }
 
+#ifdef ARDUINO_ARCH_ESP32
+// NVS namespace + key for the "this board has had a working filesystem"
+// marker. NVS lives in its own flash partition (untouched by f_mkfs) and is
+// engineered to survive power loss, so it is the one place a "was provisioned"
+// fact reliably outlives both a brownout and a FAT format.
+static const char *kWSFsNvsNamespace = "ws_fs";
+static const char *kWSFsProvisionedKey = "fs_ok";
+#endif
+
+/**************************************************************************/
+/*!
+    @brief    Returns whether this board has ever had a working filesystem
+              mounted (i.e. it was previously provisioned). On the ESP32 this
+              is persisted in NVS, which survives both a brownout and a FAT
+              format; other platforms have no equivalent off-filesystem store,
+              so this always returns false there and the blank-volume check in
+              isFlashSafeToFormat() is relied on instead.
+    @returns  True if a working filesystem has previously been seen on this
+              board, False otherwise (or if the marker can't be read).
+*/
+/**************************************************************************/
+static bool wasFilesystemProvisioned() {
+#ifdef ARDUINO_ARCH_ESP32
+  Preferences prefs;
+  if (!prefs.begin(kWSFsNvsNamespace, /*readOnly=*/true))
+    return false; // namespace doesn't exist yet -> never provisioned
+  bool provisioned = prefs.getBool(kWSFsProvisionedKey, false);
+  prefs.end();
+  return provisioned;
+#else
+  return false;
+#endif
+}
+
+/**************************************************************************/
+/*!
+    @brief    Records (once) that this board has a working filesystem, so a
+              later mount failure caused by a brownout is never mistaken for a
+              blank factory chip and silently reformatted. No-op on platforms
+              without NVS.
+*/
+/**************************************************************************/
+static void markFilesystemProvisioned() {
+#ifdef ARDUINO_ARCH_ESP32
+  Preferences prefs;
+  if (!prefs.begin(kWSFsNvsNamespace, /*readOnly=*/false))
+    return;
+  if (!prefs.getBool(kWSFsProvisionedKey, false))
+    prefs.putBool(kWSFsProvisionedKey, true);
+  prefs.end();
+#endif
+}
+
 /**************************************************************************/
 /*!
     @brief    Decides whether it is safe to (re)create the filesystem after a
               mount failure, i.e. whether the failure looks like a genuinely
-              blank/corrupt FAT user partition (safe to format) rather than a
-              flash chip whose reads are momentarily unstable due to a voltage
-              sag / brownout (must NOT be formatted - that would erase the
-              user's data on recovery). A brownout is frequently NOT reported
-              as a brownout reset reason, so we cannot rely on the reset
-              reason alone before doing something destructive.
+              blank FAT user partition (safe to format) rather than a flash
+              chip whose reads are momentarily unstable due to a voltage sag /
+              brownout, or a volume holding data that simply won't mount (must
+              NOT be formatted - that would erase the user's data on recovery).
+              A brownout is frequently NOT reported as a brownout reset reason,
+              so we cannot rely on the reset reason alone before doing
+              something destructive.
 
-              On the ESP32 the FAT partition shares the on-chip flash with the
-              bootloader, partition table (0x8000) and NVS (0x9000), so those
-              known-good structures are validated directly. Every other
-              FAT-path board (external QSPI/SPI flash on SAMD51, or the on-chip
-              flash on RP2040/RP2350) has no such off-filesystem structure, so
-              the FAT volume's own boot sector is inspected instead - it may
-              only be formatted if it reads back genuinely erased (all 0xFF).
+              This is the secondary gate, only consulted on a genuine first
+              boot (no NVS "provisioned" marker - see wasFilesystemProvisioned).
+              It (a) confirms the flash chip is actually responding, (b) on the
+              ESP32 confirms a known-good off-filesystem structure (NVS, located
+              via the partition API rather than a hardcoded offset) reads back
+              sanely, and (c) on every platform requires the FAT volume's own
+              boot sector to read back genuinely erased (all 0xFF) before
+              allowing a format.
     @returns  True if a (re)format is safe, False if the flash is unreadable /
               unstable / not genuinely blank, in which case it must NOT be
               formatted.
 */
 /**************************************************************************/
-bool flashSafeToFormat() {
-#ifdef WS_USE_ESP32_INTERNAL_FLASH
-  uint8_t buf[2];
-
-  // Partition table @ 0x8000 - the first entry must begin with the ESP-IDF
-  // partition magic 0x50AA (stored little-endian: 0xAA, 0x50).
-  if (esp_flash_read(esp_flash_default_chip, buf, 0x8000, sizeof(buf)) !=
-      ESP_OK)
-    return false;
-  if (buf[0] != 0xAA || buf[1] != 0x50)
-    return false;
-
-  // NVS partition @ 0x9000 - the first page header state must be a valid NVS
-  // page state: UNINITIALIZED 0xFFFFFFFF / ACTIVE 0xFFFFFFFE / FULL
-  // 0xFFFFFFFC / FREEING 0xFFFFFFF8. The high byte is always 0xFF; the low
-  // byte distinguishes the state. Random garbage from a browning-out SPI bus
-  // is very unlikely to match this.
-  if (esp_flash_read(esp_flash_default_chip, buf, 0x9000, sizeof(buf)) !=
-      ESP_OK)
-    return false;
-  if (buf[1] != 0xFF ||
-      (buf[0] != 0xFF && buf[0] != 0xFE && buf[0] != 0xFC && buf[0] != 0xF8))
-    return false;
-
-  return true;
-#else
-  // External/QSPI flash (SAMD51: PyPortal, Metro M4 AirLift, Titano) or the
-  // RP2040/RP2350 on-chip flash: there is no off-filesystem structure to
-  // validate, so inspect the FAT volume's own boot sector. SPIFlash reads are
-  // relative to the filesystem on every transport, so offset 0 is the boot
-  // sector.
-
-  // First confirm a real flash chip is responding - a dead/disconnected SPI
-  // bus often floats high and reads back as all 0xFF, which would otherwise be
-  // mistaken for a genuinely-erased (blank) chip.
+bool isFlashSafeToFormat() {
+  // (a) Confirm a real flash chip is responding - a dead/disconnected or
+  // browning-out SPI bus often floats high and reads back as all 0xFF, which
+  // would otherwise be mistaken for a genuinely-erased (blank) chip.
   uint32_t jedecID = flash.getJEDECID();
   if (jedecID == 0 || jedecID == 0xFFFFFF)
     return false;
 
-  // A (re)format is only appropriate when the boot sector is genuinely erased
-  // (all 0xFF). Any other unmountable content is treated as possible
-  // voltage/brownout corruption and must NOT be erased.
+#ifdef ARDUINO_ARCH_ESP32
+  // (b) Locate the NVS partition via the partition API (no hardcoded offset)
+  // and confirm its first page header is a valid NVS page state: UNINITIALIZED
+  // 0xFFFFFFFF / ACTIVE 0xFFFFFFFE / FULL 0xFFFFFFFC / FREEING 0xFFFFFFF8. The
+  // high byte is always 0xFF; the low byte distinguishes the state. Garbage
+  // from a browning-out SPI bus is very unlikely to match this.
+  const esp_partition_t *nvs = esp_partition_find_first(
+      ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_NVS, NULL);
+  if (nvs == NULL)
+    return false; // can't locate NVS -> don't trust the flash -> don't format
+  uint8_t hdr[2];
+  if (esp_partition_read(nvs, 0, hdr, sizeof(hdr)) != ESP_OK)
+    return false;
+  if (hdr[1] != 0xFF ||
+      (hdr[0] != 0xFF && hdr[0] != 0xFE && hdr[0] != 0xFC && hdr[0] != 0xF8))
+    return false;
+#endif
+
+  // (c) A (re)format is only appropriate when the FAT volume's boot sector is
+  // genuinely erased (all 0xFF). Any other unmountable content is treated as
+  // possible voltage/brownout corruption and must NOT be erased. SPIFlash
+  // reads are relative to the FAT partition, so offset 0 is the boot sector.
   uint8_t sector[256];
   for (uint32_t addr = 0; addr < 512; addr += sizeof(sector)) {
     if (flash.readBuffer(addr, sector, sizeof(sector)) != sizeof(sector))
@@ -167,8 +204,7 @@ bool flashSafeToFormat() {
         return false; // non-erased content -> not blank -> refuse to format
     }
   }
-  return true; // boot sector is fully erased -> genuinely blank -> safe
-#endif
+  return true; // chip healthy + boot sector fully erased -> safe to format
 }
 
 /**************************************************************************/
@@ -190,30 +226,58 @@ Wippersnapper_FS::Wippersnapper_FS() {
   // Wait for detach
   delay(500);
 
-  // Attempt to mount the existing filesystem WITHOUT formatting.
+  // Attempt to mount the existing filesystem WITHOUT formatting. initFilesystem
+  // (with force_format=false) no longer creates a filesystem on a mount
+  // failure - it returns false and lets the gates below decide - so a
+  // brownout-corrupted FAT is never silently wiped.
   if (!initFilesystem()) {
-    // Mount failed. A battery sag / brownout can momentarily corrupt SPI
-    // flash reads - often WITHOUT being reported as a brownout reset - so
-    // give the power rail a moment to settle and retry before doing anything
+    // Mount failed. A battery sag / brownout can momentarily corrupt SPI flash
+    // reads - often WITHOUT being reported as a brownout reset - so give the
+    // power rail a moment to settle and retry before doing anything
     // destructive.
     delay(50); // let power stabilise after failure
     if (!initFilesystem()) {
-      // Still failing. Only (re)format if flashSafeToFormat() proves the flash
-      // chip itself is healthy. This is independent of the reset reason (which
-      // frequently does NOT report a brownout): if the reads are unstable, a
-      // format would needlessly erase the user's data on recovery.
-      if (!flashSafeToFormat()) {
+      // Still unmountable. Decide - very carefully - whether to (re)format.
+
+      // PRIMARY GATE: has this board ever had a working filesystem? If so, an
+      // unmountable FAT now is brownout/corruption, NEVER a blank factory chip.
+      // Formatting would erase the user's secrets.json, so we must not do it -
+      // regardless of what the flash-health probe says. Once the battery has
+      // recovered enough to boot, the flash reads fine again, so a health probe
+      // alone cannot tell "blank from the factory" apart from "corrupted by a
+      // brownout"; this persistent marker can.
+      if (wasFilesystemProvisioned()) {
+        // Keep USB and the status LED off to conserve a dying battery, halt.
+        fsHalt("Filesystem unreadable but this board was previously "
+               "provisioned - likely a brownout. Recharge and reset; refusing "
+               "to reformat to protect your secrets.json.");
+      }
+
+      // SECONDARY GATE: genuine first boot (no marker). Only create a new FS if
+      // the flash chip is healthy AND the volume reads back genuinely blank, so
+      // a board corrupted before it was ever marked is still protected.
+      if (!isFlashSafeToFormat()) {
         // Likely a voltage/brownout event. Keep USB and the status LED off to
         // conserve a dying battery, and halt.
         fsHalt("Flash reads unstable (possible brownout) - refusing to "
                "format. Recharge/repower the board and reset.");
       }
-      // Flash is healthy: the FAT partition is genuinely blank or corrupt, so
-      // it is safe to create a new filesystem. [DESTRUCTIVE]
+
+      // Flash is healthy and genuinely blank: safe to create a new filesystem.
+      // [DESTRUCTIVE]
       if (!initFilesystem(true)) {
         TinyUSBDevice.attach();
         setStatusLEDColor(RED);
         fsHalt("ERROR Initializing Filesystem");
+      }
+
+      // Re-validate the flash chip responds after the (destructive) format - a
+      // format that "succeeded" against a flaky chip would otherwise go
+      // unnoticed.
+      uint32_t postFormatJedecID = flash.getJEDECID();
+      if (postFormatJedecID == 0 || postFormatJedecID == 0xFFFFFF) {
+        fsHalt("Flash unreadable immediately after format - aborting. "
+               "Recharge/repower the board and reset.");
       }
     }
   }
@@ -251,9 +315,19 @@ bool Wippersnapper_FS::initFilesystem(bool force_format) {
   if (!flash.begin())
     return false;
 
-  // Check if FS exists
-  if (force_format || !wipperFatFs.begin(&flash)) {
-    // No filesystem exists - create a new FS
+  // Try to mount the existing filesystem.
+  bool mounted = wipperFatFs.begin(&flash);
+
+  if (!mounted && !force_format) {
+    // Mount failed and the caller did NOT request a format. Do NOT create a
+    // filesystem here - that would erase a brownout-corrupted FAT and the
+    // user's secrets.json with it. Report the failure and let the caller (the
+    // constructor's guarded format path) decide whether a format is safe.
+    return false;
+  }
+
+  if (force_format || !mounted) {
+    // Create a new filesystem.
     // NOTE: THIS WILL ERASE ALL DATA ON THE FLASH
     if (!makeFilesystem())
       return false;
@@ -308,6 +382,16 @@ bool Wippersnapper_FS::initFilesystem(bool force_format) {
   if (!configFileExists()) {
     // Create new secrets.json file and halt
     createSecretsFile();
+  }
+
+  // We have a working, mountable filesystem that we did NOT just create this
+  // boot. Persist that fact so a future mount failure (e.g. a brownout
+  // corrupting the FAT) is recognised as corruption and never silently
+  // reformatted. On a fresh format this point is not reached: createSecretsFile
+  // above halts the board until the user edits secrets.json and resets, after
+  // which the next boot mounts the now-real FS and records the marker here.
+  if (!_freshFS) {
+    markFilesystemProvisioned();
   }
 
   return true;

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -251,14 +251,21 @@ Wippersnapper_FS::Wippersnapper_FS() {
 
       switch (decideFsAction(/*mounted=*/false, provisioned, safeToFormat)) {
       case WsFsAction::HaltProvisionedBrownout:
-        // Keep USB and the status LED off to conserve a dying battery, halt.
+        // Re-attach USB so the halt reason is visible over serial (CDC) and the
+        // board is not a silent black box. We deliberately do NOT bring up USB
+        // mass storage here: the FAT did not mount, so exposing it to the host
+        // could trigger a "repair/initialize" prompt that wipes the very
+        // secrets.json we are protecting. fsHalt() leaves the status LED solid
+        // as the on-device indicator.
+        TinyUSBDevice.attach();
         fsHalt("Filesystem unreadable but this board was previously "
                "provisioned - likely a brownout. Recharge and reset; refusing "
                "to reformat to protect your secrets.json.");
         break;
       case WsFsAction::HaltUnsafeToFormat:
-        // Likely a voltage/brownout event on a never-provisioned board. Keep
-        // USB and the status LED off to conserve a dying battery, and halt.
+        // Never-provisioned board whose flash looks unstable / not-blank.
+        // Surface the reason over serial (CDC) and halt without formatting.
+        TinyUSBDevice.attach();
         fsHalt("Flash reads unstable (possible brownout) - refusing to "
                "format. Recharge/repower the board and reset.");
         break;

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -31,6 +31,7 @@
     defined(ARDUINO_XIAO_ESP32S3) || defined(ARDUINO_ADAFRUIT_FRUITJAM_RP2350)
 
 #include "Wippersnapper_FS.h"
+#include "Wippersnapper_FS_format_policy.h"
 #include "print_dependencies.h"
 // On-board external flash (QSPI or SPI) macros should already
 // defined in your board variant if supported
@@ -238,46 +239,50 @@ Wippersnapper_FS::Wippersnapper_FS() {
     delay(50); // let power stabilise after failure
     if (!initFilesystem()) {
       // Still unmountable. Decide - very carefully - whether to (re)format.
+      // The gating order lives in decideFsAction() (pure + unit-tested):
+      //   - previously provisioned  -> NEVER format (corruption/brownout)
+      //   - genuine first boot      -> format only if the flash is healthy and
+      //                                the volume is genuinely blank.
+      bool provisioned = wasFilesystemProvisioned();
+      // Only probe the flash when a format is actually on the table - on a
+      // provisioned board we already know we must not format, so we skip the
+      // reads to conserve a possibly-dying battery.
+      bool safeToFormat = provisioned ? false : isFlashSafeToFormat();
 
-      // PRIMARY GATE: has this board ever had a working filesystem? If so, an
-      // unmountable FAT now is brownout/corruption, NEVER a blank factory chip.
-      // Formatting would erase the user's secrets.json, so we must not do it -
-      // regardless of what the flash-health probe says. Once the battery has
-      // recovered enough to boot, the flash reads fine again, so a health probe
-      // alone cannot tell "blank from the factory" apart from "corrupted by a
-      // brownout"; this persistent marker can.
-      if (wasFilesystemProvisioned()) {
+      switch (decideFsAction(/*mounted=*/false, provisioned, safeToFormat)) {
+      case WsFsAction::HaltProvisionedBrownout:
         // Keep USB and the status LED off to conserve a dying battery, halt.
         fsHalt("Filesystem unreadable but this board was previously "
                "provisioned - likely a brownout. Recharge and reset; refusing "
                "to reformat to protect your secrets.json.");
-      }
-
-      // SECONDARY GATE: genuine first boot (no marker). Only create a new FS if
-      // the flash chip is healthy AND the volume reads back genuinely blank, so
-      // a board corrupted before it was ever marked is still protected.
-      if (!isFlashSafeToFormat()) {
-        // Likely a voltage/brownout event. Keep USB and the status LED off to
-        // conserve a dying battery, and halt.
+        break;
+      case WsFsAction::HaltUnsafeToFormat:
+        // Likely a voltage/brownout event on a never-provisioned board. Keep
+        // USB and the status LED off to conserve a dying battery, and halt.
         fsHalt("Flash reads unstable (possible brownout) - refusing to "
                "format. Recharge/repower the board and reset.");
-      }
-
-      // Flash is healthy and genuinely blank: safe to create a new filesystem.
-      // [DESTRUCTIVE]
-      if (!initFilesystem(true)) {
-        TinyUSBDevice.attach();
-        setStatusLEDColor(RED);
-        fsHalt("ERROR Initializing Filesystem");
-      }
-
-      // Re-validate the flash chip responds after the (destructive) format - a
-      // format that "succeeded" against a flaky chip would otherwise go
-      // unnoticed.
-      uint32_t postFormatJedecID = flash.getJEDECID();
-      if (postFormatJedecID == 0 || postFormatJedecID == 0xFFFFFF) {
-        fsHalt("Flash unreadable immediately after format - aborting. "
-               "Recharge/repower the board and reset.");
+        break;
+      case WsFsAction::Format:
+        // Flash is healthy and genuinely blank: safe to create a new
+        // filesystem. [DESTRUCTIVE]
+        if (!initFilesystem(true)) {
+          TinyUSBDevice.attach();
+          setStatusLEDColor(RED);
+          fsHalt("ERROR Initializing Filesystem");
+        }
+        // Re-validate the flash chip responds after the (destructive) format -
+        // a format that "succeeded" against a flaky chip would otherwise go
+        // unnoticed.
+        {
+          uint32_t postFormatJedecID = flash.getJEDECID();
+          if (postFormatJedecID == 0 || postFormatJedecID == 0xFFFFFF) {
+            fsHalt("Flash unreadable immediately after format - aborting. "
+                   "Recharge/repower the board and reset.");
+          }
+        }
+        break;
+      case WsFsAction::Mounted:
+        break; // unreachable: mount already failed above
       }
     }
   }

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -344,8 +344,9 @@ Wippersnapper_FS::Wippersnapper_FS() {
         // as the on-device indicator.
         TinyUSBDevice.attach();
         fsHalt("Filesystem unreadable but this board was previously "
-               "provisioned - likely a brownout. Recharge and reset; refusing "
-               "to reformat to protect your secrets.json.");
+               "provisioned - likely a brownout or power-loss recovery. "
+               "Recharge and reset; refusing to reformat to protect your "
+               "secrets.json.");
         break;
       case WsFsAction::HaltUnsafeToFormat:
         // Never-provisioned board whose flash looks unstable / not-blank.

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -710,10 +710,37 @@ void Wippersnapper_FS::parseSecrets() {
   JsonDocument doc;
   DeserializationError error = deserializeJson(doc, secretsFile);
   if (error == DeserializationError::EmptyInput) {
-    if (WS.brownOutCausedReset) {
+    // An empty/blank read of secrets.json on a previously-provisioned board is
+    // almost never a genuinely empty file - it is the same failed-flash-read a
+    // brownout produces (the SPI rail sags during power-loss recovery and bytes
+    // come back as 0x00/0xFF, so a perfectly intact file deserializes as
+    // EmptyInput). Recreating it from the template here REMOVES the user's real
+    // credentials - observed on hardware: a drained MagTag came up, read its
+    // intact secrets.json back empty, and this path replaced it with a
+    // placeholder, leaving the real file orphaned on flash.
+    //
+    // Gate the destructive recreate on the SAME persistent NVS provisioned
+    // marker #937 uses for the format decision - NOT on WS.brownOutCausedReset.
+    // The reset reason is unreliable as a safety gate: a brownout-corrupted
+    // read routinely surfaces on a boot that reports POWERON_RESET, not
+    // brownout (15), so the brownout flag is false exactly when we most need to
+    // protect. A provisioned board that suddenly reads empty must
+    // halt-and-protect, never recreate; only a board that has never had a
+    // working FS may bootstrap one.
+    if (wasFilesystemProvisioned()) {
+      writeToBootOut("ERROR: secrets.json read back empty on a provisioned "
+                     "board - refusing to recreate (likely a "
+                     "brownout/power-loss misread). Recharge and reset.\n");
+      fsHalt("ERROR: secrets.json read back empty on a previously-provisioned "
+             "board - refusing to recreate it and erase your credentials. This "
+             "is almost always a brownout/power-loss misread of an intact "
+             "file. Recharge and reset; edit secrets.json by hand only if it "
+             "persists.");
+    } else if (WS.brownOutCausedReset) {
       fsHalt("ERROR: Empty secrets.json file, can't recreate due to brownout - "
              "recharge or must be fixed manually.");
     } else {
+      // Never-provisioned board: genuinely bootstrapping a template is correct.
       // TODO: Can't serial print here, in next PR check we're not out of space
       WS_DEBUG_PRINTLN("ERROR: Empty secrets.json file, recreating...");
       secretsFile.close();

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -22,6 +22,17 @@
 #include "fatfs/ff.h" // NOTE: This should be #included before fatfs/diskio.h!!!
 #include "fatfs/diskio.h"
 
+#ifdef ARDUINO_ARCH_ESP32
+// On the ESP32 the FAT user partition shares the on-chip flash with the
+// bootloader, partition table and NVS. We use the partition API to validate a
+// known-good, never-FAT-touched structure (NVS) when deciding whether the flash
+// is safe to (re)format, and NVS itself to persist a "this board was previously
+// provisioned" marker that survives both a brownout and a FAT format. See
+// isFlashSafeToFormat() and wasFilesystemProvisioned() in Wippersnapper_FS.cpp.
+#include <Preferences.h>
+#include <esp_partition.h>
+#endif
+
 #include "Wippersnapper.h"
 
 // forward decl.

--- a/src/provisioning/tinyusb/Wippersnapper_FS_format_policy.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS_format_policy.h
@@ -1,0 +1,69 @@
+/*!
+ * @file Wippersnapper_FS_format_policy.h
+ *
+ * Pure (hardware-free) decision policy for whether the filesystem may be
+ * (re)formatted after a mount attempt. Kept in its own header, free of any
+ * Arduino/flash/NVS includes, so the gating logic can be unit-tested on a host
+ * compiler (see test/native/test_fs_format_policy.cpp).
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * BSD license, all text here must be included in any redistribution.
+ *
+ */
+#ifndef WIPPERSNAPPER_FS_FORMAT_POLICY_H
+#define WIPPERSNAPPER_FS_FORMAT_POLICY_H
+
+/*!
+    @brief  What the filesystem constructor should do after attempting to mount
+            the existing filesystem.
+*/
+enum class WsFsAction {
+  Mounted, ///< Filesystem mounted - nothing to (re)create.
+  Format,  ///< Genuine first boot on healthy, blank flash - safe to create FS.
+           ///< [DESTRUCTIVE]
+  HaltProvisionedBrownout, ///< Board was previously provisioned but the FAT
+                           ///< won't mount: corruption (likely brownout). Must
+                           ///< NOT format - that would erase secrets.json.
+  HaltUnsafeToFormat,      ///< Never provisioned, but the flash is unhealthy or
+                           ///< the volume is not genuinely blank. Refuse to
+                           ///< format until power is stable.
+};
+
+/**************************************************************************/
+/*!
+    @brief    Pure decision for what to do after a filesystem mount attempt.
+              Contains no hardware access so it can be unit-tested on a host.
+
+              The ordering is the whole point of the fix: a board that has ever
+              had a working filesystem (wasProvisioned) must NEVER be
+              reformatted on a mount failure, regardless of how healthy the
+              flash currently looks - once a brownout-drained battery recovers
+              enough to boot, the flash reads fine again, so flashSafeToFormat
+              alone cannot tell "blank from the factory" apart from "corrupted
+              by a brownout".
+    @param    mounted
+                True if the FAT volume mounted successfully.
+    @param    wasProvisioned
+                True if a working filesystem has previously been seen on this
+                board (persisted in NVS across brownouts and FAT formats).
+    @param    flashSafeToFormat
+                True if the flash chip is responding AND the volume reads back
+                genuinely blank/erased (only meaningful when !wasProvisioned).
+    @returns  The action the constructor should take.
+*/
+/**************************************************************************/
+inline WsFsAction decideFsAction(bool mounted, bool wasProvisioned,
+                                 bool flashSafeToFormat) {
+  if (mounted)
+    return WsFsAction::Mounted;
+  if (wasProvisioned)
+    return WsFsAction::HaltProvisionedBrownout; // protect secrets.json
+  if (!flashSafeToFormat)
+    return WsFsAction::HaltUnsafeToFormat;
+  return WsFsAction::Format; // genuine first boot on healthy, blank flash
+}
+
+#endif // WIPPERSNAPPER_FS_FORMAT_POLICY_H

--- a/test/native/test_fs_format_policy.cpp
+++ b/test/native/test_fs_format_policy.cpp
@@ -1,0 +1,75 @@
+// Host-side unit tests for the filesystem (re)format decision policy.
+//
+// Pure logic, no hardware: compile and run on any host C++ compiler.
+//
+//   c++ -std=c++17 -I src/provisioning/tinyusb \
+//       test/native/test_fs_format_policy.cpp -o /tmp/fs_policy_test
+//   /tmp/fs_policy_test
+//
+// This is the regression guard for adafruit/Adafruit_Wippersnapper_Arduino
+// issue #621/#831: a board that has previously been provisioned must NEVER be
+// reformatted on a mount failure (which would erase the user's secrets.json),
+// no matter how healthy the flash currently looks.
+
+#include "Wippersnapper_FS_format_policy.h"
+#include <stdio.h>
+
+static int g_failures = 0;
+
+static const char *name(WsFsAction a) {
+  switch (a) {
+  case WsFsAction::Mounted:
+    return "Mounted";
+  case WsFsAction::Format:
+    return "Format";
+  case WsFsAction::HaltProvisionedBrownout:
+    return "HaltProvisionedBrownout";
+  case WsFsAction::HaltUnsafeToFormat:
+    return "HaltUnsafeToFormat";
+  }
+  return "?";
+}
+
+// EXPECT(mounted, provisioned, safeToFormat, expectedAction)
+static void expect(bool mounted, bool provisioned, bool safe,
+                   WsFsAction want, const char *desc) {
+  WsFsAction got = decideFsAction(mounted, provisioned, safe);
+  if (got == want) {
+    printf("  ok   : %s\n", desc);
+  } else {
+    printf("  FAIL : %s\n         decideFsAction(mounted=%d, provisioned=%d, "
+           "safeToFormat=%d) = %s, expected %s\n",
+           desc, mounted, provisioned, safe, name(got), name(want));
+    g_failures++;
+  }
+}
+
+int main() {
+  printf("decideFsAction() truth table\n");
+
+  // A successful mount is always "Mounted", whatever the other signals say.
+  expect(true, false, false, WsFsAction::Mounted, "mounted (fresh board)");
+  expect(true, true, true, WsFsAction::Mounted, "mounted (provisioned board)");
+
+  // THE FIX / regression guard: previously-provisioned board whose FAT will not
+  // mount must refuse to format - even when the flash reads back perfectly
+  // healthy (the exact case that wiped secrets.json after a deep brownout).
+  expect(false, true, true, WsFsAction::HaltProvisionedBrownout,
+         "provisioned + unmountable + flash looks healthy -> refuse to format");
+  expect(false, true, false, WsFsAction::HaltProvisionedBrownout,
+         "provisioned + unmountable + flash unhealthy -> refuse to format");
+
+  // Genuine first boot (never provisioned): format only when the flash is
+  // healthy and the volume is genuinely blank.
+  expect(false, false, true, WsFsAction::Format,
+         "first boot + blank healthy flash -> format");
+  expect(false, false, false, WsFsAction::HaltUnsafeToFormat,
+         "first boot + unhealthy/not-blank flash -> refuse to format");
+
+  if (g_failures == 0) {
+    printf("PASS: all cases\n");
+    return 0;
+  }
+  printf("FAIL: %d case(s)\n", g_failures);
+  return 1;
+}

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,308 @@
+# Brownout / power-loss filesystem hardening — open items
+
+Status: **draft / request-for-comment.** This is a running checklist of data-loss
+and corruption hazards found while validating #937 (don't auto-format a
+provisioned board) and #942 (auto-repair a power-loss-erased boot region) on real
+hardware. Several of these are **not yet fixed** — the goal of this file is to get
+the WipperSnapper maintainers' eyes on the full scope before either PR leaves
+draft. Corrections and "no, that's fine because…" very welcome.
+
+## How we got here (one paragraph)
+
+A provisioned MagTag was drained flat repeatedly. Two distinct outcomes were
+observed and dumped off-chip:
+
+1. **Boot region erased** (first 4 KB of `ffat` = boot sector + FAT). The #942
+   rescue restored it from the NVS backup and the board recovered itself —
+   `secrets.json` intact, no reformat. ✅
+2. **`secrets.json` "lost."** The FAT mounted cleanly, but the firmware halted on
+   *Invalid IO credentials*. An off-chip dump showed the **real `secrets.json`
+   was byte-intact in an orphaned cluster**, while the live directory entry now
+   pointed at a freshly-written placeholder template. Nothing was corrupted — a
+   transient brownout *read* (rail sag → `0x00`/`0xFF` bytes) was misinterpreted
+   as "empty file → recreate," which deleted the good file. This is exactly the
+   "misinterpretation of a failed flash operation" @tyeth called out, and it
+   confirms his warning that the reset reason "varies between those reboots (not
+   always brownout)."
+
+The takeaway driving this list: **brownout failures are a *family* of bugs, not
+one.** Format-on-mount-fail (#937) and boot-region-erase (#942) are two members;
+the *recreate-on-bad-read* paths and a *guard-timing* bug are still open.
+
+---
+
+## Must-fix before #937 leaves draft
+
+### [ ] 1. CRITICAL — `WS.brownOutCausedReset` is set too late; every FS-path check of it is dead code
+`brownOutCausedReset` is only set in `printDeviceInfo()` → `print_reset_reason()`
+(`Wippersnapper.cpp`), which runs inside **`connect()`**. But the sketch calls
+**`provision()` first**, and the entire `Wippersnapper_FS` constructor +
+`parseSecrets()` run inside `provision()`. So for the whole filesystem path the
+flag is still its zero-init value (`false`).
+
+Consequence — every `if (WS.brownOutCausedReset)` guard in the FS path never
+fires:
+- `parseSecrets()` "can't recreate due to brownout" — never protected anything.
+- `eraseCPFS()` `if (brownOutCausedReset) return;` — dead; it always runs.
+- `createBootFile()` brownout skips — the "skip write under brownout" branch
+  never triggers.
+
+Same class as a guard wired to a value that isn't live yet.
+
+**Empirical backing — the brownout reset code never even fires on this board.**
+`WS.brownOutCausedReset` is set only on reset code `15` (brownout). Across **~2,400
+boots over every drain cycle logged**, the observed reset-reason distribution is:
+
+| code | reason | count |
+|------|--------|-------|
+| 1  | POWERON_RESET | 2290 |
+| 3  | SW_RESET      | 101  |
+| 12 | SW_CPU_RESET  | 11   |
+| 15 | BROWNOUT_RST  | **0** |
+
+Code `15` was observed **zero times** — every single power-loss recovery comes
+back as `POWERON_RESET`. (The word "brownout" in the logs is exclusively our own
+halt-message text, not a reset code.) So the guard is doubly dead: set too late to
+matter *and* keyed on a code that empirically never occurs here. Even with the
+timing fixed, gating on the brownout reset code would protect ~0% of real drains.
+This is the measurement behind @tyeth's "the boot reason varies (not always
+brownout)" — on this hardware it is *never* brownout.
+
+**Fix:** establish the boot reason *before* constructing the FS
+(`getResetReasonCode()` is a ROM call valid immediately at boot) if a boot-reason
+is wanted for diagnostics, but **stop gating FS-destructive ops on the reset
+reason at all** — use the persistent NVS provisioned-marker, which is both live
+early and reliable. This is the keystone; several items below collapse once it's
+done.
+
+### [x] 2. HIGH — `configFileExists()` → `createSecretsFile()` was an un-fixed twin of the bug already patched in `parseSecrets()` — **now fixed**
+`configFileExists()` returns false when the **first byte** of `secrets.json`
+reads back `0x00` or `0xFF` (`file.peek()`), which is precisely what a brownout
+misread produces. `initFilesystem()` then calls `createSecretsFile()` →
+placeholder template + halt. It was **not guarded by `wasFilesystemProvisioned()`**,
+and it runs *inside the constructor, before* `parseSecrets()` — so it's actually the
+earlier / more likely trigger of the template overwrite we saw. The `parseSecrets`
+fix did **not** cover this door.
+
+**Confirmed live on hardware, then fixed.** A subsequent battery drain walked
+straight through this exact door: the MagTag mounted cleanly, `configFileExists()`
+peeked its intact `secrets.json` back blank (boot reason `1 (POWERON_RESET)`, **not**
+brownout), `createSecretsFile()` overwrote the live directory entry with the
+template, and the board halted on *"Please edit the secrets.json file."* An
+off-chip `ffat` dump showed both blobs present — the real credentials byte-intact
+in an orphaned cluster and the fresh template in the live entry — the same orphaned
+-good-file signature as the `parseSecrets` case, just through the earlier door.
+
+**Fixed** by gating the recreate on the same persistent NVS provisioned-marker
+`parseSecrets()` uses: a provisioned board that suddenly cannot read `secrets.json`
+now halts-and-protects instead of recreating; only a never-provisioned board may
+bootstrap a template.
+
+### [ ] 3. Single destructive-op rule across the FS
+Audit every destructive operation — `f_mkfs`/format, `wipperFatFs.remove(...)`,
+`rmRfStar()`, `createSecretsFile()` — against one invariant:
+**never destroy data on a previously-provisioned board without a deliberate user
+gesture.** Today only the *format* decision (#937) and *one* recreate path (the
+new `parseSecrets` fix) honor it.
+
+## Same-PR hardening (strongly recommended)
+
+### [ ] 4. MEDIUM — `eraseCPFS()` runs every boot behind the dead guard (#1)
+Removes `boot_out.txt`, `code.py`, and `rmRfStar()`s `/lib`. No-op for a normal
+WipperSnapper board (no CircuitPython files), so it hasn't bitten us — but it's a
+latent `rm -rf` gated only on the dead `brownOutCausedReset` and a single
+`exists()` a brownout could misread. Gate on the provisioned-marker / a real
+boot-reason read.
+
+### [ ] 5. MEDIUM — minimize flash writes while the rail is marginal
+During a drain the constructor *writes* repeatedly as Vcc collapses — each an
+opportunity to interrupt a program/erase and corrupt the FAT (the very thing #942
+recovers): `createBootFile()` rewrites `wipper_boot_out.txt`; `.fseventsd/`,
+`.metadata_never_index`, `.Trashes` are (re)created on `exists()` misreads;
+`writeToBootOut()` appends on every halt/error (which defeats `createBootFile`'s
+content-compare on the next boot). This is @tyeth's "diff before write" point —
+fewer writes on a marginal rail is strictly safer.
+
+### [ ] 6. MEDIUM — a cosmetic dot-file glitch can spuriously halt a provisioned board
+If any `.fseventsd`/`.metadata_never_index`/`.Trashes` open fails,
+`initFilesystem()` returns false → the constructor's format-decision path →
+`HaltProvisionedBrownout`. No data loss (good), but a macOS-marker hiccup taking
+a provisioned board offline is an availability surprise worth a guard.
+
+## #942 / follow-up scope
+
+### [ ] 7. MEDIUM — boot-region backup staleness → real FAT cross-linking
+A drain dump showed `wipper_boot_out.txt` and the template `secrets.json`
+**cross-linked** (overlapping clusters) — concrete fallout of restoring a stale
+boot region (old FAT) over a filesystem whose files had since moved. The
+"one-write-stale" limitation documented on #942 can produce an *inconsistent*
+FAT, not merely an old-but-valid one. (See also the silent backup-write-failure
+limitation already noted in the #942 description.)
+
+### [ ] 8. DESIGN — the rescue backup window is fixed, but the erasure location is random (aka stochastic)
+#942 backs up only the **first 4 KB** (boot sector + FAT). A power-loss erase hits
+a 4 KB-aligned block, but **which** block varies boot-to-boot — so a fixed backup
+window cannot cover it. Demonstrated across real drains of the *same* board:
+
+- **Drain #1** — the erase hit `0x310000` (boot sector + FAT). Rescue's window
+  matched → it restored and the board self-healed. ✅
+- **Drain #4** — the erase hit `0x311000`–`0x314000` (**the root directory**), plus
+  `0x32d000`–`0x32f000` (data). The first 4 KB was **intact** (4089 non-`0xFF`,
+  valid `55AA`), so the rescue correctly recorded *live-region-structured →
+  hands-off* and did nothing; #937 then correctly halted (unmountable + provisioned
+  → refuse to reformat). Both behaved as designed — but the damage was entirely
+  **outside** the rescue's 4 KB window, so the board could not self-heal. An
+  off-chip dump confirmed `secrets.json`'s bytes were still byte-complete at
+  `0x316600`, but **orphaned**: the root-directory entry pointing to them was
+  erased, so the file is unreachable and the volume won't mount. Data physically
+  present, functionally lost.
+- **Drain #7** — a near-exact replay of #4 on a *different* root-dir block: the
+  erase hit `0x311000`–`0x312000` (the **first 4 KB sector of the root
+  directory**), zeroing-out to `0xFF` the very entry block where `secrets.json`'s
+  8.3 directory record lived. After the erase, an off-chip dump showed **no
+  `SECRETS JSON` directory entry anywhere** on the volume, yet the real
+  credentials were still byte-complete in their data cluster (cluster 10, FAT
+  still `EOF`-allocated) — orphaned with no name pointing at them. The boot region
+  (first 4 KB) was again intact, so the rescue correctly stood down and #937
+  halted (*"refusing to reformat to protect your secrets.json"*). The serial log
+  caught the whole arc in one sitting: the board ran healthy on real creds for
+  ~2.4 h, then a single power-loss event erased the root-dir sector and it was
+  unmountable from that boot on. Notably the **fixed-window rescue *did* fire once
+  earlier in the same recovery saga** (`rescues so far: 1`) when an erase happened
+  to land on its boot-region window — concrete proof the cover is real but
+  *location-dependent*: same board, same firmware, three different erase blocks,
+  three different outcomes.
+- **Drain #9** — the finest-grained metadata erase yet: the casualty was the
+  **single 32-byte `secrets.json` directory record** alone. Unlike #4/#7 the
+  volume stayed **fully mountable** — boot sector valid (`55AA`), FAT internally
+  consistent (70 clusters, no out-of-range pointers / loops / cross-links),
+  `wipper_boot_out.txt` chaining cleanly — yet a full root-dir scan found **no
+  `secrets.json` entry**, while the real credentials sat byte-complete and
+  `EOF`-allocated at cluster 13, orphaned. So "metadata erase" isn't only the
+  coarse *root-dir-sector* case (#7); a power-loss can also surgically drop **one
+  live directory entry** and leave an otherwise-healthy volume that simply no
+  longer knows `secrets.json` exists. A region/boot-sector backup cannot cover
+  this (the boot region was pristine); only #8(b) — backing up `secrets.json`
+  *content* — would. Footnote: this boot stayed **dark (no USB-CDC serial)** and
+  the dump could *not* pin that on FS corruption (the FAT was clean), so the
+  protective halt may not always be reached — a separate worry that the
+  halt-and-protect floor only helps if the firmware survives init to print it.
+- **Drain #10** — the same erase *location* as #7 (the first 4 KB root-dir sector,
+  ffat `0x311000`, all `0xFF`) but the **opposite mount outcome**: here the boot
+  sector stayed valid (`55AA`) and the FAT stayed consistent (45 clusters, no
+  OOB), so the volume was **mountable** and only `secrets.json` went missing
+  (its entry was in the erased sector; creds again orphaned byte-complete at
+  cluster 13) — the #9 *outcome* via the #7 *mechanism*. The lesson: **a given
+  erase location does not map to a fixed outcome.** #7's first-sector erase
+  presented as *unmountable* (→ `#937` reformat-refusal halt); #10's presented as
+  *mountable with secrets.json orphaned*. Whether SdFat mounts or chokes on an
+  all-`0xFF` directory sector is itself variable, so the failure is a spectrum in
+  *both* axes — erase location **and** how the mount layer reacts to it. Same
+  conclusion: only #8(b) (content backup of `secrets.json`) auto-covers every
+  point on that spectrum.
+
+So this is broader than "data clusters aren't backed up" — the casualty in drains
+#4, #7, #9 and #10 was **metadata** (the root directory, down to a single entry).
+Two directions, not mutually exclusive:
+
+- **(a)** widen the metadata backup to boot sector + FAT + **root directory**
+  (first ~`0x5000`). Still loses if a `secrets.json` *data* cluster is the block
+  that dies.
+- **(b)** *(most robust — recommended)* back up **`secrets.json` content** to NVS
+  and re-materialize it on a failed mount, regardless of which metadata/data block
+  was erased. This covers the actual goal — *never lose the credentials* — where a
+  region-based backup only covers *some* erase locations.
+
+Reframe for #937/#942 reviewers: the boot-region rescue is a best-effort cover for
+*one* erase location; on its own it cannot make "survive any single-block
+power-loss erase" a guarantee. #937's halt-and-protect is the floor that catches
+every location the rescue misses (no data destroyed), but the board still needs a
+human to recover unless (b) is added.
+
+### [ ] 12. HIGH (#942) — the rescue only restores a *blank* boot region, not a *garbage-corrupted* one — so it stands down in-window when it could have healed
+Distinct from #8 (damage *outside* the window). Here the damage was squarely
+**inside** the rescue's 4 KB window, a valid backup was present, the rest of the
+filesystem was intact — and the rescue still did nothing, because its restore
+trigger only recognises a *clean* erase, not corruption.
+
+Observed live (drain #8, off-USB drain, recovered-on-its-own **failed**):
+- The **boot region** (`ffat 0x310000`, boot sector + FAT, file `0x0`–`0x1000`)
+  came back as **high-entropy garbage** — 3767 of 4096 bytes non-`0xFF`, no valid
+  `0x55AA` boot signature (offset `0x1FE` read `f7 fb`), boot sector starting
+  `fb fe 97 cf …` instead of a FAT `EB ..`. Not a clean erase — a *partial /
+  aborted-write corruption*.
+- **Everything else was intact.** The root directory parsed cleanly and the live
+  `secrets.json` entry (short name `SECRE~11JSO`, cluster 13) pointed at a
+  **byte-valid `secrets.json` with the real credentials** — confirmed in the dump
+  (`{ "io_username": "flaviof" … }`, 207 bytes). `wipper_boot_out.txt` intact too.
+- A **valid boot-region backup existed in NVS** (`ws_boot_bk`/`boot_bk` keys
+  present; a `0x55AA`-bearing boot sector found in the NVS dump). The damage was
+  exactly what the backup covers.
+- Yet the FS was unmountable (garbage boot sector + FAT) → #937 correctly halted.
+
+Why the rescue stood down: `restoreBootRegionIfBlank()` restores only when the
+live region is **"blank enough"** — no `0x55AA` **and** at most ~`len/64` (≈64)
+non-`0xFF` stragglers. A brownout that *corrupts* rather than *erases* leaves the
+region with **thousands** of non-`0xFF` bytes, so `3767 ≫ 64` fails the test and
+the rescue hands off — precisely when restoring its known-good backup would have
+made the volume mountable again. The heuristic was tuned for the clean-erase case
+(drain #1) and is blind to in-window corruption.
+
+**Fix:** broaden the restore trigger from "blank enough" to **"structurally
+invalid / unmountable"** — i.e. restore the CRC-verified backup whenever the live
+boot sector lacks a valid `0x55AA` (or won't parse as FAT), whether the region is
+blank *or* garbage. An unmountable boot region has nothing worth preserving, so a
+known-good restore can only help. Caveat (see #7): the backup is one-write-stale,
+so a restored FAT may need an fsck pass — but a stale-yet-valid FAT is strictly
+better than garbage, and it keeps the auto-heal promise for the *in-window* case
+instead of silently giving up. This is the cheapest high-value #942 hardening:
+the backup and the window were both right; only the trigger was too narrow.
+
+### [ ] 9. LOW — writable USB-MSC after mount
+Once mounted, the volume is exposed writable; a host OS that flags it dirty can
+write "repairs." Already mitigated for the unmounted case (MSC deliberately not
+exposed there). Consider `usb_msc.setWritable(false)` until a deliberate edit
+gesture.
+
+## Process
+
+### [ ] 10. A real test matrix — one green drain proves nothing
+The outcome depends on *which* 4 KB block the collapsing rail disturbs and *when*
+in the boot a read lands. We need fault injection (forced empty reads / single-
+block erases at each write/read point) plus many battery drains, with a
+byte-level survivor check (off-chip `ffat` dump) after each. Battery cycling alone
+is too coarse and too slow to trust.
+
+### [ ] 11. HIGH (recoverability) — the protective halt has no escape hatch; a board damaged beyond the rescue is permanently bricked for a normal user
+Direct consequence of #937's halt, observed live after drain #4 **and again
+after drain #7** (root-dir erase → unmountable → 204 consecutive halt prints
+across a night of power-cycles, no in-firmware way out). Once the NVS
+provisioned-marker is set and the FS is damaged in a way the #942 rescue can't
+repair (e.g. the erased block was the **root directory**, item #8), the board is
+deadlocked:
+
+- mount fails every boot → #937 (correctly) refuses to reformat to protect
+  `secrets.json` → `HaltProvisionedBrownout`, forever;
+- the rescue can't help (damage outside its 4 KB window);
+- re-flashing the **app** does nothing — the damage is in `ffat` (`0x310000`) and
+  the marker is in `nvs` (`0x9000`), neither of which an app upload touches.
+
+There is **no in-firmware path out**. Recovery required a host with `esptool` to
+`erase_region` both `ffat` *and* `nvs` (erasing only one isn't enough: blank `ffat`
++ marker still set → still `HaltProvisionedBrownout`; cleared marker + non-blank
+`ffat` → `HaltUnsafeToFormat`). A normal user with only the USB drive cannot do
+this — for them the board is bricked.
+
+So "refuse to reformat to protect secrets.json" needs a deliberate, user-reachable
+**override**, e.g.:
+- hold a button (D0/BOOT) during boot to authorize a one-time reformat, or
+- after N consecutive provisioned-but-unmountable boots, expose a read-only MSC
+  drive with a `RECOVER.txt`/flag the user can act on, or
+- surface a clear "hold X to reset filesystem" prompt on the halt screen/serial.
+The protective halt is the right floor; it just needs an exit that doesn't require
+a soldering-iron-adjacent toolchain. Pairs naturally with item #9 (read-only MSC).
+
+---
+
+_All hardware logs and flash dumps referenced here have SSID/credentials redacted;
+recovered private values were inspected locally only and never posted._


### PR DESCRIPTION
## What this does

This targets `tyeth/flash-health-format-guard` (the source branch of #931). On-hardware testing of #931 on a MagTag showed secrets.json **was still wiped** on a deep battery drain ([log + analysis](https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/pull/931#issuecomment-4803426537)). Digging into *why* surfaced two issues; this PR fixes both and folds in @brentru's review feedback.

### 1. The flash-health guard in #931 was unreachable (the real bug)

`initFilesystem(force_format=false)` still called `f_mkfs()` on a mount failure:

```cpp
if (force_format || !wipperFatFs.begin(&flash)) {  // <- formats on mount failure
```

So the constructor's **first** `initFilesystem()` call reformatted the corrupted FAT and `createSecretsFile()` halted — all *before* `flashSafeToFormat()` was ever consulted. The guard was effectively dead code, which is why the wipe still happened (`Please edit the secrets.json file`, not the guard's `Flash reads unstable` message).

**Fix:** `initFilesystem()` now returns `false` on a mount failure instead of creating a filesystem. Only the constructor's guarded path may format.

### 2. "Flash is readable" can't tell blank-from-factory apart from brownout-corrupted

Once the battery recovers enough to boot, the partition table and NVS read back fine — so a health probe alone always says "safe to format" on a recovered board. The shallow sags survived; the deep drain (corrupt the FAT, recover, boot) sailed straight through.

**Fix (primary gate):** a persistent `fs_ok` marker in **NVS**, which survives both a brownout and a FAT format. Set once after a successful real mount. On a later mount failure:

- **marker present** → the FAT was corrupted (brownout), never blank → **refuse to format**, halt, conserve battery → secrets.json preserved
- **no marker** → genuine first boot → fall through to the health/blank check, then format

### @brentru's #931 review feedback, folded in

- `flashSafeToFormat()` → `isFlashSafeToFormat()`
- locate NVS via `esp_partition_find_first()` instead of hardcoded `0x8000`/`0x9000`
- inspect the **FAT volume's boot sector** on ESP32 too (not just NVS) — only format if it reads back genuinely erased
- re-validate the flash **JEDEC ID after** the destructive format
- moved the ESP32 includes into `Wippersnapper_FS.h` under an `ARDUINO_ARCH_ESP32` guard

## Behavior

| Scenario | Result |
|---|---|
| Provisioned board, brownout corrupts FAT | marker present → **refuse to format**, halt → secrets safe |
| Genuine first boot (no marker, blank flash) | format ✅ |
| Normal boot, FAT mounts | mounts, marks provisioned, runs |
| Non-ESP32 (no NVS) | falls back to the blank-volume check, as in #931 |

Deliberate tradeoff: a provisioned board that can't mount now **halts asking for a recharge/reset instead of wiping**. Failing safe (preserve data) beats failing destructive. Normal re-provisioning is unaffected — editing `secrets.json` over USB never needs a format; only auto-format-on-mount-failure is blocked. A genuinely (non-brownout) corrupted FS would need an explicit reformat gesture / NVS erase, which could be a nice follow-up.

## Testing

- Builds clean for `adafruit_magtag29_esp32s2` (`pio run -e adafruit_magtag29_esp32s2` → SUCCESS).
- @flavio-fernandes will run the same sacrificed-USB battery-drain reproduction against this build and report back on #931.

Notes for reviewers: the version bump to `1.0.0-pr931.3` is just a test-build marker so the serial log identifies the flashed build — drop it before any merge. NVS namespace `ws_fs` / key `fs_ok`; if a board's partition table has no NVS, `Preferences.begin()` returns false and we degrade safely to the health/blank check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
