### PR TITLE
Fix [Pico W] - Never waits for WiFi association (uninitialised lastResult)

### DIFF
--- a/src/platforms/pico_wifi.h
+++ b/src/platforms/pico_wifi.h
@@ -306,19 +306,18 @@ protected:
         WiFi.begin(_ssid, _pass);
 
         // Use the macro to retry the status check until connected / timed out
-        int lastResult;
-        /*         RETRY_FUNCTION_UNTIL_TIMEOUT(
-                    []() -> int { return WiFi.status(); }, // Function call each
-           cycle int,                                   // return type
-                    lastResult, // return variable (unused here)
-                    [](int status) { return status == WL_CONNECTED; }, // check
-                    PICO_CONNECT_TIMEOUT_MS,      // timeout interval (ms)
-                    PICO_CONNECT_RETRY_DELAY_MS); // interval between retries */
+        int lastResult = WL_DISCONNECTED;
+        RETRY_FUNCTION_UNTIL_TIMEOUT(
+            []() -> int { return WiFi.status(); }, // Function call each cycle
+            lastResult,                            // return variable
+            [](int status) { return status == WL_CONNECTED; }, // check
+            PICO_CONNECT_TIMEOUT_MS,      // timeout interval (ms)
+            PICO_CONNECT_RETRY_DELAY_MS); // interval between retries
 
         if (lastResult == WL_CONNECTED) {
           _statusV2 = WS_NET_CONNECTED;
           // wait 2seconds for connection to stabilize
-          // WS_DELAY_WITH_WDT(2 * ONE_SECOND_IN_MS);
+          WS_DELAY_WITH_WDT(2 * ONE_SECOND_IN_MS);
           return;
         }
       }


### PR DESCRIPTION
Fixes #963.

## What was broken

The Pico W **never waited for WiFi association**. In `pico_wifi.h::_connect()` the `RETRY_FUNCTION_UNTIL_TIMEOUT` block was commented out, but the `if (lastResult == WL_CONNECTED)` check below it was left in place — reading an **uninitialised** `int lastResult;`.

So `WiFi.begin()` was called, the status compared against stack garbage with zero delay, the check failed, `_statusV2` became `WS_NET_DISCONNECTED`, and the board reboot-looped after 5 attempts.

## Why it was commented out

The V1 → V2 migration **changed the macro's signature** and this call site was commented out rather than updated:

| | signature | body |
|---|---|---|
| V1 `src/Wippersnapper.h:124` | `(func, result_type, result_var, condition, timeout, interval, ...)` | `result_type result_var = func(...);` |
| V2 `src/helpers/ws_helper_macros.h:75` | `(func, result_var, condition, timeout, interval, ...)` | `result_var = func(...);` |

V2 dropped `result_type`; the Pico call still passed it (the stray `int,  // return type` argument is visible inside the comment), so it no longer compiled. `src/platforms/airlift_wifi.h:309` is the same call migrated **correctly** — this change simply brings the Pico into line with it.

Blame: introduced in `00006b4b` (V1→V2 port), clang-formatted by `af886dba`, relocated by `337b5d7a`.

## The fix

Restore the call in the current 5-argument form, initialise `lastResult`, and re-enable the post-connect stabilisation delay.

## Hardware verification

Tested on a real Pico W (HIL bench, Pico Tripler + EYESPI).

Before:
```
Performing a WiFi scan for SSID...SSID (free4all) found! RSSI: -86
Connecting to WiFi (attempt #0) ... (attempt #4)
ERROR: Unable to connect to WiFi!
ERROR [RESET]: ERROR: Unable to connect to WiFi, rebooting soon...
```

After:
```
Connected to WiFi!
Completed checkin process!
Sending MQTT PING: SUCCESS!
WiFi RSSI: -22
```

⚠️ Note for future triage: the pre-fix log reports a **misleadingly weak RSSI (-86 dBm)** because nothing has settled yet. The same board on the same bench reads **-22 dBm** once association is actually awaited. That 64 dB phantom gap looks exactly like an antenna/placement problem and is a false lead.

## Not included here

Building `env:raspberrypi_picow` also fails to link (`region FLASH overflowed by 2636 bytes`, after `multiple definition` errors) because `Adafruit NAU7802 Library` and `Adafruit seesaw Library` are each declared **twice** in `platformio.ini` — once by registry name and once by git URL. I worked around it locally to produce the test build but left it out of this PR to keep the change focused. Happy to send it separately — flagged in #963.

@tyeth
