### PR TITLE
ci: run migrate-api-v2 build on PRs targeting the branch

### DIFF
--- a/.github/workflows/build-migrate-api-v2.yml
+++ b/.github/workflows/build-migrate-api-v2.yml
@@ -149,6 +149,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: adafruit/Wippersnapper_Boards
+          ref: api-v2
           path: ws-boards
       - name: Install CI-Arduino
         run: bash ci/actions_install.sh
@@ -601,6 +602,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: adafruit/Wippersnapper_Boards
+          ref: api-v2
           path: ws-boards
       - name: Install CI-Arduino
         run: bash ci/actions_install.sh

--- a/.github/workflows/build-migrate-api-v2.yml
+++ b/.github/workflows/build-migrate-api-v2.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - migrate-api-v2
+  pull_request:
+    branches:
+      - migrate-api-v2
 
 jobs:
   build-esp32sx:

--- a/.github/workflows/build-migrate-api-v2.yml
+++ b/.github/workflows/build-migrate-api-v2.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - migrate-api-v2
   pull_request:
+    # 'edited' covers PRs retargeted to migrate-api-v2 after opening
+    types: [opened, synchronize, reopened, edited]
     branches:
       - migrate-api-v2
 


### PR DESCRIPTION
CI updates to `.github/workflows/build-migrate-api-v2.yml`:

- Adds a `pull_request` trigger so the migrate-api-v2 build CI also runs on PRs that target `migrate-api-v2`, not just pushes to it.
- Trigger types include `edited` so a PR retargeted to `migrate-api-v2` after opening still gets a build (base changes only fire `pull_request: edited`, which the default types miss).
- Pins both `adafruit/Wippersnapper_Boards` checkouts to `ref: api-v2` (previously they used the default branch, `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)