### PR TITLE
feat(fs): auto-repair a power-loss-erased FAT boot region from NVS backup

### DIFF
--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -33,6 +33,10 @@
 
 #include "Wippersnapper_FS.h"
 #include "print_dependencies.h"
+#ifdef ARDUINO_ARCH_ESP32
+#include <Preferences.h> // NVS-backed store for the boot-region rescue backup
+#include <stdlib.h>      // malloc/free for the (heap, not stack) region buffers
+#endif
 // On-board external flash (QSPI or SPI) macros should already
 // defined in your board variant if supported
 // - EXTERNAL_FLASH_USE_QSPI
@@ -88,6 +92,226 @@ bool setVolumeLabel() {
   return true;
 }
 
+#ifdef ARDUINO_ARCH_ESP32
+// ---------------------------------------------------------------------------
+// Boot-region rescue
+//
+// A full battery drain / brownout can make the on-board SPI flash misinterpret
+// a command as Vcc collapses and erase one 4 KB block. When that block is the
+// first one of the FAT volume it takes out the *boot sector AND both FAT
+// tables* - they all live in that first 4 KB, while the root directory and file
+// data start right after it. The volume then refuses to mount even though every
+// file is still physically intact (see #621 and #898, plus PR #937: a flash
+// dump showed only the first 4 KB came back as 0xFF, with secrets.json
+// byte-perfect just past it).
+//
+// FAT keeps two FAT copies for redundancy, but one 4 KB erase wipes both at
+// once, so that doesn't help. FAT32 also keeps a backup boot sector at sector
+// 6; this volume is FAT12 (FM_FAT | FM_SFD) and has none. So we add our own:
+// after a clean mount we snapshot that first boot region into NVS - a separate
+// flash area that survives a format and is very unlikely to be hit by the same
+// erase. On a later boot, if the region reads back blank, we write the backup
+// back and re-mount, recovering the whole filesystem untouched.
+//
+// "Blank" is deliberately not "every byte is 0xFF": a real power-loss erase is
+// often incomplete and leaves a few stragglers that did not finish erasing (we
+// saw exactly one 0x7F byte in a 4 KB region after a hardware drain). So we
+// accept the region as erased when it has no valid boot signature and only a
+// handful of non-0xFF bytes (see kMaxBlankStragglerDiv).
+//
+// Paranoia is the entire point. We only ever write the region back when it is
+// blank in that sense (no boot signature, near-all-0xFF, so we can never
+// clobber a partially-written or differently-damaged FS) and only from a backup
+// that passes a boot-signature and CRC32 check, with the flash chip confirmed
+// responsive first. Anything unexpected -> do nothing and let the normal path
+// run, so this can only ever help, never make a bad situation worse.
+// ---------------------------------------------------------------------------
+namespace {
+const char *kBootBkNamespace = "ws_boot_bk"; ///< NVS namespace for the backup
+const char *kBootBkBlobKey = "blob";         ///< boot-region bytes
+const char *kBootBkLenKey = "len";           ///< blob length (bytes)
+const char *kBootBkCrcKey = "crc";           ///< CRC32 of the blob
+
+const size_t kBootSectorSize = 512;   ///< one logical FAT sector
+const size_t kFlashEraseBlock = 4096; ///< SPI-NOR erase granularity
+const size_t kMaxBootRegion = 8192;   ///< cap; keeps blob within nvs part
+
+// "Blank enough" tolerance. A real power-loss erase is often *incomplete*:
+// most of the region reaches 0xFF but a few bytes stall partway (e.g. 0x7F) as
+// Vcc collapses mid-cycle. We treat the region as erased if at most len/this
+// bytes are non-0xFF. A populated boot region has thousands of non-0xFF bytes
+// (FAT free entries are 0x00) plus a 0x55AA signature, so this never matches
+// live data. (len/64 = 64 bytes for a 4 KB region.)
+const size_t kMaxBlankStragglerDiv = 64; ///< max non-0xFF bytes = len/this
+
+/*! @brief Standard CRC32 (poly 0xEDB88420) over a byte buffer.
+    @param data Pointer to the bytes.
+    @param len  Number of bytes.
+    @returns The CRC32 value. */
+uint32_t crc32_buf(const uint8_t *data, size_t len) {
+  uint32_t crc = 0xFFFFFFFF;
+  for (size_t i = 0; i < len; i++) {
+    crc ^= data[i];
+    for (int b = 0; b < 8; b++)
+      crc = (crc >> 1) ^ (0xEDB88420 & (-(int32_t)(crc & 1)));
+  }
+  return ~crc;
+}
+
+/*! @brief Size (bytes) of the FAT boot region to protect: boot sector +
+           reserved sectors + every FAT table, rounded up to a flash erase
+           block (the unit a power-loss glitch erases). Parsed from the BPB of
+           a known-good boot sector.
+    @param bootSector A 512-byte buffer holding sector 0.
+    @returns Region length in bytes, or 0 if the BPB looks invalid. */
+size_t bootRegionLen(const uint8_t *bootSector) {
+  if (bootSector[510] != 0x55 || bootSector[511] != 0xAA)
+    return 0; // no boot signature -> not a boot sector we understand
+  uint16_t bytesPerSec = bootSector[11] | (bootSector[12] << 8);
+  uint16_t rsvdSecs = bootSector[14] | (bootSector[15] << 8);
+  uint8_t numFats = bootSector[16];
+  uint16_t fatSz16 = bootSector[22] | (bootSector[23] << 8);
+  if (bytesPerSec != kBootSectorSize || numFats == 0 || fatSz16 == 0)
+    return 0; // unexpected geometry - don't try to be clever
+  size_t regionBytes =
+      ((size_t)rsvdSecs + (size_t)numFats * fatSz16) * bytesPerSec;
+  // Round up to the flash erase block: that whole block is what gets erased.
+  regionBytes = ((regionBytes + kFlashEraseBlock - 1) / kFlashEraseBlock) *
+                kFlashEraseBlock;
+  if (regionBytes == 0 || regionBytes > kMaxBootRegion)
+    return 0;
+  return regionBytes;
+}
+} // namespace
+
+/**************************************************************************/
+/*!
+    @brief  Snapshots the FAT boot region (boot sector + reserved sectors +
+            every FAT table) into NVS, so a later power-loss erase of that
+            region can be repaired automatically. Only writes NVS when the
+            region actually changed, to spare flash wear. Safe to call only
+            once the filesystem is healthy (mounted or freshly formatted).
+*/
+/**************************************************************************/
+void Wippersnapper_FS::backupBootRegion() {
+  if (!flash.begin())
+    return;
+  uint8_t bootSec[kBootSectorSize];
+  if (!flash.readBlocks(0, bootSec, 1))
+    return;
+  size_t len = bootRegionLen(bootSec);
+  if (len == 0) {
+    WS_DEBUG_PRINTLN("[fs] boot-region backup skipped (unrecognized BPB)");
+    return;
+  }
+  uint8_t *buf = (uint8_t *)malloc(len);
+  if (buf == NULL)
+    return;
+  if (!flash.readBlocks(0, buf, len / kBootSectorSize)) {
+    free(buf);
+    return;
+  }
+  uint32_t crc = crc32_buf(buf, len);
+
+  Preferences prefs;
+  if (!prefs.begin(kBootBkNamespace, /*readOnly=*/false)) {
+    free(buf);
+    return;
+  }
+  // Skip the write if the stored backup already matches (no FS change).
+  if (prefs.getUInt(kBootBkLenKey, 0) == (uint32_t)len &&
+      prefs.getUInt(kBootBkCrcKey, 0) == crc) {
+    prefs.end();
+    free(buf);
+    return;
+  }
+  prefs.putBytes(kBootBkBlobKey, buf, len);
+  prefs.putUInt(kBootBkLenKey, (uint32_t)len);
+  prefs.putUInt(kBootBkCrcKey, crc);
+  prefs.end();
+  free(buf);
+  WS_DEBUG_PRINT("[fs] boot-region backup updated: ");
+  WS_DEBUG_PRINT(len);
+  WS_DEBUG_PRINTLN(" bytes saved to NVS");
+}
+
+/**************************************************************************/
+/*!
+    @brief  If the FAT boot region reads back blank - near-all-0xFF with no
+            valid boot signature, the fingerprint of a (possibly incomplete)
+            power-loss erase - and a verified NVS backup exists, writes that
+            backup back to flash so the volume can mount again. Performs no
+            destructive action in any other case.
+    @returns True if a restore was actually written (caller should re-mount),
+             false otherwise (no backup, region not blank, or a check failed).
+*/
+/**************************************************************************/
+bool Wippersnapper_FS::restoreBootRegionIfBlank() {
+  if (!flash.begin())
+    return false;
+  Preferences prefs;
+  if (!prefs.begin(kBootBkNamespace, /*readOnly=*/true))
+    return false;
+  size_t len = prefs.getUInt(kBootBkLenKey, 0);
+  uint32_t wantCrc = prefs.getUInt(kBootBkCrcKey, 0);
+  if (len == 0 || len > kMaxBootRegion ||
+      (size_t)prefs.getBytesLength(kBootBkBlobKey) != len) {
+    prefs.end();
+    return false; // no usable backup
+  }
+  uint8_t *backup = (uint8_t *)malloc(len);
+  uint8_t *live = (uint8_t *)malloc(len);
+  if (backup == NULL || live == NULL) {
+    prefs.end();
+    free(backup);
+    free(live);
+    return false;
+  }
+  size_t got = prefs.getBytes(kBootBkBlobKey, backup, len);
+  prefs.end();
+
+  bool ok = (got == len) &&
+            // Trust the backup only if it passes its own integrity checks.
+            (crc32_buf(backup, len) == wantCrc) && (backup[510] == 0x55) &&
+            (backup[511] == 0xAA) &&
+            // Read the live region; we decide below whether it is blank.
+            flash.readBlocks(0, live, len / kBootSectorSize);
+  if (ok) {
+    // Restore when the region is blank *enough*: no valid boot signature, and
+    // only a handful of non-0xFF stragglers left by an incomplete power-loss
+    // erase. Anything structured (a 0x55AA signature, or many non-0xFF bytes)
+    // means a state we do not understand - hands off.
+    size_t stragglers = 0;
+    for (size_t i = 0; i < len; i++)
+      if (live[i] != 0xFF)
+        stragglers++;
+    bool hasBootSig = (live[510] == 0x55 && live[511] == 0xAA);
+    if (hasBootSig || stragglers > len / kMaxBlankStragglerDiv)
+      ok = false; // structured data or too dirty -> do not touch
+  }
+  // Confirm the flash chip is actually responding before writing to it.
+  if (ok) {
+    uint32_t jedec = flash.getJEDECID();
+    if (jedec == 0 || jedec == 0xFFFFFF)
+      ok = false;
+  }
+
+  if (ok) {
+    WS_DEBUG_PRINTLN("[fs] boot region blank - restoring from backup...");
+    ok = flash.writeBlocks(0, backup, len / kBootSectorSize);
+    flash.syncBlocks();
+    if (ok) {
+      WS_DEBUG_PRINT("[fs] boot region restored (");
+      WS_DEBUG_PRINT(len);
+      WS_DEBUG_PRINTLN(" bytes). Re-mounting...");
+    }
+  }
+  free(backup);
+  free(live);
+  return ok;
+}
+#endif // ARDUINO_ARCH_ESP32
+
 /**************************************************************************/
 /*!
     @brief    Initializes USB-MSC and the QSPI flash filesystem.
@@ -106,13 +330,28 @@ Wippersnapper_FS::Wippersnapper_FS() {
   // Wait for detach
   delay(500);
 
-  // If a filesystem does not already exist - attempt to initialize a new
-  // filesystem
-  if (!initFilesystem() && !initFilesystem(true)) {
+  // Try to mount the existing filesystem first.
+  bool mounted = initFilesystem();
+#ifdef ARDUINO_ARCH_ESP32
+  // If the mount failed because a power-loss glitch erased the boot region
+  // (boot sector + FATs), restore it from our NVS backup and try again - this
+  // recovers the volume without reformatting, keeping every file intact.
+  if (!mounted && restoreBootRegionIfBlank())
+    mounted = initFilesystem();
+#endif
+  // Last resort (and the original behavior): create a fresh filesystem.
+  if (!mounted && !initFilesystem(true)) {
     TinyUSBDevice.attach();
     setStatusLEDColor(RED);
     fsHalt("ERROR Initializing Filesystem");
   }
+
+#ifdef ARDUINO_ARCH_ESP32
+  // Filesystem is healthy now (mounted or freshly formatted): refresh the NVS
+  // backup of the boot region so a future power-loss erase of it can be
+  // auto-repaired on the next boot.
+  backupBootRegion();
+#endif
 
   // Initialize USB-MSD
   initUSBMSC();

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -56,7 +56,13 @@ public:
   void fsHalt(String msg);
 
   void parseSecrets();
+
 private:
+#ifdef ARDUINO_ARCH_ESP32
+  bool restoreBootRegionIfBlank(); ///< Restore a power-loss-erased boot
+                                   ///< region (boot+FATs) from NVS backup.
+  void backupBootRegion();         ///< Snapshot the boot region into NVS.
+#endif
   bool _freshFS = false; /*!< True if filesystem was initialized by
                             WipperSnapper, False otherwise. */
 };


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on #937.** On its own this PR cannot recover anything: on a plain `main` base, `initFilesystem()` reformats the volume the moment a mount fails — *before* the restore hook can run — so the boot region (and `secrets.json`) is already gone. #937 is what changes `initFilesystem()` to return `false` instead of auto-formatting, which is the precondition this rescue needs. The two are partners: #937 stops a power-loss-erased board from being reformatted (no data loss); this PR lets that same board **repair itself and boot** instead of only halting. Full end-to-end validation lives on the combined branch `test/fs-937-plus-942-rescue` (see Testing).

## What this does

Adds an automatic, self-healing recovery for the "MagTag loses `secrets.json` after the battery dies" failure (#621, #898). After a clean mount, the firmware keeps a backup of the FAT **boot region** (boot sector + reserved sectors + both FAT tables) in NVS. On a later boot, if that region comes back blank, it restores it from the backup and re-mounts — recovering the whole filesystem, untouched, with no reformat.

## Why — what actually breaks

On a full battery drain the on-board SPI flash can misread a command as Vcc collapses and erase a single 4 KB block. We reproduced this on a MagTag and dumped the flash to see exactly what happened:

- Exactly the **first 4 KB** of the `ffat` partition (`0x310000`) came back blank.
- Everything past it was **byte-perfect** — the root directory, and a valid 206-byte `secrets.json`.

The catch is what lives in that first 4 KB. It is not just the 512-byte boot sector — it is the **boot sector + both FAT tables**. The root directory and file data start right after, at `0x1000`. So the volume won't mount even though every file is physically intact.

Two bits of built-in FAT redundancy don't save us here:

- FAT keeps **two FAT copies** — but a single 4 KB erase takes *both* at once.
- FAT32 keeps a **backup boot sector** (sector 6) — but this volume is FAT12 (`f_mkfs(FM_FAT | FM_SFD)`) and has none.

So we add our own backup, the same way a filesystem copies its superblock.

## How it works

- **Backup** (`backupBootRegion`): after a healthy mount, read the boot sector, parse the BPB to size the region (`reserved + numFATs * FATSz`, rounded up to the 4 KB erase block), read those bytes, and store them in NVS (namespace `ws_boot_bk`) with their length and a CRC32. NVS lives in a separate flash area that survives a format and is very unlikely to be hit by the same erase. The write is skipped when the stored copy already matches, so it costs nothing on a normal boot.
- **Restore** (`restoreBootRegionIfBlank`): on a failed mount, if the live region is blank and a good backup exists, write the backup back and let the constructor re-mount.

In the constructor the order is: try mount → if it failed, try the boot-region restore and re-mount → only then fall through to #937's careful format/halt gates.

## "Blank enough", not "entirely 0xFF" — a finding from a real drain

The first cut of this rescue restored only when the live region was **entirely** `0xFF`. On the bench that always worked, because forcing the failure with `esptool erase-region 0x310000 0x1000` produces a *perfectly clean* all-`0xFF` block. A genuine battery drain does **not** erase that cleanly.

After a real full drain, the dump showed the 4 KB region almost entirely `0xFF` — but with **one stray `0x7F` byte** at `0x310C4C`. That single byte is the fingerprint of an **erase interrupted partway**: as Vcc collapsed mid-erase-cycle, one byte didn't finish erasing (top bit still programmed → `0111 1111`). The strict "entirely `0xFF`" rule (correctly, per its own wording) refused that case, so the board sat in #937's protective halt loop instead of self-healing.

So the rule is now **blank *enough***: restore when the live region has **no valid `0x55AA` boot signature** and **at most `len/64` non-`0xFF` stragglers** (64 bytes for a 4 KB region). A populated boot region carries a boot signature and *thousands* of non-`0xFF` bytes (FAT free entries are stored as `0x00`), so this can never match live filesystem data — it stays paranoid, just no longer fooled by an incomplete erase.

## Paranoid by design

It will only ever write to flash when all of these hold, and is a complete no-op otherwise — so it can help but never make a bad situation worse:

1. The live boot region carries **no valid `0x55AA` boot signature** and is **blank enough** — at most `len/64` bytes differ from `0xFF`. If it looks structured (a signature, or many non-`0xFF` bytes), the FS is in some state we don't understand, and we do **not** touch it.
2. A backup must exist in NVS with a matching stored length.
3. The backup must pass a **CRC32** check and carry a valid **`0x55AA` boot signature**.
4. The flash chip must report a healthy **JEDEC ID** before any write.
5. The BPB geometry must be the expected 512-byte-sector layout and fit a small size cap; anything odd → skip.

Scope/footprint: ESP32-only (uses NVS via `Preferences`). The region buffers are heap-allocated, not stack, to stay off the small constructor stack. No change to the format decision or to any non-ESP32 board.

Honest limitation: the backup can be at most one write stale — if a write changes the FAT and power is lost before the next backup refresh, a restore brings back the previous good region (board mounts, `secrets.json` intact; you'd lose only the very last `wipper_boot_out.txt` rewrite). That's an acceptable trade for a rescue path.

## How it was tested

**Build:** `pio run -e adafruit_magtag29_esp32s2` → SUCCESS.

> [!NOTE]
> This rescue **cannot be tested on a `main`-only base** — without #937, the volume is reformatted on the failed mount before the restore can run, so you'd only ever see a wiped FS. All on-hardware testing below was done on `test/fs-937-plus-942-rescue` (this branch rebased on top of #937).

**On hardware — the real failure (the decisive test).** A provisioned MagTag was drained fully, then powered back. Before this change it stayed in the halt loop for hours; a flash dump confirmed the first 4 KB was blank (the `0x7F` straggler described above) with `secrets.json` intact past it. We then reflashed the app **only** — leaving that genuine drain damage and the NVS backup on the flash — and reset. The board **restored the boot region from NVS on the next boot and came straight back up**: WiFi connected, MQTT pinging, `secrets.json` intact, no reformat. The *same flash* had kept the strict "entirely `0xFF`" build halting; the blank-enough build recovered it.

**On hardware — forcing it without a battery drain.** This reproduces a *clean* version of the failure in seconds. With the board in ROM download mode:

```
# wipe the first 4 KB of the ffat partition (boot sector + FATs):
esptool erase-region 0x310000 0x1000
# reset the board
```

To exercise the **incomplete-erase** path specifically (the real-world shape), leave a straggler behind after erasing, e.g. write a single non-`0xFF` byte into the region (one `0x7F` at `0x310C4C`) before resetting.

Expected serial on the next boot:

```
[fs] boot region blank - restoring from backup...
[fs] boot region restored (4096 bytes). Re-mounting...
```

(To confirm the backup exists first, do a normal boot once after flashing; that prints `[fs] boot-region backup updated: 4096 bytes saved to NVS`.)

## Notes for reviewers

- The 4 KB erase size matches the SPI-NOR erase granularity, which is why the damage is always at least one 4 KB block aligned to `0x310000`. The backup size is derived from the BPB and rounded up to that block, so it adapts if a board's FAT geometry differs (with a small cap so the blob always fits the nvs partition).
- The `len/64` straggler tolerance is intentionally generous against incomplete erases yet far below real data: even a freshly-formatted region has thousands of non-`0xFF` bytes, versus the single straggler we observed. Combined with the no-signature requirement, it cannot match a structured boot region.
- Because of the dependency above, the cleanest path is to land #937 first and rebase this on top of it (which is what `test/fs-937-plus-942-rescue` already is). Happy to retarget this PR onto #937's branch if that's preferred.

### Known limitation — backup-write failures are not surfaced (deliberate, for simplicity)

`backupBootRegion()` is intentionally best-effort and **silent on failure**. If any step can't complete — `flash.begin()`/read fails, the BPB isn't recognized, the heap alloc fails, or the NVS `Preferences` write can't open or tears partway — it simply returns and leaves whatever backup was already in NVS untouched. It does **not** check the `putBytes`/`putUInt` return values or record a "backup failed/stale" breadcrumb. The consequence is a *diagnostics* gap, not a data-safety one:

- **It is still fail-safe.** A torn or inconsistent backup is caught on the *restore* side, which validates length, CRC32, and the `55 AA` signature before trusting the blob. A backup that fails those checks is rejected (`kRescueBackupBad` / `kRescueNoBackup`) and the board falls through to #937's protective halt (recharge & reset, refuse to reformat) rather than writing garbage over the boot region. A failed backup can never cause data loss — at worst it means "no auto-repair this time."
- **What you lose is early warning.** You won't learn the backup is missing or stale until a later restore needs it and reports it. Combined with the one-write-stale window noted above (the backup only catches up on a clean boot, so a re-provision immediately followed by a drain could restore a slightly-older boot region), the board could decline to self-heal a case it "should" have covered — and you'd only find out after the fact.

This was left as-is on purpose to keep the rescue path small and obvious. The additive fix would be to check the write result and persist a `last_backup_ok` (and/or backup age) breadcrumb into the existing `[fs]` diagnostics block, so a board self-reports a stale/missing backup *before* a drain needs it.

**Question for reviewers (@tyeth, @brentru):** is documenting this as a known, fail-safe limitation acceptable for now, or would you consider surfacing the backup result in diagnostics a must-have for this PR? Happy to fold the breadcrumb in if you'd prefer it land here rather than as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

