### PR TITLE
Dfrobot firebeetle2 esp32c5

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -174,6 +174,27 @@ build_flags =
 board_build.filesystem = littlefs
 board_build.partitions = min_spiffs.csv
 
+; DFRobot Firebeetle ESP32-C5
+[env:dfrobot-firebeetle2-esp32c5]
+extends = common:esp32
+board = esp32-c5-devkitc1-n4
+build_type = debug
+; debug_tool = esp-builtin
+; upload_protocol = esp-builtin
+; debug_init_break = tbreak setup
+build_flags =
+    -DWS_DFROBOT_FIREBEETLE2_ESP32C5
+    -DARDUINO_ESP32C5_DEV
+    -DDEBUG=1
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DESP_LOG_LEVEL=5
+    -DARDUINO_LOG_LEVEL=5
+    -DCORE_DEBUG_LEVEL=5
+    ; -DMQTT_DEBUG=1
+board_build.filesystem = littlefs
+board_build.partitions = min_spiffs.csv
+
 ; Espressif ESP32-C5 8MB FLASH 2MB PSRAM ESP32-C5-DevKitC-1
 [env:espressif_esp32-c5-devkitc-1-n8r4]
 extends = common:esp32

--- a/platformio.ini
+++ b/platformio.ini
@@ -101,7 +101,7 @@ lib_deps =
 
 ; Common build environment for ESP32 platform
 [common:esp32]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.33/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.36/platform-espressif32.zip
 ; This is needed for occasional new features and bug fixes
 ; platform = https://github.com/pioarduino/platform-espressif32#develop
 lib_ignore = WiFiNINA, WiFiNINA_-_Adafruit_Fork, WiFi101, OneWire

--- a/src/Wippersnapper_Boards.h
+++ b/src/Wippersnapper_Boards.h
@@ -171,6 +171,16 @@
 #define USE_STATUS_NEOPIXEL
 #define STATUS_NEOPIXEL_PIN PIN_NEOPIXEL
 #define STATUS_NEOPIXEL_NUM 1
+#elif defined(WS_DFROBOT_FIREBEETLE2_ESP32C5)
+#define BOARD_ID "dfrobot-firebeetle2-esp32c5"
+#define USE_LITTLEFS
+#define USE_STATUS_NEOPIXEL
+#define STATUS_NEOPIXEL_PIN PIN_RGB_LED
+// PIN_RGB_LED = 27, or GPIO_NUM+27 if using RGBwrite()
+#define STATUS_NEOPIXEL_NUM 1
+#ifdef BOARD_HAS_PSRAM
+#define USE_PSRAM ///< Board has PSRAM, use it for dynamic memory allocation
+#endif
 #elif defined(ARDUINO_ESP32C5_DEV)
 #define BOARD_ID "esp32c5-devkitc-1-n8r4"
 #define USE_LITTLEFS

--- a/src/components/display/drivers/dispDrvSt7789.h
+++ b/src/components/display/drivers/dispDrvSt7789.h
@@ -75,8 +75,13 @@ public:
       @return True if the display was initialized successfully, false otherwise.
   */
   bool begin() override {
-
-    _display = new Adafruit_ST7789(_pin_cs, _pin_dc, _pin_rst);
+    WS_DEBUG_PRINTLN("Initializing ST7789 display driver with these pins:");
+    WS_DEBUG_PRINTLN("  CS: " + String(_pin_cs));
+    WS_DEBUG_PRINTLN("  DC: " + String(_pin_dc));
+    WS_DEBUG_PRINTLN("  RST: " + String(_pin_rst));
+    WS_DEBUG_PRINTLN("  MOSI: " + String(_pin_mosi));
+    WS_DEBUG_PRINTLN("  SCK: " + String(_pin_sck));
+    _display = new Adafruit_ST7789(_pin_cs, _pin_dc, _pin_mosi, _pin_sck, _pin_rst);
     if (!_display)
       return false;
 

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -21,6 +21,7 @@
     defined(ARDUINO_SPARKLEMOTIONMINI_ESP32) ||                                \
     defined(ARDUINO_SPARKLEMOTIONSTICK_ESP32) ||                               \
     defined(ARDUINO_ADAFRUIT_QTPY_ESP32C3) ||                                  \
+    defined(WS_DFROBOT_FIREBEETLE2_ESP32C5) ||                                 \
     defined(ARDUINO_ADAFRUIT_FEATHER_ESP32C6) || defined(ARDUINO_ESP32C5_DEV)
 #include "WipperSnapper_LittleFS.h"
 


### PR DESCRIPTION
~~Needs boards.local.txt or board specific define to avoid esp32c5 clash w/ other entryless boards.
See #784~~

Has it's own board define in boards.txt, `DFROBOT_FIREBEETLE_2_ESP32C5`