### PR TITLE
fix: memset nanopb message re-inits instead of init_zero assignment (ESP8266 GCC)

### DIFF
--- a/src/components/error/handler.cpp
+++ b/src/components/error/handler.cpp
@@ -38,7 +38,13 @@ static bool encode_string_callback(pb_ostream_t *stream,
 /*!
     @brief  ErrorHandler constructor
 */
-ErrorHandler::ErrorHandler() { memset(&_d2b_msg, 0, sizeof(_d2b_msg)); }
+ErrorHandler::ErrorHandler() {
+  // NOTE: memset, not `_d2b_msg = ws_error_D2B_init_zero;` - ESP8266's GCC
+  // rejects braced-list re-assignment now that the initializer contains
+  // string-literal char-array members (the pin name fields). memset is
+  // bit-identical to init_zero for this all-static struct.
+  memset(&_d2b_msg, 0, sizeof(_d2b_msg));
+}
 
 /*!
     @brief  ErrorHandler destructor
@@ -137,6 +143,7 @@ bool ErrorHandler::HandleThrottle(const ws_error_ThrottleError &throttle) {
 */
 bool ErrorHandler::publishComponentError(const char *pin,
                                          const char *error_msg) {
+  // memset, not init_zero assignment - see note in ErrorHandler()
   memset(&_d2b_msg, 0, sizeof(_d2b_msg));
   _d2b_msg.which_payload = ws_error_D2B_component_tag;
 
@@ -165,6 +172,7 @@ bool ErrorHandler::publishComponentError(ws_i2c_Descriptor i2c,
   WS_DEBUG_PRINT(": ");
   WS_DEBUG_PRINTLNVAR(error_msg);
 
+  // memset, not init_zero assignment - see note in ErrorHandler()
   memset(&_d2b_msg, 0, sizeof(_d2b_msg));
   _d2b_msg.which_payload = ws_error_D2B_component_tag;
 
@@ -192,6 +200,7 @@ bool ErrorHandler::publishComponentError(ws_spi_Descriptor spi,
   WS_DEBUG_PRINT(": ");
   WS_DEBUG_PRINTLNVAR(error_msg);
 
+  // memset, not init_zero assignment - see note in ErrorHandler()
   memset(&_d2b_msg, 0, sizeof(_d2b_msg));
   _d2b_msg.which_payload = ws_error_D2B_component_tag;
 
@@ -214,6 +223,7 @@ bool ErrorHandler::publishComponentError(ws_spi_Descriptor spi,
 */
 bool ErrorHandler::publishComponentError(ws_uart_Descriptor uart,
                                          const char *error_msg) {
+  // memset, not init_zero assignment - see note in ErrorHandler()
   memset(&_d2b_msg, 0, sizeof(_d2b_msg));
   _d2b_msg.which_payload = ws_error_D2B_component_tag;
 

--- a/src/components/error/handler.cpp
+++ b/src/components/error/handler.cpp
@@ -38,7 +38,7 @@ static bool encode_string_callback(pb_ostream_t *stream,
 /*!
     @brief  ErrorHandler constructor
 */
-ErrorHandler::ErrorHandler() { _d2b_msg = ws_error_D2B_init_zero; }
+ErrorHandler::ErrorHandler() { memset(&_d2b_msg, 0, sizeof(_d2b_msg)); }
 
 /*!
     @brief  ErrorHandler destructor
@@ -137,7 +137,7 @@ bool ErrorHandler::HandleThrottle(const ws_error_ThrottleError &throttle) {
 */
 bool ErrorHandler::publishComponentError(const char *pin,
                                          const char *error_msg) {
-  _d2b_msg = ws_error_D2B_init_zero;
+  memset(&_d2b_msg, 0, sizeof(_d2b_msg));
   _d2b_msg.which_payload = ws_error_D2B_component_tag;
 
   ws_error_ComponentError *comp = &_d2b_msg.payload.component;
@@ -165,7 +165,7 @@ bool ErrorHandler::publishComponentError(ws_i2c_Descriptor i2c,
   WS_DEBUG_PRINT(": ");
   WS_DEBUG_PRINTLNVAR(error_msg);
 
-  _d2b_msg = ws_error_D2B_init_zero;
+  memset(&_d2b_msg, 0, sizeof(_d2b_msg));
   _d2b_msg.which_payload = ws_error_D2B_component_tag;
 
   ws_error_ComponentError *comp = &_d2b_msg.payload.component;
@@ -192,7 +192,7 @@ bool ErrorHandler::publishComponentError(ws_spi_Descriptor spi,
   WS_DEBUG_PRINT(": ");
   WS_DEBUG_PRINTLNVAR(error_msg);
 
-  _d2b_msg = ws_error_D2B_init_zero;
+  memset(&_d2b_msg, 0, sizeof(_d2b_msg));
   _d2b_msg.which_payload = ws_error_D2B_component_tag;
 
   ws_error_ComponentError *comp = &_d2b_msg.payload.component;
@@ -214,7 +214,7 @@ bool ErrorHandler::publishComponentError(ws_spi_Descriptor spi,
 */
 bool ErrorHandler::publishComponentError(ws_uart_Descriptor uart,
                                          const char *error_msg) {
-  _d2b_msg = ws_error_D2B_init_zero;
+  memset(&_d2b_msg, 0, sizeof(_d2b_msg));
   _d2b_msg.which_payload = ws_error_D2B_component_tag;
 
   ws_error_ComponentError *comp = &_d2b_msg.payload.component;

--- a/src/wippersnapper.cpp
+++ b/src/wippersnapper.cpp
@@ -734,7 +734,6 @@ bool wippersnapper::PublishD2b(pb_size_t which_payload, void *payload) {
 
   // Initialize DeviceToBroker message
   memset(msg, 0, sizeof(ws_signal_DeviceToBroker));
-  *msg = ws_signal_DeviceToBroker_init_zero;
 
   // Fill generic signal payload with the payload from the args.
   switch (which_payload) {

--- a/src/wippersnapper.cpp
+++ b/src/wippersnapper.cpp
@@ -733,6 +733,11 @@ bool wippersnapper::PublishD2b(pb_size_t which_payload, void *payload) {
   }
 
   // Initialize DeviceToBroker message
+  // NOTE: memset only - do not re-add `*msg =
+  // ws_signal_DeviceToBroker_init_zero;` ESP8266's GCC rejects braced-list
+  // re-assignment now that the initializer contains string-literal char-array
+  // members (the i2c/uart pin name fields). memset is bit-identical to
+  // init_zero for this all-static struct.
   memset(msg, 0, sizeof(ws_signal_DeviceToBroker));
 
   // Fill generic signal payload with the payload from the args.


### PR DESCRIPTION
## Summary

Splits the error-handler / signal-encoder fixes out of #943, per review there ("The error handler fixes should be in another PR against `migrate-api-v2`...").

## Changes

Replaces `_d2b_msg = ws_error_D2B_init_zero;` re-assignments in `ErrorHandler` (ctor + the four `publishComponentError` overloads) and the redundant `*msg = ws_signal_DeviceToBroker_init_zero;` after `memset` in `wippersnapper::PublishD2b` with plain `memset`.

**Why:** ESP8266's older GCC rejects braced-list *re-assignment* (as opposed to declaration-initialization) once the `init_zero` initializer contains string-literal char-array members — which happens as soon as the i2c/uart pin fields become `char[]` strings (#943 / adafruit/Wippersnapper_Protobuf#207). `memset` is bit-identical to `init_zero` for these all-static structs, so this is a no-op on `migrate-api-v2` today and unblocks the huzzah8266 build for #943.

The changes are byte-identical to the corresponding lines in #943, so once this merges, #943 rebases/merges over it without conflicts and its diff shrinks accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)