### PR TITLE
add(board): LilyGO T-Dongle C5 (ESP32-C5) + ST7735 SPI display driver

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -373,7 +373,7 @@ build_flags =
     -DBOARD_HAS_PSRAM
     -DARDUINO_USB_MODE=1
     -DARDUINO_USB_CDC_ON_BOOT=1
-board_build.partitions = default_16MB.csv
+board_build.partitions = default_8MB.csv
 board_build.filesystem = littlefs
 
 ; LilyGO T-Dongle C5 Debug (ESP32-C5, 16MB flash, 8MB PSRAM)
@@ -393,7 +393,7 @@ build_flags =
     -DARDUINO_CORE_DEBUG_LEVEL=5
     -DCORE_DEBUG_LEVEL=5
     -DARDUHAL_LOG_LEVEL=5
-board_build.partitions = default_16MB.csv
+board_build.partitions = default_8MB.csv
 board_build.filesystem = littlefs
 
 ; Adafruit QT Py ESP32-S2

--- a/platformio.ini
+++ b/platformio.ini
@@ -361,6 +361,21 @@ board_build.filesystem = littlefs
 board_build.partitions = min_spiffs.csv
 upload_port = /dev/cu.usbserial-120
 
+; LilyGO T-Dongle C5 (ESP32-C5, 16MB flash, 8MB PSRAM)
+; Uses the generic 16MB C5 devkit board (closest match; the devkit PSRAM
+; variant is 4MB but PSRAM is auto-detected at runtime).
+[env:lilygo_t_dongle_c5]
+extends = common:esp32
+board = esp32-c5-devkitc1-n16r4
+build_flags =
+    -DWS_LILYGO_T_DONGLE_C5
+    -DARDUINO_ESP32C5_DEV
+    -DBOARD_HAS_PSRAM
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+board_build.partitions = default_16MB.csv
+board_build.filesystem = littlefs
+
 ; Adafruit QT Py ESP32-S2
 [env:adafruit_qtpy_esp32s2]
 extends = common:esp32

--- a/platformio.ini
+++ b/platformio.ini
@@ -376,6 +376,26 @@ build_flags =
 board_build.partitions = default_16MB.csv
 board_build.filesystem = littlefs
 
+; LilyGO T-Dongle C5 Debug (ESP32-C5, 16MB flash, 8MB PSRAM)
+; Uses the generic 16MB C5 devkit board (closest match; the devkit PSRAM
+; variant is 4MB but PSRAM is auto-detected at runtime).
+[env:lilygo_t_dongle_c5_debug]
+extends = common:esp32
+board = esp32-c5-devkitc1-n16r4
+build_type = debug
+build_flags =
+    -DWS_LILYGO_T_DONGLE_C5
+    -DARDUINO_ESP32C5_DEV
+    -DBOARD_HAS_PSRAM
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DESP_LOG_LEVEL=5
+    -DARDUINO_CORE_DEBUG_LEVEL=5
+    -DCORE_DEBUG_LEVEL=5
+    -DARDUHAL_LOG_LEVEL=5
+board_build.partitions = default_16MB.csv
+board_build.filesystem = littlefs
+
 ; Adafruit QT Py ESP32-S2
 [env:adafruit_qtpy_esp32s2]
 extends = common:esp32

--- a/src/components/display/drivers/dispDrvBase.h
+++ b/src/components/display/drivers/dispDrvBase.h
@@ -117,7 +117,10 @@ public:
       @note   Move backlight pin into proto Add message instead of board
               defines.
   */
-  void setBacklightPin(int16_t pin) { _pin_bl = pin; }
+  void setBacklightPin(int16_t pin, bool active_low = false) {
+    _pin_bl = pin;
+    _bl_active_low = active_low;
+  }
 
   /*! @brief Shows the display splash screen, if supported. */
   virtual void showSplash() {}
@@ -202,7 +205,8 @@ protected:
   int16_t _pin_miso = -1;    ///< MISO pin (TFT only)
   int16_t _pin_sram_cs = -1; ///< SRAM Chip Select pin (EPD only)
   int16_t _pin_busy = -1;    ///< Busy pin (EPD only)
-  int16_t _pin_bl = -1;      ///< Backlight pin (-1 = not set)
+  int16_t _pin_bl = -1;        ///< Backlight pin (-1 = not set)
+  bool _bl_active_low = false;  ///< True if the backlight is active-low
   uint8_t _text_sz = 1;      ///< Text size multiplier
   int16_t _width;            ///< Display width
   int16_t _height;           ///< Display height

--- a/src/components/display/drivers/dispDrvBase.h
+++ b/src/components/display/drivers/dispDrvBase.h
@@ -114,6 +114,7 @@ public:
   /*!
       @brief  Sets the backlight control pin.
       @param  pin  Pin number for the backlight (-1 to disable).
+      @param  active_low  True if the backlight is active-low (driven LOW = on).
       @note   Move backlight pin into proto Add message instead of board
               defines.
   */
@@ -197,20 +198,20 @@ protected:
     return false;
   }
 
-  int16_t _pin_cs;           ///< Chip Select pin
-  int16_t _pin_dc;           ///< Data/Command pin
-  int16_t _pin_mosi = -1;    ///< MOSI pin (TFT only)
-  int16_t _pin_sck = -1;     ///< SCK pin (TFT only)
-  int16_t _pin_rst;          ///< Reset pin
-  int16_t _pin_miso = -1;    ///< MISO pin (TFT only)
-  int16_t _pin_sram_cs = -1; ///< SRAM Chip Select pin (EPD only)
-  int16_t _pin_busy = -1;    ///< Busy pin (EPD only)
+  int16_t _pin_cs;             ///< Chip Select pin
+  int16_t _pin_dc;             ///< Data/Command pin
+  int16_t _pin_mosi = -1;      ///< MOSI pin (TFT only)
+  int16_t _pin_sck = -1;       ///< SCK pin (TFT only)
+  int16_t _pin_rst;            ///< Reset pin
+  int16_t _pin_miso = -1;      ///< MISO pin (TFT only)
+  int16_t _pin_sram_cs = -1;   ///< SRAM Chip Select pin (EPD only)
+  int16_t _pin_busy = -1;      ///< Busy pin (EPD only)
   int16_t _pin_bl = -1;        ///< Backlight pin (-1 = not set)
-  bool _bl_active_low = false;  ///< True if the backlight is active-low
-  uint8_t _text_sz = 1;      ///< Text size multiplier
-  int16_t _width;            ///< Display width
-  int16_t _height;           ///< Display height
-  uint8_t _rotation;         ///< Display rotation (0-3)
+  bool _bl_active_low = false; ///< True if the backlight is active-low
+  uint8_t _text_sz = 1;        ///< Text size multiplier
+  int16_t _width;              ///< Display width
+  int16_t _height;             ///< Display height
+  uint8_t _rotation;           ///< Display rotation (0-3)
 
   /*! @brief Cached status bar layout and state. */
   int _statusbar_icons_y;         ///< Y position of status bar icons

--- a/src/components/display/drivers/dispDrvSt7735.h
+++ b/src/components/display/drivers/dispDrvSt7735.h
@@ -1,0 +1,230 @@
+/*!
+ * @file src/components/display/drivers/dispDrvSt7735.h
+ *
+ * Driver for ST7735-based TFT displays (V2).
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright (c) Tyeth Gundry 2025 for Adafruit Industries.
+ *
+ * BSD license, all text here must be included in any redistribution.
+ *
+ */
+#ifndef WS_DISP_DRV_ST7735_H
+#define WS_DISP_DRV_ST7735_H
+
+#include "dispDrvBase.h"
+#include <Adafruit_ST7735.h>
+
+#define ST7735_STATUSBAR_HEIGHT 20      ///< Status bar height in pixels
+#define ST7735_STATUSBAR_ICON_SZ 16     ///< Status bar icon size in pixels
+#define ST7735_STATUSBAR_ICON_SPACING 4 ///< Spacing between icons
+#define ST7735_STATUSBAR_ICON_MARGIN 5  ///< Margin from edge of display
+
+/*!
+    @brief  Driver for ST7735-based TFT displays (e.g. 0.96" 160x80 IPS).
+*/
+class dispDrvSt7735 : public dispDrvBase {
+public:
+  /*!
+      @brief  Constructor for the ST7735 TFT driver.
+      @param  cs    Chip Select pin.
+      @param  dc    Data/Command pin.
+      @param  mosi  MOSI pin.
+      @param  sck   SCK pin.
+      @param  rst   Reset pin (-1 if not used).
+      @param  miso  MISO pin (-1 if not used).
+  */
+  dispDrvSt7735(int16_t cs, int16_t dc, int16_t mosi, int16_t sck,
+                int16_t rst = -1, int16_t miso = -1)
+      : dispDrvBase(cs, dc, mosi, sck, rst, miso), _display(nullptr) {}
+
+  ~dispDrvSt7735() {
+    if (_display) {
+      _display->fillScreen(ST77XX_BLACK);
+      delete _display;
+      _display = nullptr;
+    }
+    if (_pin_bl >= 0)
+      digitalWrite(_pin_bl, LOW);
+  }
+
+  /*!
+      @brief  Initializes the ST7735 TFT display.
+      @return True if initialization succeeded, False otherwise.
+  */
+  bool begin() override {
+    _display =
+        new Adafruit_ST7735(_pin_cs, _pin_dc, _pin_mosi, _pin_sck, _pin_rst);
+    if (!_display)
+      return false;
+
+    // INITR_MINI160x80 targets the 0.96" 160x80 IPS panel (col offset 24).
+    // Many of these IPS panels also require inverted colours; if the display
+    // shows negative colours on hardware, switch to INITR_MINI160x80_PLUGIN
+    // (or drop the invertDisplay call).
+    _display->initR(INITR_MINI160x80);
+    _display->invertDisplay(true);
+    _display->setRotation(_rotation);
+    _display->fillScreen(ST77XX_BLACK);
+    _display->setTextColor(ST77XX_WHITE);
+    _display->setTextWrap(false);
+    _display->setTextSize(_text_sz);
+
+    // Turn on backlight
+    if (_pin_bl >= 0) {
+      pinMode(_pin_bl, OUTPUT);
+      digitalWrite(_pin_bl, HIGH);
+      WS_DEBUG_PRINTLN("[display] Backlight ON");
+    }
+
+    WS_DEBUG_PRINTLN("[display] ST7735 initialized");
+    return true;
+  }
+
+  /*!
+      @brief  Draws the status bar and the Adafruit IO username.
+      @param  io_username  Adafruit IO username to display.
+  */
+  void drawStatusBar(const char *io_username) override {
+    if (!_display)
+      return;
+
+    // Clear entire display to remove splash screen
+    _display->fillScreen(ST77XX_BLACK);
+
+    // Draw white status bar at top
+    _display->fillRect(0, 0, _display->width(), ST7735_STATUSBAR_HEIGHT,
+                       ST77XX_WHITE);
+
+    // Draw username on left side
+    _display->setTextSize(1);
+    _display->setTextColor(ST77XX_BLACK);
+    _display->setCursor(5, 6);
+    _display->print(io_username);
+
+    // Calculate icon positions (right-aligned), centered vertically
+    _statusbar_icons_y =
+        (ST7735_STATUSBAR_HEIGHT - ST7735_STATUSBAR_ICON_SZ) / 2;
+    _statusbar_icon_battery_x = _display->width() - ST7735_STATUSBAR_ICON_SZ -
+                                ST7735_STATUSBAR_ICON_MARGIN;
+    _statusbar_icon_wifi_x = _statusbar_icon_battery_x -
+                             ST7735_STATUSBAR_ICON_SZ -
+                             ST7735_STATUSBAR_ICON_SPACING;
+    _statusbar_icon_cloud_x = _statusbar_icon_wifi_x -
+                              ST7735_STATUSBAR_ICON_SZ -
+                              ST7735_STATUSBAR_ICON_SPACING;
+
+    // Draw icons
+    _display->drawBitmap(_statusbar_icon_cloud_x, _statusbar_icons_y,
+                         epd_bmp_cloud_online, ST7735_STATUSBAR_ICON_SZ,
+                         ST7735_STATUSBAR_ICON_SZ, ST77XX_BLACK);
+    _display->drawBitmap(_statusbar_icon_wifi_x, _statusbar_icons_y,
+                         epd_bmp_wifi_full, ST7735_STATUSBAR_ICON_SZ,
+                         ST7735_STATUSBAR_ICON_SZ, ST77XX_BLACK);
+    _display->drawBitmap(_statusbar_icon_battery_x, _statusbar_icons_y,
+                         epd_bmp_bat_full, ST7735_STATUSBAR_ICON_SZ,
+                         ST7735_STATUSBAR_ICON_SZ, ST77XX_BLACK);
+
+    // Reset text color and size for main text area
+    _display->setTextColor(ST77XX_WHITE);
+    _display->setTextSize(_text_sz);
+  }
+
+  /*!
+      @brief  Updates the status bar icons based on current state.
+      @param  rssi         Current WiFi RSSI value.
+      @param  bat          Current battery level (0-100).
+      @param  mqtt_status  True if MQTT is connected.
+  */
+  void updateStatusBar(int8_t rssi, uint8_t bat, bool mqtt_status) override {
+    if (!_display)
+      return;
+
+    bool update_rssi = abs(rssi - _statusbar_rssi) >= 3;
+    bool update_mqtt = mqtt_status != _statusbar_mqtt_connected;
+
+    if (!update_rssi && !update_mqtt)
+      return;
+
+    if (update_mqtt) {
+      _display->fillRect(_statusbar_icon_cloud_x, _statusbar_icons_y,
+                         ST7735_STATUSBAR_ICON_SZ, ST7735_STATUSBAR_ICON_SZ,
+                         ST77XX_WHITE);
+      if (mqtt_status) {
+        _display->drawBitmap(_statusbar_icon_cloud_x, _statusbar_icons_y,
+                             epd_bmp_cloud_online, ST7735_STATUSBAR_ICON_SZ,
+                             ST7735_STATUSBAR_ICON_SZ, ST77XX_BLACK);
+      } else {
+        _display->drawBitmap(_statusbar_icon_cloud_x, _statusbar_icons_y,
+                             epd_bmp_cloud_offline, ST7735_STATUSBAR_ICON_SZ,
+                             ST7735_STATUSBAR_ICON_SZ, ST77XX_BLACK);
+      }
+      _statusbar_mqtt_connected = mqtt_status;
+    }
+
+    if (update_rssi) {
+      const unsigned char *wifi_icon = epd_bmp_wifi_no_signal;
+      if (rssi >= -50) {
+        wifi_icon = epd_bmp_wifi_full;
+      } else if (rssi >= -60) {
+        wifi_icon = epd_bmp_wifi_fair;
+      } else if (rssi >= -70) {
+        wifi_icon = epd_bmp_wifi_weak;
+      }
+      _display->fillRect(_statusbar_icon_wifi_x, _statusbar_icons_y,
+                         ST7735_STATUSBAR_ICON_SZ, ST7735_STATUSBAR_ICON_SZ,
+                         ST77XX_WHITE);
+      _display->drawBitmap(_statusbar_icon_wifi_x, _statusbar_icons_y,
+                           wifi_icon, ST7735_STATUSBAR_ICON_SZ,
+                           ST7735_STATUSBAR_ICON_SZ, ST77XX_BLACK);
+      _statusbar_rssi = rssi;
+    }
+  }
+
+  void writeMessage(const char *message) override {
+    if (!_display)
+      return;
+
+    // Clear only below status bar, start text below status bar
+    _display->fillRect(0, ST7735_STATUSBAR_HEIGHT, _display->width(),
+                       _display->height() - ST7735_STATUSBAR_HEIGHT,
+                       ST77XX_BLACK);
+
+    int16_t y_idx = ST7735_STATUSBAR_HEIGHT + 5;
+    int16_t line_height = 8 * _text_sz;
+
+    _display->setTextSize(_text_sz);
+    _display->setCursor(0, y_idx);
+
+    size_t msg_len = strlen(message);
+    for (size_t i = 0; i < msg_len; i++) {
+      // Stop if we'd overflow the display
+      if (y_idx + line_height > _height)
+        break;
+
+      char parsed_char = 0;
+      bool is_newline = false;
+      if (parseWriteToken(message, msg_len, i, parsed_char, is_newline,
+                          char(247))) {
+        if (is_newline) {
+          y_idx += line_height;
+          if (y_idx + line_height > _height)
+            break;
+          _display->setCursor(0, y_idx);
+        } else {
+          _display->write(parsed_char);
+        }
+        continue;
+      }
+      _display->print(message[i]);
+    }
+  }
+
+private:
+  Adafruit_ST7735 *_display;
+};
+
+#endif // WS_DISP_DRV_ST7735_H

--- a/src/components/display/drivers/dispDrvSt7735.h
+++ b/src/components/display/drivers/dispDrvSt7735.h
@@ -48,7 +48,7 @@ public:
       _display = nullptr;
     }
     if (_pin_bl >= 0)
-      digitalWrite(_pin_bl, LOW);
+      digitalWrite(_pin_bl, _bl_active_low ? HIGH : LOW);
   }
 
   /*!
@@ -61,22 +61,22 @@ public:
     if (!_display)
       return false;
 
-    // INITR_MINI160x80 targets the 0.96" 160x80 IPS panel (col offset 24).
-    // Many of these IPS panels also require inverted colours; if the display
-    // shows negative colours on hardware, switch to INITR_MINI160x80_PLUGIN
-    // (or drop the invertDisplay call).
-    _display->initR(INITR_MINI160x80);
-    _display->invertDisplay(true);
+    // INITR_MINI160x80_PLUGIN matches the LilyGO 0.96" 160x80 panel:
+    // BGR, inverted, column offset 26 / row offset 1 (== LilyGo's
+    // GREENTAB160x80 config). This variant handles the inversion internally,
+    // so no explicit invertDisplay() call is needed. If a different 160x80
+    // panel renders negative colours, toggle invertDisplay().
+    _display->initR(INITR_MINI160x80_PLUGIN);
     _display->setRotation(_rotation);
     _display->fillScreen(ST77XX_BLACK);
     _display->setTextColor(ST77XX_WHITE);
     _display->setTextWrap(false);
     _display->setTextSize(_text_sz);
 
-    // Turn on backlight
+    // Turn on backlight (honor active-low panels, e.g. LilyGO T-Dongle C5)
     if (_pin_bl >= 0) {
       pinMode(_pin_bl, OUTPUT);
-      digitalWrite(_pin_bl, HIGH);
+      digitalWrite(_pin_bl, _bl_active_low ? LOW : HIGH);
       WS_DEBUG_PRINTLN("[display] Backlight ON");
     }
 

--- a/src/components/display/drivers/dispDrvSt7789.h
+++ b/src/components/display/drivers/dispDrvSt7789.h
@@ -48,7 +48,7 @@ public:
       _display = nullptr;
     }
     if (_pin_bl >= 0)
-      digitalWrite(_pin_bl, LOW);
+      digitalWrite(_pin_bl, _bl_active_low ? HIGH : LOW);
   }
 
   /*!
@@ -71,10 +71,10 @@ public:
     _display->setTextWrap(false);
     _display->setTextSize(_text_sz);
 
-    // Turn on backlight
+    // Turn on backlight (honor active-low panels)
     if (_pin_bl >= 0) {
       pinMode(_pin_bl, OUTPUT);
-      digitalWrite(_pin_bl, HIGH);
+      digitalWrite(_pin_bl, _bl_active_low ? LOW : HIGH);
       WS_DEBUG_PRINTLN("[display] Backlight ON");
     }
 

--- a/src/components/display/hardware.cpp
+++ b/src/components/display/hardware.cpp
@@ -172,9 +172,10 @@ bool DisplayHardware::beginSpiTft(ws_display_Add *msg) {
   _drvDisp->setBacklightPin(TFT_BACKLIGHT);
 #endif
 
-  // Backlight pin from the display Add proto (shared BacklightConfig). Overrides
-  // any board-level TFT_BACKLITE/TFT_BACKLIGHT define when present, so boards
-  // without a hardcoded backlight define (e.g. LilyGO T-Dongle C5) still work.
+  // Backlight pin from the display Add proto (shared BacklightConfig).
+  // Overrides any board-level TFT_BACKLITE/TFT_BACKLIGHT define when present,
+  // so boards without a hardcoded backlight define (e.g. LilyGO T-Dongle C5)
+  // still work.
   if (msg->has_backlight) {
     int16_t bl_pin = -1;
     bool bl_active_low = false;
@@ -183,7 +184,8 @@ bool DisplayHardware::beginSpiTft(ws_display_Add *msg) {
       bl_pin =
           parsePin(msg->backlight.backlight_add.backlight_digital.pin_name);
       // Active-low backlight (e.g. LilyGO T-Dongle C5 drives LCD_BL LOW = on)
-      bl_active_low = msg->backlight.backlight_add.backlight_digital.is_inverted;
+      bl_active_low =
+          msg->backlight.backlight_add.backlight_digital.is_inverted;
     } else if (msg->backlight.which_backlight_add ==
                ws_display_BacklightConfig_backlight_pwm_tag) {
       bl_pin = parsePin(msg->backlight.backlight_add.backlight_pwm.pin);

--- a/src/components/display/hardware.cpp
+++ b/src/components/display/hardware.cpp
@@ -153,6 +153,8 @@ bool DisplayHardware::beginSpiTft(ws_display_Add *msg) {
 
   if (strcmp(msg->driver, "ST7789") == 0) {
     _drvDisp = new dispDrvSt7789(cs, dc, mosi, sck, rst, miso);
+  } else if (strcmp(msg->driver, "ST7735") == 0) {
+    _drvDisp = new dispDrvSt7735(cs, dc, mosi, sck, rst, miso);
   } else {
     WS_DEBUG_PRINT("[display] ERROR: Unsupported TFT driver: ");
     WS_DEBUG_PRINTLNVAR(msg->driver);
@@ -169,6 +171,24 @@ bool DisplayHardware::beginSpiTft(ws_display_Add *msg) {
 #elif defined(TFT_BACKLIGHT)
   _drvDisp->setBacklightPin(TFT_BACKLIGHT);
 #endif
+
+  // Backlight pin from the display Add proto (shared BacklightConfig). Overrides
+  // any board-level TFT_BACKLITE/TFT_BACKLIGHT define when present, so boards
+  // without a hardcoded backlight define (e.g. LilyGO T-Dongle C5) still work.
+  if (msg->has_backlight) {
+    int16_t bl_pin = -1;
+    if (msg->backlight.which_backlight_add ==
+        ws_display_BacklightConfig_backlight_digital_tag) {
+      bl_pin =
+          parsePin(msg->backlight.backlight_add.backlight_digital.pin_name);
+    } else if (msg->backlight.which_backlight_add ==
+               ws_display_BacklightConfig_backlight_pwm_tag) {
+      bl_pin = parsePin(msg->backlight.backlight_add.backlight_pwm.pin);
+    }
+    if (bl_pin >= 0) {
+      _drvDisp->setBacklightPin(bl_pin);
+    }
+  }
 
   _drvDisp->setWidth(config->width);
   _drvDisp->setHeight(config->height);

--- a/src/components/display/hardware.cpp
+++ b/src/components/display/hardware.cpp
@@ -177,16 +177,19 @@ bool DisplayHardware::beginSpiTft(ws_display_Add *msg) {
   // without a hardcoded backlight define (e.g. LilyGO T-Dongle C5) still work.
   if (msg->has_backlight) {
     int16_t bl_pin = -1;
+    bool bl_active_low = false;
     if (msg->backlight.which_backlight_add ==
         ws_display_BacklightConfig_backlight_digital_tag) {
       bl_pin =
           parsePin(msg->backlight.backlight_add.backlight_digital.pin_name);
+      // Active-low backlight (e.g. LilyGO T-Dongle C5 drives LCD_BL LOW = on)
+      bl_active_low = msg->backlight.backlight_add.backlight_digital.is_inverted;
     } else if (msg->backlight.which_backlight_add ==
                ws_display_BacklightConfig_backlight_pwm_tag) {
       bl_pin = parsePin(msg->backlight.backlight_add.backlight_pwm.pin);
     }
     if (bl_pin >= 0) {
-      _drvDisp->setBacklightPin(bl_pin);
+      _drvDisp->setBacklightPin(bl_pin, bl_active_low);
     }
   }
 

--- a/src/components/display/hardware.h
+++ b/src/components/display/hardware.h
@@ -22,6 +22,7 @@
 #include "drivers/dispDrvQuadAlphaNum.h"
 #include "drivers/dispDrvSh1107.h"
 #include "drivers/dispDrvSsd1306.h"
+#include "drivers/dispDrvSt7735.h"
 #include "drivers/dispDrvSt7789.h"
 #include "wippersnapper.h"
 #ifdef ARDUINO_ADAFRUIT_QUALIA_S3_RGB666

--- a/src/components/sleep/hardware.cpp
+++ b/src/components/sleep/hardware.cpp
@@ -255,7 +255,8 @@ bool SleepHardware::RegisterExt0Wakeup(const char *pin_name, bool pin_level,
   }
   gpio_num_t pin = (gpio_num_t)pin_num;
 
-#if defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)
+#if defined(CONFIG_IDF_TARGET_ESP32C3) ||                                      \
+    defined(CONFIG_IDF_TARGET_ESP32C5) || defined(CONFIG_IDF_TARGET_ESP32C6)
   // Configure pull resistor
   if (pin_pull) {
     if (pin_level) {

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -18,7 +18,8 @@
     defined(ARDUINO_ADAFRUIT_FEATHER_ESP32_V2) ||                              \
     defined(ARDUINO_ADAFRUIT_QTPY_ESP32_PICO) ||                               \
     defined(ARDUINO_ADAFRUIT_QTPY_ESP32C3) || defined(ARDUINO_ESP32_DEV) ||    \
-    defined(ESP32_DEV) || defined(ARDUINO_ADAFRUIT_FEATHER_ESP32C6)
+    defined(ESP32_DEV) || defined(ARDUINO_ADAFRUIT_FEATHER_ESP32C6) ||         \
+    defined(WS_LILYGO_T_DONGLE_C5)
 #include "WipperSnapper_LittleFS.h"
 
 /*!

--- a/src/ws_boards.h
+++ b/src/ws_boards.h
@@ -244,6 +244,18 @@
 #define USE_TINYUSB
 #define USE_PSRAM
 #define BOOT_BUTTON 0
+#elif defined(WS_LILYGO_T_DONGLE_C5)
+#define BOARD_ID "lilygo-t-dongle-c5"      ///< Board ID
+#define USE_LITTLEFS                       ///< Use LittleFS for provisioning
+#define USE_STATUS_DOTSTAR                 ///< Onboard RGB LED is an APA102/DotStar
+#define STATUS_DOTSTAR_PIN_DATA 5          ///< DotStar Data Pin (LED_DI)
+#define STATUS_DOTSTAR_PIN_CLK 4           ///< DotStar Clock Pin (LED_CI)
+#define STATUS_DOTSTAR_NUM 1               ///< Number of DotStar LEDs
+#define STATUS_DOTSTAR_COLOR_ORDER DOTSTAR_BGR ///< DotStar Color Order
+#define BOOT_BUTTON 28                     ///< Normalized boot button pin
+#ifdef BOARD_HAS_PSRAM
+#define USE_PSRAM ///< Board has PSRAM, use it for dynamic memory allocation
+#endif
 #else
 #warning "Board type not identified within ws_boards.h!"
 #endif

--- a/src/ws_boards.h
+++ b/src/ws_boards.h
@@ -245,14 +245,14 @@
 #define USE_PSRAM
 #define BOOT_BUTTON 0
 #elif defined(WS_LILYGO_T_DONGLE_C5)
-#define BOARD_ID "lilygo-t-dongle-c5"      ///< Board ID
-#define USE_LITTLEFS                       ///< Use LittleFS for provisioning
-#define USE_STATUS_DOTSTAR                 ///< Onboard RGB LED is an APA102/DotStar
-#define STATUS_DOTSTAR_PIN_DATA 5          ///< DotStar Data Pin (LED_DI)
-#define STATUS_DOTSTAR_PIN_CLK 4           ///< DotStar Clock Pin (LED_CI)
-#define STATUS_DOTSTAR_NUM 1               ///< Number of DotStar LEDs
+#define BOARD_ID "lilygo-t-dongle-c5" ///< Board ID
+#define USE_LITTLEFS                  ///< Use LittleFS for provisioning
+#define USE_STATUS_DOTSTAR            ///< Onboard RGB LED is an APA102/DotStar
+#define STATUS_DOTSTAR_PIN_DATA 5     ///< DotStar Data Pin (LED_DI)
+#define STATUS_DOTSTAR_PIN_CLK 4      ///< DotStar Clock Pin (LED_CI)
+#define STATUS_DOTSTAR_NUM 1          ///< Number of DotStar LEDs
 #define STATUS_DOTSTAR_COLOR_ORDER DOTSTAR_BGR ///< DotStar Color Order
-#define BOOT_BUTTON 28                     ///< Normalized boot button pin
+#define BOOT_BUTTON 28                         ///< Normalized boot button pin
 #ifdef BOARD_HAS_PSRAM
 #define USE_PSRAM ///< Board has PSRAM, use it for dynamic memory allocation
 #endif


### PR DESCRIPTION
Adds WipperSnapper support for the **LilyGO T-Dongle C5** (ESP32-C5, 16 MB flash, 8 MB PSRAM), plus a new SPI **ST7735** display driver. Based on #943 (`api-v2-pins-as-strings`) for the string-pin i2c protos.

## Board support
- `ws_boards.h` block (`WS_LILYGO_T_DONGLE_C5`): LittleFS provisioning, APA102 **DotStar** status LED (data D5 / clk D4, BGR), BOOT button D28, PSRAM.
- LittleFS allowlist + `platformio.ini` env (`board = esp32-c5-devkitc1-n16r4`, 16 MB, littlefs).
- `sleep/hardware.cpp`: add ESP32-C5 to the no-`ext0` wakeup branch (C5 has no `esp_sleep_enable_ext0_wakeup`).

## ST7735 SPI display driver
- New `dispDrvSt7735` (`Adafruit_ST7735`), registered in `beginSpiTft`.
- Uses `INITR_MINI160x80_PLUGIN` (colstart 26 / rowstart 1, BGR, inverted) to match the 0.96" 160x80 panel.
- **Backlight from the display Add proto**, honoring `is_inverted` (the T-Dongle drives LCD_BL active-low). `beginSpiTft` now reads the `BacklightConfig` digital/pwm pin instead of relying only on `TFT_BACKLITE`.

## HIL-verified on real hardware
Boots, WiFi, checkin, i2c scan finds an HTU31D at 0x40 (SDA=11/SCL=12), and the ST7735 panel renders the status bar + text upright with correct offset/colours.

Companion PRs: adafruit/protomq#4 (test scripts) and the Wippersnapper_Boards definition/magic.json.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>