### PR TITLE
fix(i2c): MAX44009 override getEventLight() so light readings publish

### DIFF
--- a/src/components/i2c/drivers/drvMax44009.h
+++ b/src/components/i2c/drivers/drvMax44009.h
@@ -171,17 +171,17 @@ public:
   /*******************************************************************************/
   /*!
       @brief    Gets the MAX44009's current ambient light reading in lux.
-      @param    luxEvent
+      @param    lightEvent
                 Light sensor reading, in lux.
       @returns  True if the sensor event was obtained successfully, False
                 otherwise.
   */
   /*******************************************************************************/
-  bool getEventLux(sensors_event_t *luxEvent) {
+  bool getEventLight(sensors_event_t *lightEvent) override {
     float lux = _max44009->readLux();
     if (isnan(lux))
       return false;
-    luxEvent->light = lux;
+    lightEvent->light = lux;
     return true;
   }
 


### PR DESCRIPTION
## Problem

`drvMax44009` defined a non-virtual **`getEventLux()`**, which overrides nothing. The controller dispatches the `LIGHT` sensor type to the base virtual **`getEventLight()`**:

- `drivers/drvBase.h` — `GetSensorEvent` routes `ws_sensor_Type_T_LIGHT` → `getEventLight(event)`.
- base `getEventLight()` is a `{ return false; }` stub.

So for a MAX44009 configured with the `light` type, the read always failed → `I2cController::update()` bailed (`read_succeeded=false`) → **no Event was ever published**. The device ACKs and reads fine; it was just never asked via the right method.

## Fix

Rename the override to `getEventLight(sensors_event_t *lightEvent) override` (keeping the NaN guard, assigning `lightEvent->light = lux`), matching sibling light drivers like `drvVeml7700`. 3 lines.

## Verification

- Builds for `adafruit_qtpy_esp32s3_with_psram`.
- HIL-verified on a QT Py ESP32-S3 N4R2: MAX44009 at `0x4a` now publishes a light reading —
  `I2C_SETTINGS_VERDICT label=max44009_light status=ok readings={5=48.96}` (`{"type":"T_LIGHT","floatValue":48.96}`). Previously `status=no_event`.

Found during HIL settings testing of the backported v2 I2C drivers (#933); independent of the controller-level online-publish fix (#939).