### PR TITLE
api-v2: pin-name review fixes + expander pin resolution utility (#943 follow-up)

### DIFF
--- a/src/components/analogIn/controller.cpp
+++ b/src/components/analogIn/controller.cpp
@@ -131,8 +131,10 @@ AnalogInHardware *AnalogInController::GetPin(uint8_t pin_num,
 bool AnalogInController::Handle_AnalogInAdd(ws_analogin_Add *msg) {
   WS_DEBUG_PRINTLN("[analogin] Handle_AnalogInAdd MESSAGE...");
   uint8_t pin_num = 0;
-  if (!ExpanderHardware::ParsePinNum(msg->pin_name, pin_num)) {
-    WS_DEBUG_PRINTLN("[analogin] ERROR: Malformed expander pin name!");
+  ExpanderHardware *expander_drv = nullptr;
+  if (!Ws._expander_controller->ResolvePinName(msg->pin_name, pin_num,
+                                               &expander_drv)) {
+    WS_DEBUG_PRINTLN("[analogin] ERROR: Unable to resolve pin name!");
     return false;
   }
 
@@ -147,17 +149,6 @@ bool AnalogInController::Handle_AnalogInAdd(ws_analogin_Add *msg) {
       msg->sample_mode != ws_analogin_SampleMode_SM_EVENT) {
     WS_DEBUG_PRINTLN("[analogin] ERROR: Invalid sample mode in message!");
     return false;
-  }
-
-  // Resolve the expander driver if this is an expander pin
-  ExpanderHardware *expander_drv = nullptr;
-  if (strncmp(msg->pin_name, "EXP_", 4) == 0) {
-    uint8_t i2c_addr = (uint8_t)strtoul(msg->pin_name + 4, nullptr, 16);
-    expander_drv = Ws._expander_controller->GetDriver(i2c_addr);
-    if (!expander_drv) {
-      WS_DEBUG_PRINTLN("[analogin] ERROR: Expander not found for address!");
-      return false;
-    }
   }
 
   // If pin is being updated, remove the existing pin first
@@ -200,20 +191,11 @@ bool AnalogInController::Handle_AnalogInAdd(ws_analogin_Add *msg) {
 */
 bool AnalogInController::Handle_AnalogInRemove(ws_analogin_Remove *msg) {
   uint8_t pin_num = 0;
-  if (!ExpanderHardware::ParsePinNum(msg->pin_name, pin_num)) {
-    WS_DEBUG_PRINTLN("[analogin] ERROR: Malformed expander pin name!");
-    return false;
-  }
-
-  // Resolve the expander driver if this is an expander pin
   ExpanderHardware *expander_drv = nullptr;
-  if (strncmp(msg->pin_name, "EXP_", 4) == 0) {
-    uint8_t i2c_addr = (uint8_t)strtoul(msg->pin_name + 4, nullptr, 16);
-    expander_drv = Ws._expander_controller->GetDriver(i2c_addr);
-    if (!expander_drv) {
-      WS_DEBUG_PRINTLN("[analogin] ERROR: Expander not found for address!");
-      return false;
-    }
+  if (!Ws._expander_controller->ResolvePinName(msg->pin_name, pin_num,
+                                               &expander_drv)) {
+    WS_DEBUG_PRINTLN("[analogin] ERROR: Unable to resolve pin name!");
+    return false;
   }
 
   if (!RemovePin(pin_num, expander_drv)) {

--- a/src/components/digitalIO/controller.cpp
+++ b/src/components/digitalIO/controller.cpp
@@ -138,22 +138,13 @@ bool DigitalIOController::Handle_DigitalIO_Add(ws_digitalio_Add *msg) {
     return false;
   }
 
-  if (!ExpanderHardware::ParsePinNum(msg->pin_name, pin_num)) {
-    Ws.error_handler->publishComponentError(msg->pin_name,
-                                            "Malformed pin name");
-    return false;
-  }
-
-  // Resolve the expander driver if this is an expander pin
+  // Resolve the pin number and owning expander driver (if any)
   ExpanderHardware *expander_drv = nullptr;
-  if (strncmp(msg->pin_name, "EXP_", 4) == 0) {
-    uint8_t i2c_addr = (uint8_t)strtoul(msg->pin_name + 4, nullptr, 16);
-    expander_drv = Ws._expander_controller->GetDriver(i2c_addr);
-    if (!expander_drv) {
-      Ws.error_handler->publishComponentError(msg->pin_name,
-                                              "Expander not found");
-      return false;
-    }
+  if (!Ws._expander_controller->ResolvePinName(msg->pin_name, pin_num,
+                                               &expander_drv)) {
+    Ws.error_handler->publishComponentError(msg->pin_name,
+                                            "Unable to resolve pin name");
+    return false;
   }
 
   // Remove existing pin if re-adding (destructor deinits hardware)
@@ -195,20 +186,11 @@ bool DigitalIOController::Handle_DigitalIO_Add(ws_digitalio_Add *msg) {
 */
 bool DigitalIOController::Handle_DigitalIO_Remove(ws_digitalio_Remove *msg) {
   uint8_t pin_num = 0;
-  if (!ExpanderHardware::ParsePinNum(msg->pin_name, pin_num)) {
-    WS_DEBUG_PRINTLN("[dio] ERROR: Malformed expander pin name!");
-    return false;
-  }
-
-  // Resolve the expander driver if this is an expander pin
   ExpanderHardware *expander_drv = nullptr;
-  if (strncmp(msg->pin_name, "EXP_", 4) == 0) {
-    uint8_t i2c_addr = (uint8_t)strtoul(msg->pin_name + 4, nullptr, 16);
-    expander_drv = Ws._expander_controller->GetDriver(i2c_addr);
-    if (!expander_drv) {
-      WS_DEBUG_PRINTLN("[dio] ERROR: Expander not found for address!");
-      return false;
-    }
+  if (!Ws._expander_controller->ResolvePinName(msg->pin_name, pin_num,
+                                               &expander_drv)) {
+    WS_DEBUG_PRINTLN("[dio] ERROR: Unable to resolve pin name!");
+    return false;
   }
 
   if (!RemovePin(pin_num, expander_drv)) {
@@ -251,22 +233,12 @@ DigitalIOHardware *DigitalIOController::GetPin(uint8_t pin_num,
 */
 bool DigitalIOController::Handle_DigitalIO_Write(ws_digitalio_Write *msg) {
   uint8_t pin_num = 0;
-  if (!ExpanderHardware::ParsePinNum(msg->pin_name, pin_num)) {
-    Ws.error_handler->publishComponentError(msg->pin_name,
-                                            "Malformed pin name");
-    return false;
-  }
-
-  // Resolve the expander driver if this is an expander pin
   ExpanderHardware *expander_drv = nullptr;
-  if (strncmp(msg->pin_name, "EXP_", 4) == 0) {
-    uint8_t i2c_addr = (uint8_t)strtoul(msg->pin_name + 4, nullptr, 16);
-    expander_drv = Ws._expander_controller->GetDriver(i2c_addr);
-    if (!expander_drv) {
-      Ws.error_handler->publishComponentError(msg->pin_name,
-                                              "Expander not found");
-      return false;
-    }
+  if (!Ws._expander_controller->ResolvePinName(msg->pin_name, pin_num,
+                                               &expander_drv)) {
+    Ws.error_handler->publishComponentError(msg->pin_name,
+                                            "Unable to resolve pin name");
+    return false;
   }
 
   DigitalIOHardware *pin = GetPin(pin_num, expander_drv);

--- a/src/components/expander/controller.cpp
+++ b/src/components/expander/controller.cpp
@@ -132,6 +132,33 @@ ExpanderHardware *ExpanderController::GetDriver(uint8_t addr) {
   return nullptr;
 }
 
+/*!
+ * @brief Resolves a pin name to a pin number and, for expander pin names
+ *        ("EXP_0xNN_P"), the owning expander driver. Lets other components
+ *        (digitalio, analogio, pwm, ...) resolve a pin without knowing the
+ *        expander addressing scheme, analogous to
+ *        DigitalIOController::QueryPinState() for pin-in-use queries.
+ * @param pin_name     The pin name string, native ("D5", "A0") or expander
+ *                     ("EXP_0x48_3").
+ * @param pin_num      Out: the pin number — for expander pins this is the
+ *                     pin (channel) index on that expander.
+ * @param expander_drv Out: the owning expander driver, or nullptr for a
+ *                     native MCU pin.
+ * @return True if resolved, False if the pin name is malformed or no
+ *         expander is registered at the referenced address.
+ */
+bool ExpanderController::ResolvePinName(const char *pin_name, uint8_t &pin_num,
+                                        ExpanderHardware **expander_drv) {
+  *expander_drv = nullptr;
+  if (!ExpanderHardware::ParsePinNum(pin_name, pin_num))
+    return false;
+  int32_t addr = WsPinNameToExpanderAddr(pin_name);
+  if (addr == WS_PIN_INVALID)
+    return true; // Native MCU pin, no expander driver
+  *expander_drv = GetDriver((uint8_t)addr);
+  return *expander_drv != nullptr;
+}
+
 /// Pointer to an expander setter that applies one decoded setting value.
 typedef bool (ExpanderHardware::*ExpanderSetterFn)(const ws_config_Value &);
 

--- a/src/components/expander/controller.h
+++ b/src/components/expander/controller.h
@@ -41,6 +41,8 @@ public:
   bool Handle_Add(ws_expander_Add *msg);
   bool Handle_Remove(ws_expander_Remove *msg);
   ExpanderHardware *GetDriver(uint8_t addr);
+  bool ResolvePinName(const char *pin_name, uint8_t &pin_num,
+                      ExpanderHardware **expander_drv);
 
 private:
   bool AddExpander(const char *device_name, uint8_t i2c_addr, TwoWire *wire);

--- a/src/components/expander/hardware.h
+++ b/src/components/expander/hardware.h
@@ -16,6 +16,7 @@
  */
 #ifndef WS_EXPANDER_HARDWARE_H
 #define WS_EXPANDER_HARDWARE_H
+#include "helpers/ws_helper_pins.h"
 #include <Arduino.h>
 #include <Wire.h>
 #include <protos/config.pb.h>
@@ -40,19 +41,17 @@ public:
   uint8_t getAddress() const { return _i2c_addr; }
 
   /*!  @brief  Parses pin number from a pin name string. Handles both
-               native ("A0", "D5") and expander ("EXP_0x48_0") formats.
+               native ("A0", "D5") and expander ("EXP_0x48_0") formats —
+               for expander pins the parsed number is the pin (channel)
+               index on that expander (see WsPinNameToNum()).
        @param  pin_name  The pin name string.
        @param  pin_num   Output: the parsed pin number.
        @return True if parsed successfully, false if malformed. */
   static bool ParsePinNum(const char *pin_name, uint8_t &pin_num) {
-    if (strncmp(pin_name, "EXP_", 4) == 0) {
-      const char *pin_str = strchr(pin_name + 4, '_');
-      if (!pin_str)
-        return false;
-      pin_num = atoi(pin_str + 1);
-    } else {
-      pin_num = atoi(pin_name + 1);
-    }
+    int32_t num = WsPinNameToNum(pin_name);
+    if (num == WS_PIN_INVALID || num > 0xFF)
+      return false;
+    pin_num = (uint8_t)num;
     return true;
   }
 

--- a/src/components/i2c/controller.cpp
+++ b/src/components/i2c/controller.cpp
@@ -1056,8 +1056,9 @@ TwoWire *I2cController::GetI2cBusByIndex(size_t index) {
 I2cHardware *I2cController::findOrCreateBus(const char *pin_scl,
                                             const char *pin_sda) {
   // Resolve the pin names to pin numbers
-  uint32_t scl_num, sda_num;
-  if (!WsPinNameToNum(pin_scl, scl_num) || !WsPinNameToNum(pin_sda, sda_num)) {
+  int32_t scl_num = WsPinNameToNum(pin_scl);
+  int32_t sda_num = WsPinNameToNum(pin_sda);
+  if (scl_num == WS_PIN_INVALID || sda_num == WS_PIN_INVALID) {
     WS_DEBUG_PRINTLN("[i2c] ERROR: Invalid SCL/SDA pin name!");
     return nullptr;
   }
@@ -1066,8 +1067,8 @@ I2cHardware *I2cController::findOrCreateBus(const char *pin_scl,
   for (I2cHardware *bus : _i2c_buses) {
     if (bus == nullptr)
       continue;
-    if (scl_num == (uint32_t)bus->getSCL() &&
-        sda_num == (uint32_t)bus->getSDA()) {
+    if (scl_num == (int32_t)bus->getSCL() &&
+        sda_num == (int32_t)bus->getSDA()) {
       return bus;
     }
   }
@@ -1111,14 +1112,15 @@ bool I2cController::IsBusStatusOK(I2cHardware *bus) {
     @returns  Pointer to the TwoWire bus, or nullptr if the bus doesn't exist.
 */
 TwoWire *I2cController::GetI2cBus(const char *pin_scl, const char *pin_sda) {
-  uint32_t scl_num, sda_num;
-  if (!WsPinNameToNum(pin_scl, scl_num) || !WsPinNameToNum(pin_sda, sda_num))
+  int32_t scl_num = WsPinNameToNum(pin_scl);
+  int32_t sda_num = WsPinNameToNum(pin_sda);
+  if (scl_num == WS_PIN_INVALID || sda_num == WS_PIN_INVALID)
     return nullptr;
   for (I2cHardware *bus : _i2c_buses) {
     if (bus == nullptr)
       continue;
-    if (scl_num == (uint32_t)bus->getSCL() &&
-        sda_num == (uint32_t)bus->getSDA()) {
+    if (scl_num == (int32_t)bus->getSCL() &&
+        sda_num == (int32_t)bus->getSDA()) {
       return bus->GetBus();
     }
   }

--- a/src/components/i2c/drivers/drvBase.h
+++ b/src/components/i2c/drivers/drvBase.h
@@ -26,6 +26,13 @@
 struct DecodedSetting;    ///< Forward declaration
 #define NO_MUX_CH 0xFFFF; ///< No MUX channel specified
 
+/*! Size of the device name buffer, exactly matches ws_i2c_Add.name in
+    i2c.pb.h */
+#define DRV_BASE_NAME_LEN (sizeof(((ws_i2c_Add *)0)->name))
+/*! Size of the pin name buffers, exactly matches
+    ws_i2c_AddressSpace.pin_scl/pin_sda in i2c.pb.h */
+#define DRV_BASE_PIN_NAME_LEN (sizeof(((ws_i2c_AddressSpace *)0)->pin_scl))
+
 /*!
     @brief  Base class for I2C Drivers.
 */
@@ -858,16 +865,18 @@ public:
   ws_i2c_Add_TypesEntry _sensors[16]; ///< Keyed sensor types from broker.
 
 protected:
-  TwoWire *_i2c;             ///< Pointer to the TwoWire bus
-  uint16_t _address;         ///< The device's I2C address.
-  uint32_t _i2c_mux_addr;    ///< The I2C MUX address, if applicable.
-  uint32_t _i2c_mux_channel; ///< The I2C MUX channel, if applicable.
-  char _name[15];            ///< The device's name.
-  char _pin_scl[32];         ///< The SCL pin name for this driver's bus.
-  char _pin_sda[32];         ///< The SDA pin name for this driver's bus.
-  ulong _sensor_period;      ///< The sensor's period, in milliseconds.
-  ulong _sensor_period_prv;  ///< The sensor's previous period, in milliseconds.
-  size_t _sensors_count;     ///< Number of sensors on the device.
+  TwoWire *_i2c;                        ///< Pointer to the TwoWire bus
+  uint16_t _address;                    ///< The device's I2C address.
+  uint32_t _i2c_mux_addr;               ///< The I2C MUX address, if applicable.
+  uint32_t _i2c_mux_channel;            ///< The I2C MUX channel, if applicable.
+  char _name[DRV_BASE_NAME_LEN];        ///< The device's name.
+  char _pin_scl[DRV_BASE_PIN_NAME_LEN]; ///< The SCL pin name for this
+                                        ///< driver's bus.
+  char _pin_sda[DRV_BASE_PIN_NAME_LEN]; ///< The SDA pin name for this
+                                        ///< driver's bus.
+  ulong _sensor_period;     ///< The sensor's period, in milliseconds.
+  ulong _sensor_period_prv; ///< The sensor's previous period, in milliseconds.
+  size_t _sensors_count;    ///< Number of sensors on the device.
   bool _did_read_send; ///< True if data was read and sent to IO successfully.
 };
 #endif // DRV_BASE_H

--- a/src/components/pwm/controller.cpp
+++ b/src/components/pwm/controller.cpp
@@ -72,20 +72,11 @@ bool PWMController::Router(pb_istream_t *stream) {
 */
 bool PWMController::Handle_PWM_Add(ws_pwm_Add *msg) {
   uint8_t pin = 0;
-  if (!ExpanderHardware::ParsePinNum(msg->pin, pin)) {
-    Ws.error_handler->publishComponentError(msg->pin, "Malformed pin name");
-    return false;
-  }
-
-  // Resolve the expander driver if this is an expander pin
   ExpanderHardware *expander_drv = nullptr;
-  if (strncmp(msg->pin, "EXP_", 4) == 0) {
-    uint8_t i2c_addr = (uint8_t)strtoul(msg->pin + 4, nullptr, 16);
-    expander_drv = Ws._expander_controller->GetDriver(i2c_addr);
-    if (!expander_drv) {
-      Ws.error_handler->publishComponentError(msg->pin, "Expander not found");
-      return false;
-    }
+  if (!Ws._expander_controller->ResolvePinName(msg->pin, pin, &expander_drv)) {
+    Ws.error_handler->publishComponentError(msg->pin,
+                                            "Unable to resolve pin name");
+    return false;
   }
 
   // If pin already exists, remove it before re-adding (for updates)
@@ -115,20 +106,11 @@ bool PWMController::Handle_PWM_Add(ws_pwm_Add *msg) {
 */
 bool PWMController::Handle_PWM_Remove(ws_pwm_Remove *msg) {
   uint8_t pin = 0;
-  if (!ExpanderHardware::ParsePinNum(msg->pin, pin)) {
-    Ws.error_handler->publishComponentError(msg->pin, "Malformed pin name");
-    return false;
-  }
-
-  // Resolve the expander driver if this is an expander pin
   ExpanderHardware *expander_drv = nullptr;
-  if (strncmp(msg->pin, "EXP_", 4) == 0) {
-    uint8_t i2c_addr = (uint8_t)strtoul(msg->pin + 4, nullptr, 16);
-    expander_drv = Ws._expander_controller->GetDriver(i2c_addr);
-    if (!expander_drv) {
-      Ws.error_handler->publishComponentError(msg->pin, "Expander not found");
-      return false;
-    }
+  if (!Ws._expander_controller->ResolvePinName(msg->pin, pin, &expander_drv)) {
+    Ws.error_handler->publishComponentError(msg->pin,
+                                            "Unable to resolve pin name");
+    return false;
   }
 
   if (!RemovePin(pin, expander_drv)) {
@@ -180,20 +162,11 @@ PWMHardware *PWMController::GetPin(uint8_t pin, ExpanderHardware *expander) {
 */
 bool PWMController::Handle_PWM_Write(ws_pwm_Write *msg) {
   uint8_t pin = 0;
-  if (!ExpanderHardware::ParsePinNum(msg->pin, pin)) {
-    Ws.error_handler->publishComponentError(msg->pin, "Malformed pin name");
-    return false;
-  }
-
-  // Resolve the expander driver if this is an expander pin
   ExpanderHardware *expander_drv = nullptr;
-  if (strncmp(msg->pin, "EXP_", 4) == 0) {
-    uint8_t i2c_addr = (uint8_t)strtoul(msg->pin + 4, nullptr, 16);
-    expander_drv = Ws._expander_controller->GetDriver(i2c_addr);
-    if (!expander_drv) {
-      Ws.error_handler->publishComponentError(msg->pin, "Expander not found");
-      return false;
-    }
+  if (!Ws._expander_controller->ResolvePinName(msg->pin, pin, &expander_drv)) {
+    Ws.error_handler->publishComponentError(msg->pin,
+                                            "Unable to resolve pin name");
+    return false;
   }
 
   PWMHardware *hw = GetPin(pin, expander_drv);

--- a/src/components/uart/controller.cpp
+++ b/src/components/uart/controller.cpp
@@ -90,8 +90,8 @@ bool UARTController::Handle_UartAdd(ws_uart_Add *msg) {
   }
 
   // Have we already added this UART port?
-  uint32_t port;
-  if (!WsPinNameToNum(msg->descriptor.pin_rx, port)) {
+  int32_t port = WsPinNameToNum(msg->descriptor.pin_rx);
+  if (port == WS_PIN_INVALID) {
     Ws.error_handler->publishComponentError(msg->descriptor,
                                             "Invalid RX pin name");
     return false;
@@ -180,8 +180,8 @@ bool UARTController::Handle_UartAdd(ws_uart_Add *msg) {
 bool UARTController::Handle_UartRemove(ws_uart_Remove *msg) {
 
   // Find the corresponding hardware instance for the UART port
-  uint32_t port_num;
-  if (!WsPinNameToNum(msg->descriptor.pin_rx, port_num)) {
+  int32_t port_num = WsPinNameToNum(msg->descriptor.pin_rx);
+  if (port_num == WS_PIN_INVALID) {
     Ws.error_handler->publishComponentError(msg->descriptor,
                                             "Invalid RX pin name");
     return false;
@@ -193,7 +193,7 @@ bool UARTController::Handle_UartRemove(ws_uart_Remove *msg) {
       for (std::vector<drvUartBase *>::iterator driver_it =
                _uart_drivers.begin();
            driver_it != _uart_drivers.end(); ++driver_it) {
-        if ((*driver_it)->GetPortNum() == port_num) {
+        if ((*driver_it)->GetPortNum() == (uint32_t)port_num) {
           // Driver found, remove it
           delete *driver_it;
           _uart_drivers.erase(driver_it);

--- a/src/components/uart/drivers/drvUartBase.h
+++ b/src/components/uart/drivers/drvUartBase.h
@@ -22,6 +22,13 @@
 #include <protos/sensor.pb.h>
 #include <protos/uart.pb.h>
 
+/*! Size of the device name buffer, exactly matches ws_uart_Add.name in
+    uart.pb.h */
+#define DRV_UART_NAME_LEN (sizeof(((ws_uart_Add *)0)->name))
+/*! Size of the pin name buffers, exactly matches ws_uart_Descriptor.pin_rx
+    in uart.pb.h */
+#define DRV_UART_PIN_NAME_LEN (sizeof(((ws_uart_Descriptor *)0)->pin_rx))
+
 /*!
     @brief  Base class for UART Drivers.
 */
@@ -346,12 +353,13 @@ public:
 protected:
   HardwareSerial *_hw_serial; ///< Pointer to a HardwareSerial instance
 #if HAS_SW_SERIAL
-  SoftwareSerial *_sw_serial; ///< Pointer to a SoftwareSerial instance
-#endif                        // HAS_SW_SERIAL
-  char _name[32];             ///< The device's name
-  char _port_name[32] = {0};  ///< The RX pin name for the UART device
-  uint32_t _port_num = 0;     ///< The port number for the UART device, resolved
-                              ///< from the RX pin name
+  SoftwareSerial *_sw_serial;    ///< Pointer to a SoftwareSerial instance
+#endif                           // HAS_SW_SERIAL
+  char _name[DRV_UART_NAME_LEN]; ///< The device's name
+  char _port_name[DRV_UART_PIN_NAME_LEN] = {
+      0};                 ///< The RX pin name for the UART device
+  uint32_t _port_num = 0; ///< The port number for the UART device, resolved
+                          ///< from the RX pin name
 
   /*!
       @brief    Stores the RX pin name and resolves it to a port number.
@@ -361,8 +369,8 @@ protected:
   void SetPortName(const char *port_name) {
     strncpy(_port_name, port_name, sizeof(_port_name) - 1);
     _port_name[sizeof(_port_name) - 1] = '\0';
-    if (!WsPinNameToNum(_port_name, _port_num))
-      _port_num = 0;
+    int32_t port_num = WsPinNameToNum(_port_name);
+    _port_num = (port_num == WS_PIN_INVALID) ? 0 : (uint32_t)port_num;
   }
   bool _is_software_serial =
       false; ///< Indicates if this driver uses SoftwareSerial

--- a/src/components/uart/hardware.cpp
+++ b/src/components/uart/hardware.cpp
@@ -25,8 +25,13 @@ UARTHardware::UARTHardware(const ws_uart_SerialConfig &config,
   _config = config;
   _pin_rx = 0;
   _pin_tx = 0;
-  _pins_valid =
-      WsPinNameToNum(pin_rx, _pin_rx) && WsPinNameToNum(pin_tx, _pin_tx);
+  int32_t rx_num = WsPinNameToNum(pin_rx);
+  int32_t tx_num = WsPinNameToNum(pin_tx);
+  _pins_valid = (rx_num != WS_PIN_INVALID) && (tx_num != WS_PIN_INVALID);
+  if (_pins_valid) {
+    _pin_rx = (uint32_t)rx_num;
+    _pin_tx = (uint32_t)tx_num;
+  }
 }
 
 /*!

--- a/src/helpers/ws_helper_pins.h
+++ b/src/helpers/ws_helper_pins.h
@@ -16,49 +16,81 @@
 #define WS_HELPER_PINS_H
 #include <Arduino.h>
 #include <ctype.h>
+#include <stdlib.h>
+
+#define WS_PIN_INVALID -1 ///< Returned when a pin name fails to resolve
+
+/*!
+    @brief  Parses an expander pin name ("EXP_0xNN_P") and returns the
+            expander's I2C address. Use this to detect expander pins and
+            to look up the owning driver, e.g. via
+            ExpanderController::GetDriver().
+    @param  pin_name
+            The pin name string to parse.
+    @returns The expander's I2C address, or WS_PIN_INVALID if the name is
+             not a well-formed expander pin name.
+*/
+inline int32_t WsPinNameToExpanderAddr(const char *pin_name) {
+  if (pin_name == nullptr || strncmp(pin_name, "EXP_", 4) != 0)
+    return WS_PIN_INVALID;
+  char *end = nullptr;
+  unsigned long addr = strtoul(pin_name + 4, &end, 16);
+  if (end == pin_name + 4 || *end != '_' || addr > 0x7F)
+    return WS_PIN_INVALID;
+  return (int32_t)addr;
+}
 
 /*!
     @brief  Resolves a pin name string to a pin number. Accepts numeric
-            strings ("22"), prefixed pin names ("D22", "A4", "GPIO22"), and
-            the board-defined I2C pin names ("SDA", "SCL", and "SDA1"/"SCL1"
-            on boards with a second hardware I2C port).
+            strings ("22"), prefixed pin names ("D22", "A4", "GPIO22"), the
+            board-defined I2C pin names ("SDA", "SCL", and "SDA1"/"SCL1"
+            on boards with a second hardware I2C port), and expander pin
+            names ("EXP_0x48_3"). For expander pins the returned number is
+            the pin (channel) index on that expander — e.g. channels 0-7
+            and spare GPIO 8-15 on a 16-channel driver — scoped to the
+            expander identified by WsPinNameToExpanderAddr(), not a native
+            MCU pin.
     @param  pin_name
             The pin name string to resolve.
-    @param  pin_num
-            Output: the resolved pin number.
-    @returns True if the pin name was resolved, False if the pin name is
-             NULL, empty, or contains no pin number.
+    @returns The resolved pin number, or WS_PIN_INVALID if the pin name is
+             NULL, empty, malformed, or contains no pin number.
 */
-inline bool WsPinNameToNum(const char *pin_name, uint32_t &pin_num) {
+inline int32_t WsPinNameToNum(const char *pin_name) {
   if (pin_name == nullptr || pin_name[0] == '\0')
-    return false;
+    return WS_PIN_INVALID;
+  // Expander pin names ("EXP_0xNN_P") resolve to the pin index on the
+  // expander at address 0xNN
+  if (strncmp(pin_name, "EXP_", 4) == 0) {
+    if (WsPinNameToExpanderAddr(pin_name) == WS_PIN_INVALID)
+      return WS_PIN_INVALID;
+    const char *pin_str = strchr(pin_name + 4, '_');
+    if (pin_str == nullptr || !isdigit((unsigned char)pin_str[1]))
+      return WS_PIN_INVALID;
+    return (int32_t)atoi(pin_str + 1);
+  }
   // Board-defined I2C pin names (CircuitPython/Blinka-style)
-  if (strcmp(pin_name, "SDA") == 0) {
-    pin_num = (uint32_t)SDA;
-    return true;
-  }
-  if (strcmp(pin_name, "SCL") == 0) {
-    pin_num = (uint32_t)SCL;
-    return true;
-  }
+  if (strcmp(pin_name, "SDA") == 0)
+    return (int32_t)SDA;
+  if (strcmp(pin_name, "SCL") == 0)
+    return (int32_t)SCL;
 #if defined(PIN_WIRE1_SDA) && defined(PIN_WIRE1_SCL)
-  if (strcmp(pin_name, "SDA1") == 0) {
-    pin_num = (uint32_t)PIN_WIRE1_SDA;
-    return true;
-  }
-  if (strcmp(pin_name, "SCL1") == 0) {
-    pin_num = (uint32_t)PIN_WIRE1_SCL;
-    return true;
-  }
+  if (strcmp(pin_name, "SDA1") == 0)
+    return (int32_t)PIN_WIRE1_SDA;
+  if (strcmp(pin_name, "SCL1") == 0)
+    return (int32_t)PIN_WIRE1_SCL;
+#elif defined(SDA1) && defined(SCL1)
+  if (strcmp(pin_name, "SDA1") == 0)
+    return (int32_t)SDA1;
+  if (strcmp(pin_name, "SCL1") == 0)
+    return (int32_t)SCL1;
 #endif
   // Skip a non-numeric prefix, e.g. "D22", "A4", "GPIO22"
   const char *numeric = pin_name;
   while (*numeric && !isdigit((unsigned char)*numeric))
     numeric++;
   if (*numeric == '\0')
-    return false;
-  pin_num = (uint32_t)atoi(numeric);
-  return true;
+    return WS_PIN_INVALID;
+  return (int32_t)atoi(numeric);
 }
 
 #endif // WS_HELPER_PINS_H


### PR DESCRIPTION
## Summary

Follow-up to #943, addressing the review comments there, plus the expander pin-resolution utility discussed in the `ws_helper_pins.h` thread (refs #936's `QueryPinState` pattern and the shared-pin issue #952).

## Review comments addressed

- **`WsPinNameToNum` signature** (@brentru): now `int32_t WsPinNameToNum(const char *pin_name)` returning `WS_PIN_INVALID` (-1) on failure — no more out-param that could be left uninitialized. All i2c/uart call sites updated to assign-and-validate.
- **`EXP_` check at the front** (@brentru): `"EXP_0xNN_P"` resolves to `P`, the pin (**channel**) index on the expander at address `0xNN` — matching the 16-channel solenoid-driver paradigm where 0–7 are the A-channel transistor-backed GPIO and 8–15 the spare B-channel GPIO. A companion `WsPinNameToExpanderAddr()` returns the expander's I2C address (also serving as the "is this an expander pin" test).
- **Pass off to the expander controller** (@tyeth, analogous to `QueryPinState` from #936): new `ExpanderController::ResolvePinName(pin_name, pin_num, &expander_drv)` resolves any pin name to its number and, for expander names, the owning `ExpanderHardware*` (nullptr for native pins). The eight duplicated `ParsePinNum` + `strtoul` + `GetDriver` blocks in digitalio/analogio/pwm now route through it, and `ExpanderHardware::ParsePinNum` delegates to `WsPinNameToNum` — malformed expander names now fail instead of silently parsing as pin 0.
- **Buffer sizes `#define`'d to exactly match the pb** (@brentru): `drvBase.h` defines `DRV_BASE_NAME_LEN` / `DRV_BASE_PIN_NAME_LEN` as `sizeof()` of the `ws_i2c_Add.name` / `ws_i2c_AddressSpace.pin_scl` pb fields (fixes `_name[15]` vs the pb's `name[16]`); `drvUartBase.h` likewise sizes `_name` / `_port_name` from `ws_uart_Add.name` / `ws_uart_Descriptor.pin_rx`. Tied to the pb via `sizeof`, they can't drift when the protos are regenerated.
- **SDA1/SCL1** (@tyeth): added the `#elif defined(SDA1) && defined(SCL1)` fallback for cores that define the bare macros rather than `PIN_WIRE1_*`.

## Expander pin paradigm (why the channel index)

For an `EXP_` pin the "pin number" is the channel index scoped to that expander, exactly as the existing digitalio/analogio/pwm expander support treats it — `(expander_drv, pin_num)` pairs are the identity everywhere. A hypothetical board that routes header pins through an onboard expander (e.g. an Arduino Nesso-style port) would surface those pins as `EXP_<addr>_<n>` names and resolve through the same two calls: `WsPinNameToNum()` for the channel, `WsPinNameToExpanderAddr()` → `ExpanderController::GetDriver()` (or just `ResolvePinName()`) for the owning driver — no per-component parsing required.

## Deliberately out of scope

- **Shrinking the pb pin fields 32 → 16 chars** (@brentru): needs the field width changed in adafruit/Wippersnapper_Protobuf and a nanopb regen; the `sizeof`-based defines here will pick it up automatically when that lands.
- **Error-handler / signal-encoder fixes in #943** (@brentru asked for a separate PR against `migrate-api-v2`): untouched here.
- Refcounted shared pin/rail ownership remains tracked in #952.

## Build verification

CI on this PR; local `adafruit_feather_esp32s3` build was still in flight when pushed (will follow up with the result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)