### PR TITLE
V2 add(scd43): refactor scd4x into separate components

### DIFF
--- a/src/components/i2c/controller.cpp
+++ b/src/components/i2c/controller.cpp
@@ -217,6 +217,11 @@ static const std::map<std::string, FnCreateI2CSensorDriver> I2cFactorySensor = {
         const char *driver_name) -> drvBase * {
        return new drvPm25(i2c, addr, mux_channel, driver_name);
      }},
+    {"scd30",
+     [](TwoWire *i2c, uint16_t addr, uint32_t mux_channel,
+        const char *driver_name) -> drvBase * {
+       return new drvScd30(i2c, addr, mux_channel, driver_name);
+     }},
     {"scd40",
      [](TwoWire *i2c, uint16_t addr, uint32_t mux_channel,
         const char *driver_name) -> drvBase * {
@@ -227,10 +232,10 @@ static const std::map<std::string, FnCreateI2CSensorDriver> I2cFactorySensor = {
         const char *driver_name) -> drvBase * {
        return new drvScd4x(i2c, addr, mux_channel, driver_name);
      }},
-    {"scd30",
+    {"scd43",
      [](TwoWire *i2c, uint16_t addr, uint32_t mux_channel,
         const char *driver_name) -> drvBase * {
-       return new drvScd30(i2c, addr, mux_channel, driver_name);
+       return new drvScd4x(i2c, addr, mux_channel, driver_name);
      }},
     {"sgp40",
      [](TwoWire *i2c, uint16_t addr, uint32_t mux_channel,


### PR DESCRIPTION
Matches https://github.com/adafruit/Wippersnapper_Components/pull/341

> Adds the SCD43.
> Adds descriptions to the existing shared SCD40\41 component, to specify the differing measurement ranges, splitting them out and leaving separate SCD40 SCD41 and SCD43 components.
> 
> The publish is false for the 43 and 41, but 41 is already supported in the arduino firmware so can be published true(~ = only true for v2).
> 
> Older user components were originally labelled SCD40/41 and will now be SCD40.