### PR TITLE
api-v2: address second review round on #943 (WsPinName struct, resolver semantics, digitalio cleanups)

### DIFF
--- a/src/components/digitalIO/hardware.cpp
+++ b/src/components/digitalIO/hardware.cpp
@@ -56,6 +56,23 @@ DigitalIOHardware::~DigitalIOHardware() {
 }
 
 /*!
+    @brief  Converts a logical pin value to the electrical level to drive.
+            The digitalio.proto `is_inverted` field marks active-low pins
+            (e.g. an LED wired to VCC): IO always speaks in logical values,
+            so inverted pins must drive the opposite electrical level.
+    @param  logical_value  The logical value from the broker's perspective.
+    @return HIGH or LOW, the electrical level to apply to the pin.
+*/
+uint8_t DigitalIOHardware::GetElectricalLevel(bool logical_value) {
+  bool level = logical_value;
+  if (_is_inverted)
+    level = !logical_value;
+  if (level)
+    return HIGH;
+  return LOW;
+}
+
+/*!
     @brief  Configures the pin's mode based on its direction.
     @return True if the pin was successfully configured.
 */
@@ -66,19 +83,17 @@ bool DigitalIOHardware::SetMode() {
   bool has_expander = (_expander_drv != nullptr);
 
   if (_direction == ws_digitalio_Direction_D_OUTPUT) {
-    // _value is the logical value; drive the electrical level (inverted for
-    // active-low pins).
-    bool electrical = _is_inverted ? !_value : _value;
+    uint8_t level = GetElectricalLevel(_value);
     if (!has_expander) {
       pinMode(_name, OUTPUT);
-      digitalWrite(_name, electrical ? HIGH : LOW);
+      digitalWrite(_name, level);
 #if defined(ARDUINO_ESP8266_ADAFRUIT_HUZZAH)
-      if (!electrical)
-        digitalWrite(_name, !0);
+      if (level == LOW)
+        digitalWrite(_name, HIGH);
 #endif
     } else {
       _expander_drv->pinMode(_name, OUTPUT);
-      _expander_drv->digitalWrite(_name, electrical ? HIGH : LOW);
+      _expander_drv->digitalWrite(_name, level);
     }
   } else if (_direction == ws_digitalio_Direction_D_INPUT) {
     if (!has_expander) {
@@ -106,15 +121,11 @@ void DigitalIOHardware::Write(bool value) {
   if (_value == value)
     return;
 
-  bool has_expander = (_expander_drv != nullptr);
-
-  // value is the logical value; drive the electrical level (inverted for
-  // active-low pins).
-  bool electrical = _is_inverted ? !value : value;
-  if (!has_expander) {
-    digitalWrite(_name, electrical ? HIGH : LOW);
+  uint8_t level = GetElectricalLevel(value);
+  if (_expander_drv != nullptr) {
+    _expander_drv->digitalWrite(_name, level);
   } else {
-    _expander_drv->digitalWrite(_name, electrical ? HIGH : LOW);
+    digitalWrite(_name, level);
   }
   _value = value;
 }
@@ -125,12 +136,18 @@ void DigitalIOHardware::Write(bool value) {
     @return The pin's current value.
 */
 bool DigitalIOHardware::ReadValue() {
-  bool has_expander = (_expander_drv != nullptr);
+  bool raw;
+  if (_expander_drv != nullptr) {
+    raw = _expander_drv->digitalRead(_name);
+  } else {
+    raw = digitalRead(_name);
+  }
 
-  bool raw =
-      has_expander ? _expander_drv->digitalRead(_name) : digitalRead(_name);
-  // Report the logical value (inverted for active-low pins).
-  _value = _is_inverted ? !raw : raw;
+  // Report the logical value: is_inverted (active-low) pins read as the
+  // opposite of their electrical level.
+  _value = raw;
+  if (_is_inverted)
+    _value = !raw;
   return _value;
 }
 
@@ -141,9 +158,12 @@ bool DigitalIOHardware::ReadValue() {
 bool DigitalIOHardware::CheckEvent() {
   ReadValue();
 
-  // First read after add: _prv_value was only a guess (initial_value), so we
-  // cannot infer a real transition. Seed the baseline from this read and report
-  // it as the pin's initial state rather than comparing against the guess.
+  // First read after add: _prv_value was only a guess (the Add's
+  // initial_value), so we cannot infer a real transition from it. Comparing
+  // against the guess either suppressed the initial report entirely (guess
+  // happened to match the real state, IO never learns the pin's value) or
+  // fabricated a transition that never happened. Seed the baseline from this
+  // read and report it as the pin's initial state instead.
   if (_first_read) {
     _first_read = false;
     _prv_value = _value;

--- a/src/components/digitalIO/hardware.h
+++ b/src/components/digitalIO/hardware.h
@@ -53,6 +53,7 @@ public:
 
 private:
   bool SetMode();
+  uint8_t GetElectricalLevel(bool logical_value);
   bool IsPinTimerExpired(ulong cur_time);
   bool IsStatusLEDPin() const;
 
@@ -61,7 +62,11 @@ private:
   ws_digitalio_SampleMode _sample_mode;
   bool _value;
   bool _prv_value;
-  bool _first_read; ///< True until the first CheckEvent() read seeds _prv_value
+  bool _first_read;  ///< True until CheckEvent() has read real hardware state.
+                     ///< _value/_prv_value are bools and can't encode "not yet
+                     ///< read" - until the first read they only hold the Add's
+                     ///< initial_value guess, which must not be compared
+                     ///< against as if it were an observed state.
   bool _is_inverted; ///< True if the pin's logic is active-low (inverted)
   ulong _period;
   ulong _prv_time;

--- a/src/components/expander/controller.cpp
+++ b/src/components/expander/controller.cpp
@@ -134,29 +134,42 @@ ExpanderHardware *ExpanderController::GetDriver(uint8_t addr) {
 
 /*!
  * @brief Resolves a pin name to a pin number and, for expander pin names
- *        ("EXP_0xNN_P"), the owning expander driver. Lets other components
- *        (digitalio, analogio, pwm, ...) resolve a pin without knowing the
- *        expander addressing scheme, analogous to
- *        DigitalIOController::QueryPinState() for pin-in-use queries.
+ *        ("EXP_0xNN_P"), the owning expander driver. Handles BOTH pin
+ *        domains so callers (digitalio, analogio, pwm, ...) need a single
+ *        call and no knowledge of the expander addressing scheme: a native
+ *        name ("D5", "A0") resolves successfully with expander_drv left
+ *        nullptr, an expander name must reference a registered expander.
+ *        Analogous to DigitalIOController::QueryPinState() for pin-in-use
+ *        queries.
  * @param pin_name     The pin name string, native ("D5", "A0") or expander
  *                     ("EXP_0x48_3").
  * @param pin_num      Out: the pin number — for expander pins this is the
  *                     pin (channel) index on that expander.
  * @param expander_drv Out: the owning expander driver, or nullptr for a
  *                     native MCU pin.
- * @return True if resolved, False if the pin name is malformed or no
- *         expander is registered at the referenced address.
+ * @return True if resolved. False if the pin name is malformed, out of
+ *         range, or names an expander address with no registered driver.
  */
 bool ExpanderController::ResolvePinName(const char *pin_name, uint8_t &pin_num,
                                         ExpanderHardware **expander_drv) {
-  *expander_drv = nullptr;
-  if (!ExpanderHardware::ParsePinNum(pin_name, pin_num))
+  *expander_drv = nullptr; // Only set for expander-backed pins
+
+  int32_t pin = WsPinNameToNum(pin_name);
+  if (pin == WS_PIN_INVALID || pin > 0xFF)
     return false;
-  int32_t addr = WsPinNameToExpanderAddr(pin_name);
-  if (addr == WS_PIN_INVALID)
-    return true; // Native MCU pin, no expander driver
-  *expander_drv = GetDriver((uint8_t)addr);
-  return *expander_drv != nullptr;
+
+  // Expander pin name? The expander at that address must be registered.
+  if (strncmp(pin_name, "EXP_", 4) == 0) {
+    int32_t addr = WsPinNameToExpanderAddr(pin_name);
+    if (addr == WS_PIN_INVALID)
+      return false;
+    *expander_drv = GetDriver((uint8_t)addr);
+    if (*expander_drv == nullptr)
+      return false;
+  }
+
+  pin_num = (uint8_t)pin;
+  return true;
 }
 
 /// Pointer to an expander setter that applies one decoded setting value.

--- a/src/components/expander/hardware.h
+++ b/src/components/expander/hardware.h
@@ -16,7 +16,6 @@
  */
 #ifndef WS_EXPANDER_HARDWARE_H
 #define WS_EXPANDER_HARDWARE_H
-#include "helpers/ws_helper_pins.h"
 #include <Arduino.h>
 #include <Wire.h>
 #include <protos/config.pb.h>
@@ -40,24 +39,9 @@ public:
        @return The I2C address. */
   uint8_t getAddress() const { return _i2c_addr; }
 
-  /*!  @brief  Parses pin number from a pin name string. Handles both
-               native ("A0", "D5") and expander ("EXP_0x48_0") formats —
-               for expander pins the parsed number is the pin (channel)
-               index on that expander (see WsPinNameToNum()).
-       @param  pin_name  The pin name string.
-       @param  pin_num   Output: the parsed pin number.
-       @return True if parsed successfully, false if malformed. */
-  static bool ParsePinNum(const char *pin_name, uint8_t &pin_num) {
-    int32_t num = WsPinNameToNum(pin_name);
-    if (num == WS_PIN_INVALID || num > 0xFF)
-      return false;
-    pin_num = (uint8_t)num;
-    return true;
-  }
-
   /*!  @brief  Formats an expander pin name into a buffer.
-               Inverse of ParsePinNum — builds "EXP_0xNN_P" from address and
-     pin.
+               Inverse of WsPinNameToNum()/WsPinNameToExpanderAddr() —
+               builds "EXP_0xNN_P" from address and pin.
        @param  buf       Output buffer (must be >= 16 bytes).
        @param  buf_size  Size of the output buffer.
        @param  addr      The I2C address of the expander.

--- a/src/components/i2c/controller.cpp
+++ b/src/components/i2c/controller.cpp
@@ -578,8 +578,16 @@ bool I2cController::Handle_Add(ws_i2c_Add *msg) {
   }
 
   // Store the bus pin names on the driver so we can query it
-  drv->SetPins(descriptor.address_space.pin_scl,
-               descriptor.address_space.pin_sda);
+  if (!drv->SetPins(descriptor.address_space.pin_scl,
+                    descriptor.address_space.pin_sda)) {
+    Ws.error_handler->publishComponentError(descriptor,
+                                            "Invalid I2C bus pin name(s)!");
+    if (use_mux) {
+      bus->ClearMuxChannel();
+    }
+    delete drv;
+    return false;
+  }
 
   // Configure sensor driver settings
   drv->EnableSensorReads(msg->types, msg->types_count);
@@ -1055,10 +1063,9 @@ TwoWire *I2cController::GetI2cBusByIndex(size_t index) {
 */
 I2cHardware *I2cController::findOrCreateBus(const char *pin_scl,
                                             const char *pin_sda) {
-  // Resolve the pin names to pin numbers
-  int32_t scl_num = WsPinNameToNum(pin_scl);
-  int32_t sda_num = WsPinNameToNum(pin_sda);
-  if (scl_num == WS_PIN_INVALID || sda_num == WS_PIN_INVALID) {
+  // Validate the pin names and resolve them to pin numbers, once
+  WsPinName scl, sda;
+  if (!scl.Set(pin_scl) || !sda.Set(pin_sda)) {
     WS_DEBUG_PRINTLN("[i2c] ERROR: Invalid SCL/SDA pin name!");
     return nullptr;
   }
@@ -1067,8 +1074,8 @@ I2cHardware *I2cController::findOrCreateBus(const char *pin_scl,
   for (I2cHardware *bus : _i2c_buses) {
     if (bus == nullptr)
       continue;
-    if (scl_num == (int32_t)bus->getSCL() &&
-        sda_num == (int32_t)bus->getSDA()) {
+    if (scl.num == (int32_t)bus->getSCL() &&
+        sda.num == (int32_t)bus->getSDA()) {
       return bus;
     }
   }
@@ -1080,7 +1087,7 @@ I2cHardware *I2cController::findOrCreateBus(const char *pin_scl,
   WS_DEBUG_PRINT("SDA Pin: ");
   WS_DEBUG_PRINTLNVAR(pin_sda);
 
-  I2cHardware *new_bus = new I2cHardware(sda_num, scl_num);
+  I2cHardware *new_bus = new I2cHardware(sda.num, scl.num);
   if (!new_bus->begin()) {
     WS_DEBUG_PRINTLN("[i2c] ERROR: Failed to initialize I2C bus!");
     delete new_bus;
@@ -1112,15 +1119,14 @@ bool I2cController::IsBusStatusOK(I2cHardware *bus) {
     @returns  Pointer to the TwoWire bus, or nullptr if the bus doesn't exist.
 */
 TwoWire *I2cController::GetI2cBus(const char *pin_scl, const char *pin_sda) {
-  int32_t scl_num = WsPinNameToNum(pin_scl);
-  int32_t sda_num = WsPinNameToNum(pin_sda);
-  if (scl_num == WS_PIN_INVALID || sda_num == WS_PIN_INVALID)
+  WsPinName scl, sda;
+  if (!scl.Set(pin_scl) || !sda.Set(pin_sda))
     return nullptr;
   for (I2cHardware *bus : _i2c_buses) {
     if (bus == nullptr)
       continue;
-    if (scl_num == (int32_t)bus->getSCL() &&
-        sda_num == (int32_t)bus->getSDA()) {
+    if (scl.num == (int32_t)bus->getSCL() &&
+        sda.num == (int32_t)bus->getSDA()) {
       return bus->GetBus();
     }
   }

--- a/src/components/i2c/drivers/drvBase.h
+++ b/src/components/i2c/drivers/drvBase.h
@@ -16,6 +16,7 @@
 #ifndef DRV_BASE_H
 #define DRV_BASE_H
 #include "../../../helpers/ws_helper_macros.h"
+#include "../../../helpers/ws_helper_pins.h"
 #include <Adafruit_Sensor.h>
 #include <Arduino.h>
 #include <Wire.h>
@@ -32,6 +33,8 @@ struct DecodedSetting;    ///< Forward declaration
 /*! Size of the pin name buffers, exactly matches
     ws_i2c_AddressSpace.pin_scl/pin_sda in i2c.pb.h */
 #define DRV_BASE_PIN_NAME_LEN (sizeof(((ws_i2c_AddressSpace *)0)->pin_scl))
+static_assert(sizeof(WsPinName::name) >= DRV_BASE_PIN_NAME_LEN,
+              "WsPinName.name must hold any ws_i2c_AddressSpace pin name");
 
 /*!
     @brief  Base class for I2C Drivers.
@@ -59,8 +62,6 @@ public:
     _i2c_mux_channel = mux_channel;
     strncpy(_name, driver_name, sizeof(_name) - 1);
     _name[sizeof(_name) - 1] = '\0';
-    _pin_scl[0] = '\0';
-    _pin_sda[0] = '\0';
     _did_read_send = false;
   }
 
@@ -95,30 +96,32 @@ public:
   void SetMuxAddress(uint32_t mux_address) { _i2c_mux_addr = mux_address; }
 
   /*!
-      @brief    Sets the I2C bus pin names for this driver.
+      @brief    Validates and sets the I2C bus pin names for this driver,
+                resolving each to its pin number.
       @param    pin_scl
                 The SCL pin name.
       @param    pin_sda
                 The SDA pin name.
+      @returns  True if both names are non-null, fit without truncation,
+                and resolve to pin numbers; False otherwise.
   */
-  void SetPins(const char *pin_scl, const char *pin_sda) {
-    strncpy(_pin_scl, pin_scl, sizeof(_pin_scl) - 1);
-    _pin_scl[sizeof(_pin_scl) - 1] = '\0';
-    strncpy(_pin_sda, pin_sda, sizeof(_pin_sda) - 1);
-    _pin_sda[sizeof(_pin_sda) - 1] = '\0';
+  bool SetPins(const char *pin_scl, const char *pin_sda) {
+    bool scl_ok = _pin_scl.Set(pin_scl);
+    bool sda_ok = _pin_sda.Set(pin_sda);
+    return scl_ok && sda_ok;
   }
 
   /*!
       @brief    Gets the SCL pin name for this driver's I2C bus.
       @returns  The SCL pin name.
   */
-  const char *GetPinSCL() { return _pin_scl; }
+  const char *GetPinSCL() { return _pin_scl.name; }
 
   /*!
       @brief    Gets the SDA pin name for this driver's I2C bus.
       @returns  The SDA pin name.
   */
-  const char *GetPinSDA() { return _pin_sda; }
+  const char *GetPinSDA() { return _pin_sda.name; }
 
   /*!
       @brief    Gets the I2C MUX channel connected to the I2C device.
@@ -865,15 +868,15 @@ public:
   ws_i2c_Add_TypesEntry _sensors[16]; ///< Keyed sensor types from broker.
 
 protected:
-  TwoWire *_i2c;                        ///< Pointer to the TwoWire bus
-  uint16_t _address;                    ///< The device's I2C address.
-  uint32_t _i2c_mux_addr;               ///< The I2C MUX address, if applicable.
-  uint32_t _i2c_mux_channel;            ///< The I2C MUX channel, if applicable.
-  char _name[DRV_BASE_NAME_LEN];        ///< The device's name.
-  char _pin_scl[DRV_BASE_PIN_NAME_LEN]; ///< The SCL pin name for this
-                                        ///< driver's bus.
-  char _pin_sda[DRV_BASE_PIN_NAME_LEN]; ///< The SDA pin name for this
-                                        ///< driver's bus.
+  TwoWire *_i2c;                 ///< Pointer to the TwoWire bus
+  uint16_t _address;             ///< The device's I2C address.
+  uint32_t _i2c_mux_addr;        ///< The I2C MUX address, if applicable.
+  uint32_t _i2c_mux_channel;     ///< The I2C MUX channel, if applicable.
+  char _name[DRV_BASE_NAME_LEN]; ///< The device's name.
+  WsPinName _pin_scl;       ///< The SCL pin (name + resolved number) for this
+                            ///< driver's bus.
+  WsPinName _pin_sda;       ///< The SDA pin (name + resolved number) for this
+                            ///< driver's bus.
   ulong _sensor_period;     ///< The sensor's period, in milliseconds.
   ulong _sensor_period_prv; ///< The sensor's previous period, in milliseconds.
   size_t _sensors_count;    ///< Number of sensors on the device.

--- a/src/components/uart/drivers/drvUartBase.h
+++ b/src/components/uart/drivers/drvUartBase.h
@@ -28,6 +28,8 @@
 /*! Size of the pin name buffers, exactly matches ws_uart_Descriptor.pin_rx
     in uart.pb.h */
 #define DRV_UART_PIN_NAME_LEN (sizeof(((ws_uart_Descriptor *)0)->pin_rx))
+static_assert(sizeof(WsPinName::name) >= DRV_UART_PIN_NAME_LEN,
+              "WsPinName.name must hold any ws_uart_Descriptor pin name");
 
 /*!
     @brief  Base class for UART Drivers.
@@ -99,15 +101,20 @@ public:
 
   /*!
       @brief    Gets the port number for the UART device.
-      @returns  The port number, resolved from the RX pin name.
+      @returns  The port number, resolved from the RX pin name, or 0 if
+                the pin name did not resolve.
   */
-  uint32_t GetPortNum() const { return _port_num; }
+  uint32_t GetPortNum() const {
+    if (_port.num == WS_PIN_INVALID)
+      return 0;
+    return (uint32_t)_port.num;
+  }
 
   /*!
       @brief    Gets the name of the RX pin for the UART device.
       @returns  The RX pin name.
   */
-  const char *GetPortName() const { return _port_name; }
+  const char *GetPortName() const { return _port.name; }
 
   /*!
       @brief    Gets the name of the UART driver.
@@ -356,22 +363,18 @@ protected:
   SoftwareSerial *_sw_serial;    ///< Pointer to a SoftwareSerial instance
 #endif                           // HAS_SW_SERIAL
   char _name[DRV_UART_NAME_LEN]; ///< The device's name
-  char _port_name[DRV_UART_PIN_NAME_LEN] = {
-      0};                 ///< The RX pin name for the UART device
-  uint32_t _port_num = 0; ///< The port number for the UART device, resolved
-                          ///< from the RX pin name
+  WsPinName _port; ///< The RX pin (name + resolved port number) for the
+                   ///< UART device
 
   /*!
-      @brief    Stores the RX pin name and resolves it to a port number.
+      @brief    Validates and stores the RX pin name, resolving it to a
+                port number.
       @param    port_name
                 The name of the RX pin for the UART device.
+      @returns  True if the name is non-null, fits without truncation, and
+                resolves to a pin number; False otherwise.
   */
-  void SetPortName(const char *port_name) {
-    strncpy(_port_name, port_name, sizeof(_port_name) - 1);
-    _port_name[sizeof(_port_name) - 1] = '\0';
-    int32_t port_num = WsPinNameToNum(_port_name);
-    _port_num = (port_num == WS_PIN_INVALID) ? 0 : (uint32_t)port_num;
-  }
+  bool SetPortName(const char *port_name) { return _port.Set(port_name); }
   bool _is_software_serial =
       false; ///< Indicates if this driver uses SoftwareSerial
   // Sensor API - UART INPUT

--- a/src/components/uart/hardware.cpp
+++ b/src/components/uart/hardware.cpp
@@ -23,15 +23,10 @@
 UARTHardware::UARTHardware(const ws_uart_SerialConfig &config,
                            const char *pin_rx, const char *pin_tx) {
   _config = config;
-  _pin_rx = 0;
-  _pin_tx = 0;
-  int32_t rx_num = WsPinNameToNum(pin_rx);
-  int32_t tx_num = WsPinNameToNum(pin_tx);
-  _pins_valid = (rx_num != WS_PIN_INVALID) && (tx_num != WS_PIN_INVALID);
-  if (_pins_valid) {
-    _pin_rx = (uint32_t)rx_num;
-    _pin_tx = (uint32_t)tx_num;
-  }
+  // Validate and resolve the pin names once; name + number travel together
+  bool rx_ok = _pin_rx.Set(pin_rx);
+  bool tx_ok = _pin_tx.Set(pin_tx);
+  _pins_valid = rx_ok && tx_ok;
 }
 
 /*!
@@ -130,8 +125,8 @@ bool UARTHardware::ConfigureSerial() {
     WS_DEBUG_PRINTLN("[uart] ERROR: Invalid RX/TX pin name!");
     return false;
   }
-  int8_t rx_pin = (int8_t)_pin_rx;
-  int8_t tx_pin = (int8_t)_pin_tx;
+  int8_t rx_pin = (int8_t)_pin_rx.num;
+  int8_t tx_pin = (int8_t)_pin_tx.num;
   uint16_t cfg = UartPacketFormatToConfig(_config.format);
 
   if (_config.use_sw_serial) {
@@ -209,7 +204,7 @@ bool UARTHardware::isSoftwareSerial() const {
  * @brief  Gets the bus number of the hardware instance.
  * @return The bus number of the hardware instance, or -1 if not set.
  */
-int UARTHardware::getPortNum() { return (int)_pin_rx; }
+int UARTHardware::getPortNum() { return (int)_pin_rx.num; }
 
 /*!
  * @brief  Gets the HardwareSerial instance for this port

--- a/src/components/uart/hardware.h
+++ b/src/components/uart/hardware.h
@@ -55,8 +55,8 @@ private:
 #if HAS_SW_SERIAL
   SoftwareSerial *_swSerial = nullptr; ///< SoftwareSerial instance for this bus
 #endif                                 // HAS_SW_SERIAL
-  uint32_t _pin_rx;    ///< The RX pin number, resolved from the RX pin name
-  uint32_t _pin_tx;    ///< The TX pin number, resolved from the TX pin name
+  WsPinName _pin_rx;                   ///< The RX pin (name + resolved number)
+  WsPinName _pin_tx;                   ///< The TX pin (name + resolved number)
   bool _pins_valid;    ///< True if the RX/TX pin names resolved to pin numbers
   uint32_t _baud_rate; ///< The baud rate for this hardware instance
 };

--- a/src/helpers/ws_helper_pins.h
+++ b/src/helpers/ws_helper_pins.h
@@ -93,4 +93,38 @@ inline int32_t WsPinNameToNum(const char *pin_name) {
   return (int32_t)atoi(numeric);
 }
 
+/*!
+    @brief  A pin reference: pairs the broker-facing pin name string with
+            its resolved pin number, so the name is validated and resolved
+            exactly once and both representations travel together instead
+            of re-resolving the string at every use.
+*/
+struct WsPinName {
+  char name[32] = {0}; ///< Pin name string, sized to hold any pb pin-name
+                       ///< field (holders static_assert this against the
+                       ///< pb field sizes they mirror).
+  int32_t num = WS_PIN_INVALID; ///< Resolved pin number, or WS_PIN_INVALID.
+
+  /*!
+      @brief  Validates a pin name and resolves it to a pin number.
+      @param  pin_name
+              The pin name string to store and resolve.
+      @returns True if pin_name is non-null, fits the buffer without
+               truncation, and resolves to a pin number; False otherwise
+               (fields are reset to empty / WS_PIN_INVALID).
+  */
+  bool Set(const char *pin_name) {
+    name[0] = '\0';
+    num = WS_PIN_INVALID;
+    if (pin_name == nullptr)
+      return false;
+    if (strlen(pin_name) >= sizeof(name))
+      return false; // would truncate
+    strncpy(name, pin_name, sizeof(name) - 1);
+    name[sizeof(name) - 1] = '\0';
+    num = WsPinNameToNum(name);
+    return num != WS_PIN_INVALID;
+  }
+};
+
 #endif // WS_HELPER_PINS_H


### PR DESCRIPTION
## Summary

Addresses the 2026-07-23 review round on #943. Each inline thread there gets a reply pointing at the change here.

## Changes

- **`WsPinName` struct** (`ws_helper_pins.h`): pairs the pin-name string with its resolved number — validated and resolved once via `Set()`, then both representations travel together instead of re-resolving the string at every use. `Set()` rejects `nullptr` and any name that would truncate (`strlen >= sizeof` fails; `strncpy` can no longer silently truncate). Adopted by:
  - `drvBase` (`_pin_scl`/`_pin_sda`, `static_assert`'d to hold the pb pin-name fields; `SetPins()` returns bool and the i2c controller fails the Add with a component error on invalid names)
  - `UARTHardware` (`_pin_rx`/`_pin_tx`) and `drvUartBase` (`_port`)
  - the i2c bus lookup (`findOrCreateBus`/`GetI2cBus`)
- **`ExpanderController::ResolvePinName` restructured**: explicit expander-vs-native paths. An expander pin name whose expander isn't registered **fails**; a native name succeeds with `expander_drv` left `nullptr` — documented as the point of the API (one call serves both pin domains for digitalio/analogio/pwm). `ExpanderHardware::ParsePinNum` is removed outright, so no more `::` static call.
- **digitalio**: the `is_inverted` (active-low) logical→electrical conversion is now a documented `GetElectricalLevel()` helper; all ternary ops in `hardware.cpp` replaced with if/else. The `_first_read` seeding is kept (it fixes a HIL-verified bug where comparing against the Add's `initial_value` guess either suppressed the pin's initial report or fabricated a transition) with the reasoning now spelled out in the comments — two bools can't encode "not yet read".

## Build verification

Local `adafruit_feather_esp32s3` ✅ and `huzzah8266` ✅; full matrix via CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)