### PR TITLE
add(component): Add SCD43 and split SCD40 / SCD41

### DIFF
--- a/src/components/i2c/WipperSnapper_I2C.cpp
+++ b/src/components/i2c/WipperSnapper_I2C.cpp
@@ -756,7 +756,9 @@ bool WipperSnapper_Component_I2C::initI2CDevice(
     _veml7700->configureDriver(msgDeviceInitReq);
     drivers.push_back(_veml7700);
     WS_DEBUG_PRINTLN("VEML7700 Initialized Successfully!");
-  } else if (strcmp("scd40", msgDeviceInitReq->i2c_device_name) == 0) {
+  } else if ((strcmp("scd40", msgDeviceInitReq->i2c_device_name) == 0) ||
+             (strcmp("scd41", msgDeviceInitReq->i2c_device_name) == 0) ||
+             (strcmp("scd43", msgDeviceInitReq->i2c_device_name) == 0)) {
     _scd40 = new WipperSnapper_I2C_Driver_SCD4X(this->_i2c, i2cAddress);
     if (!_scd40->begin()) {
       WS_DEBUG_PRINTLN("ERROR: Failed to initialize SCD4x!");


### PR DESCRIPTION
Adds SCD43 and SCD41 as separate components to v1, matching https://github.com/adafruit/Wippersnapper_Components/pull/341

> Adds the SCD43.
> Adds descriptions to the existing shared SCD40\41 component, to specify the differing measurement ranges, splitting them out and leaving separate SCD40 SCD41 and SCD43 components.
> 
> The publish is false for the 43 and 41, but 41 is already supported in the arduino firmware so can be published true(~ = only true for v2).
> 
> Older user components were originally labelled SCD40/41 and will now be SCD40.