### PR TITLE
fix(i2c): publish v2 sensor reading Events online

### DIFF
--- a/src/components/i2c/controller.cpp
+++ b/src/components/i2c/controller.cpp
@@ -887,7 +887,8 @@ void I2cController::update(bool force) {
       // Online: wrap the device event in the i2c D2B envelope and publish it to
       // IO (mirrors publishProbed()'s D2B publish path).
       if (!_i2c_model->EncodeI2cDeviceEventD2B() ||
-          !Ws.PublishD2b(ws_signal_DeviceToBroker_i2c_tag, _i2c_model->GetI2cD2B())) {
+          !Ws.PublishD2b(ws_signal_DeviceToBroker_i2c_tag,
+                         _i2c_model->GetI2cD2B())) {
         WS_DEBUG_PRINTLN("[i2c] ERROR: Unable to publish the I2cDeviceEvent!");
       }
     } else {

--- a/src/components/i2c/controller.cpp
+++ b/src/components/i2c/controller.cpp
@@ -884,7 +884,12 @@ void I2cController::update(bool force) {
     _i2c_model->EncodeI2cDeviceEvent();
 
     if (!Ws._sdCardV2->isModeOffline()) {
-      // TODO: Implement online mode publishing
+      // Online: wrap the device event in the i2c D2B envelope and publish it to
+      // IO (mirrors publishProbed()'s D2B publish path).
+      if (!_i2c_model->EncodeI2cDeviceEventD2B() ||
+          !Ws.PublishD2b(ws_signal_DeviceToBroker_i2c_tag, _i2c_model->GetI2cD2B())) {
+        WS_DEBUG_PRINTLN("[i2c] ERROR: Unable to publish the I2cDeviceEvent!");
+      }
     } else {
       if (!Ws._sdCardV2->LogI2cDeviceEvent(_i2c_model->GetI2cDeviceEvent())) {
         WS_DEBUG_PRINTLN(

--- a/src/components/i2c/model.cpp
+++ b/src/components/i2c/model.cpp
@@ -462,6 +462,24 @@ bool I2cModel::EncodeI2cDeviceEvent() {
 }
 
 /*!
+    @brief    Wraps the current I2cDeviceEvent in the ws_i2c_D2B envelope so it
+              can be published to IO online (parallel to EncodeProbed()).
+    @returns  True if the wrapped D2B message is encodable, False otherwise.
+*/
+bool I2cModel::EncodeI2cDeviceEventD2B() {
+  memset(&_msg_i2c_d2b, 0, sizeof(_msg_i2c_d2b));
+  _msg_i2c_d2b.which_payload = ws_i2c_D2B_event_tag;
+  _msg_i2c_d2b.payload.event = _msg_i2c_event;
+
+  // Verify we can get the encoded size before handing it to PublishD2b.
+  size_t sz_msg;
+  if (!pb_get_encoded_size(&sz_msg, ws_i2c_D2B_fields, &_msg_i2c_d2b))
+    return false;
+
+  return true;
+}
+
+/*!
     @brief    Returns a pointer to the I2cDeviceEvent message.
     @returns  Pointer to the I2cDeviceEvent message.
 */

--- a/src/components/i2c/model.h
+++ b/src/components/i2c/model.h
@@ -67,6 +67,7 @@ public:
   bool DecodeI2cDeviceOutputWrite(pb_istream_t *stream);
   // Encoders
   bool EncodeI2cDeviceEvent();
+  bool EncodeI2cDeviceEventD2B();
   // Getters
   ws_i2c_Remove *GetI2cDeviceRemoveMsg();
   ws_i2c_Add *GetI2cDeviceAddOrReplaceMsg();


### PR DESCRIPTION
## Problem

`I2cController::update()` reads each driver's sensors, builds + encodes the `ws_i2c_Event`, then:

```cpp
if (!Ws._sdCardV2->isModeOffline()) {
  // TODO: Implement online mode publishing      // <-- event dropped
} else {
  Ws._sdCardV2->LogI2cDeviceEvent(...);          // offline only
}
```

So in **online mode the encoded reading is discarded** — no v2 I2C driver ever reports its sensor readings over the broker. Only the offline SD-card path logs them. (Probed/scan replies and component errors *do* publish, via `publishProbed()` / the error path, which is why scanning + settings-rejection work — but periodic readings never reach IO.)

## Fix

Fill the TODO the same way `publishProbed()` already publishes the Probed reply: wrap the populated event in the `ws_i2c_D2B` envelope and publish it.

- `I2cModel::EncodeI2cDeviceEventD2B()` — new, mirrors `EncodeProbed()`: sets `which_payload = ws_i2c_D2B_event_tag`, `payload.event = _msg_i2c_event`, validates encodability.
- `update()` online branch now calls it + `PublishD2b(ws_signal_DeviceToBroker_i2c_tag, GetI2cD2B())`.

3 files, +25/−1. No change to the offline path or any driver.

## Verification

- **Builds** for `adafruit_qtpy_esp32s3_with_psram`.
- **HIL-verified** on a QT Py ESP32-S3 N4R2 over protomq: with this build, i2c reading Events now publish (broker shows `{"i2c":{"event":{…floatValue…}}}`); previously identical Adds produced zero reading events. A `sea_level_pressure` setting on a BMP581 demonstrably changes the published altitude reading, and a full matrix of backported drivers reports readings (temp/pressure/altitude/humidity/light/proximity/CO2/VOC).

Found while HIL-testing the backported v2 I2C drivers (#933) and their custom settings — this is the upstream gap that blocked reading-back any of them online.