### PR TITLE
Marquee Test Firmware - Fix [Pico W] - Never waits for WiFi association (uninitialised lastResult)

### DIFF
--- a/src/platforms/pico_wifi.h
+++ b/src/platforms/pico_wifi.h
@@ -306,19 +306,18 @@ protected:
         WiFi.begin(_ssid, _pass);
 
         // Use the macro to retry the status check until connected / timed out
-        int lastResult;
-        /*         RETRY_FUNCTION_UNTIL_TIMEOUT(
-                    []() -> int { return WiFi.status(); }, // Function call each
-           cycle int,                                   // return type
-                    lastResult, // return variable (unused here)
-                    [](int status) { return status == WL_CONNECTED; }, // check
-                    PICO_CONNECT_TIMEOUT_MS,      // timeout interval (ms)
-                    PICO_CONNECT_RETRY_DELAY_MS); // interval between retries */
+        int lastResult = WL_DISCONNECTED;
+        RETRY_FUNCTION_UNTIL_TIMEOUT(
+            []() -> int { return WiFi.status(); }, // Function call each cycle
+            lastResult,                            // return variable
+            [](int status) { return status == WL_CONNECTED; }, // check
+            PICO_CONNECT_TIMEOUT_MS,      // timeout interval (ms)
+            PICO_CONNECT_RETRY_DELAY_MS); // interval between retries
 
         if (lastResult == WL_CONNECTED) {
           _statusV2 = WS_NET_CONNECTED;
           // wait 2seconds for connection to stabilize
-          // WS_DELAY_WITH_WDT(2 * ONE_SECOND_IN_MS);
+          WS_DELAY_WITH_WDT(2 * ONE_SECOND_IN_MS);
           return;
         }
       }


### PR DESCRIPTION
Same fix as #964 (which targets `migrate-api-v2`), applied to this branch so the canvas/marquee work can be exercised on a Pico W. See #963 for the full write-up.

## Why this branch needs it too

This bug is inherited here from the V2 line, and it makes the Pico W **completely unusable** as a marquee target — it never associates with WiFi, so it never reaches a broker, so the canvas path can't be tested on it at all.

In `pico_wifi.h::_connect()` the `RETRY_FUNCTION_UNTIL_TIMEOUT` block is commented out while the `if (lastResult == WL_CONNECTED)` check below it remains, reading an **uninitialised** `int lastResult;`. `WiFi.begin()` is never waited on, the check fails against stack garbage, and the board reboot-loops after 5 attempts.

It was originally commented out because the V1→V2 migration dropped the macro's `result_type` parameter and this call site still passed it, so it stopped compiling. `src/platforms/airlift_wifi.h:309` is the same call migrated correctly; this brings the Pico into line.

## Hardware verification on *this* branch's firmware

Built `env:raspberrypi_picow` from this branch, flashed a real Pico W (HIL bench, Pico Tripler + EYESPI), and pointed it at a protomq broker.

Before:
```
Performing a WiFi scan for SSID...SSID (free4all) found! RSSI: -86
Connecting to WiFi (attempt #0) ... (attempt #4)
ERROR: Unable to connect to WiFi!
ERROR [RESET]: ERROR: Unable to connect to WiFi, rebooting soon...
```

After:
```
Connected to WiFi!
Completed checkin process!
Sending MQTT PING: SUCCESS!
WiFi RSSI: -22
```

⚠️ Heads-up for anyone triaging this: the pre-fix log reports a **misleadingly weak RSSI (-86 dBm)** because nothing has settled yet. The same board on the same bench reads **-22 dBm** once association is actually awaited — a 64 dB phantom gap that looks just like an antenna/placement problem. It isn't.

## Also hit while building this branch

`env:raspberrypi_picow` fails to link — `region FLASH overflowed by 2636 bytes`, preceded by `multiple definition` errors — because `Adafruit NAU7802 Library` and `Adafruit seesaw Library` are each declared **twice** in `platformio.ini`, once by registry name and once by git URL. I dropped the duplicate registry entries locally to get a test build, but kept it out of this PR to keep the diff focused. Flagged in #963.

@tyeth
