### PR TITLE
fix(linking): Update global Ws to be the platform specific version (matches #829 which was v1)

### DIFF
--- a/src/components/analogIn/controller.h
+++ b/src/components/analogIn/controller.h
@@ -54,5 +54,4 @@ private:
   float _mcu_ref_voltage; ///< MCU/board reference voltage, used for native pins
                           ///< (expander pins use their own message ref_voltage)
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_ANALOGIN_CONTROLLER_H

--- a/src/components/analogIn/controller.h
+++ b/src/components/analogIn/controller.h
@@ -54,4 +54,4 @@ private:
   float _mcu_ref_voltage; ///< MCU/board reference voltage, used for native pins
                           ///< (expander pins use their own message ref_voltage)
 };
-#endif                   // WS_ANALOGIN_CONTROLLER_H
+#endif // WS_ANALOGIN_CONTROLLER_H

--- a/src/components/checkin/model.h
+++ b/src/components/checkin/model.h
@@ -61,4 +61,4 @@ private:
       ws_checkin_D2B_init_zero; ///< Device to Broker message wrapper
   bool _got_response;           ///< Flag indicating if response was received
 };
-#endif                   // WS_CHECKIN_H
+#endif // WS_CHECKIN_H

--- a/src/components/checkin/model.h
+++ b/src/components/checkin/model.h
@@ -61,5 +61,4 @@ private:
       ws_checkin_D2B_init_zero; ///< Device to Broker message wrapper
   bool _got_response;           ///< Flag indicating if response was received
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_CHECKIN_H

--- a/src/components/digitalIO/controller.h
+++ b/src/components/digitalIO/controller.h
@@ -50,4 +50,4 @@ private:
   std::vector<DigitalIOHardware *> _pins_output;
   DigitalIOModel *_dio_model;
 };
-#endif                   // WS_DIGITALIO_CONTROLLER_H
+#endif // WS_DIGITALIO_CONTROLLER_H

--- a/src/components/digitalIO/controller.h
+++ b/src/components/digitalIO/controller.h
@@ -50,5 +50,4 @@ private:
   std::vector<DigitalIOHardware *> _pins_output;
   DigitalIOModel *_dio_model;
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_DIGITALIO_CONTROLLER_H

--- a/src/components/display/controller.h
+++ b/src/components/display/controller.h
@@ -46,5 +46,4 @@ private:
   bool removeExistingDisplayByName(const char *name);
   int8_t findDisplayIndexByName(const char *name);
 };
-extern wippersnapper Ws; ///< Global V2 instance
 #endif                   // WS_DISPLAY_CONTROLLER_H

--- a/src/components/display/controller.h
+++ b/src/components/display/controller.h
@@ -46,4 +46,4 @@ private:
   bool removeExistingDisplayByName(const char *name);
   int8_t findDisplayIndexByName(const char *name);
 };
-#endif                   // WS_DISPLAY_CONTROLLER_H
+#endif // WS_DISPLAY_CONTROLLER_H

--- a/src/components/ds18x20/controller.h
+++ b/src/components/ds18x20/controller.h
@@ -43,5 +43,4 @@ private:
   std::vector<DS18X20Hardware *> _DS18X20_pins;
   int _num_drivers;
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_DS18X20_CONTROLLER_H

--- a/src/components/ds18x20/controller.h
+++ b/src/components/ds18x20/controller.h
@@ -43,4 +43,4 @@ private:
   std::vector<DS18X20Hardware *> _DS18X20_pins;
   int _num_drivers;
 };
-#endif                   // WS_DS18X20_CONTROLLER_H
+#endif // WS_DS18X20_CONTROLLER_H

--- a/src/components/error/handler.h
+++ b/src/components/error/handler.h
@@ -38,5 +38,4 @@ private:
   bool publishD2B();
   ws_error_D2B _d2b_msg; ///< D2B message instance
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_ERROR_HANDLER_H

--- a/src/components/error/handler.h
+++ b/src/components/error/handler.h
@@ -38,4 +38,4 @@ private:
   bool publishD2B();
   ws_error_D2B _d2b_msg; ///< D2B message instance
 };
-#endif                   // WS_ERROR_HANDLER_H
+#endif // WS_ERROR_HANDLER_H

--- a/src/components/expander/controller.h
+++ b/src/components/expander/controller.h
@@ -46,5 +46,4 @@ private:
   bool AddExpander(const char *device_name, uint8_t i2c_addr, TwoWire *wire);
   std::vector<ExpanderHardware *> _expanders; ///< Expander hardware instances
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_EXPANDER_CONTROLLER_H

--- a/src/components/expander/controller.h
+++ b/src/components/expander/controller.h
@@ -46,4 +46,4 @@ private:
   bool AddExpander(const char *device_name, uint8_t i2c_addr, TwoWire *wire);
   std::vector<ExpanderHardware *> _expanders; ///< Expander hardware instances
 };
-#endif                   // WS_EXPANDER_CONTROLLER_H
+#endif // WS_EXPANDER_CONTROLLER_H

--- a/src/components/gps/controller.h
+++ b/src/components/gps/controller.h
@@ -50,5 +50,4 @@ private:
   std::vector<GPSHardware *> _gps_drivers; ///< GPS hardware instances
   std::vector<UARTHardware *> _ports;      ///< UART hardware for GPS serial
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_GPS_CONTROLLER_H

--- a/src/components/gps/controller.h
+++ b/src/components/gps/controller.h
@@ -50,4 +50,4 @@ private:
   std::vector<GPSHardware *> _gps_drivers; ///< GPS hardware instances
   std::vector<UARTHardware *> _ports;      ///< UART hardware for GPS serial
 };
-#endif                   // WS_GPS_CONTROLLER_H
+#endif // WS_GPS_CONTROLLER_H

--- a/src/components/gps/hardware.h
+++ b/src/components/gps/hardware.h
@@ -166,5 +166,4 @@ public:
   */
   void SetDidReadSend(bool value) { _did_read_send = value; }
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_GPS_HARDWARE_H

--- a/src/components/gps/hardware.h
+++ b/src/components/gps/hardware.h
@@ -166,4 +166,4 @@ public:
   */
   void SetDidReadSend(bool value) { _did_read_send = value; }
 };
-#endif                   // WS_GPS_HARDWARE_H
+#endif // WS_GPS_HARDWARE_H

--- a/src/components/i2c/controller.h
+++ b/src/components/i2c/controller.h
@@ -117,4 +117,4 @@ private:
       _i2c_buses;                      ///< Vector of ptrs to I2C hardware buses
   std::vector<drvBase *> _i2c_drivers; ///< Vector of ptrs to I2C drivers
 };
-#endif                   // WS_I2C_CONTROLLER_H
+#endif // WS_I2C_CONTROLLER_H

--- a/src/components/i2c/controller.h
+++ b/src/components/i2c/controller.h
@@ -117,5 +117,4 @@ private:
       _i2c_buses;                      ///< Vector of ptrs to I2C hardware buses
   std::vector<drvBase *> _i2c_drivers; ///< Vector of ptrs to I2C drivers
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_I2C_CONTROLLER_H

--- a/src/components/pixels/controller.h
+++ b/src/components/pixels/controller.h
@@ -47,4 +47,4 @@ private:
   uint8_t _num_strands;                       ///< Number of pixel strands
   uint16_t GetStrandIndex(uint16_t pin_data); // Returns 0xFF if not found
 };
-#endif                   // WS_PIXELS_CONTROLLER_H
+#endif // WS_PIXELS_CONTROLLER_H

--- a/src/components/pixels/controller.h
+++ b/src/components/pixels/controller.h
@@ -47,5 +47,4 @@ private:
   uint8_t _num_strands;                       ///< Number of pixel strands
   uint16_t GetStrandIndex(uint16_t pin_data); // Returns 0xFF if not found
 };
-extern wippersnapper Ws; ///< Global V2 instance
 #endif                   // WS_PIXELS_CONTROLLER_H

--- a/src/components/pwm/controller.h
+++ b/src/components/pwm/controller.h
@@ -43,5 +43,4 @@ private:
   PWMModel *_pwm_model;
   std::vector<PWMHardware *> _pins;
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_PWM_CONTROLLER_H

--- a/src/components/pwm/controller.h
+++ b/src/components/pwm/controller.h
@@ -43,4 +43,4 @@ private:
   PWMModel *_pwm_model;
   std::vector<PWMHardware *> _pins;
 };
-#endif                   // WS_PWM_CONTROLLER_H
+#endif // WS_PWM_CONTROLLER_H

--- a/src/components/servo/controller.h
+++ b/src/components/servo/controller.h
@@ -50,4 +50,4 @@ private:
   ServoHardware *_servo_hardware[MAX_SERVOS] = {nullptr};
   int _active_servo_pins; ///< Number of active servo pins
 };
-#endif                   // WS_SERVO_CONTROLLER_H
+#endif // WS_SERVO_CONTROLLER_H

--- a/src/components/servo/controller.h
+++ b/src/components/servo/controller.h
@@ -50,5 +50,4 @@ private:
   ServoHardware *_servo_hardware[MAX_SERVOS] = {nullptr};
   int _active_servo_pins; ///< Number of active servo pins
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_SERVO_CONTROLLER_H

--- a/src/components/sleep/controller.h
+++ b/src/components/sleep/controller.h
@@ -72,7 +72,6 @@ private:
   uint8_t _wake_enable_pin;       ///< Pin to check for wake enable
   uint8_t _wake_enable_pin_pull;  ///< Pull mode: 0=none, 1=pulldown, 2=pullup
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 
 #endif // ARDUINO_ARCH_ESP32 || ARDUINO_ARCH_RP2350
 #endif // WS_SLEEP_CONTROLLER_H

--- a/src/components/statusLED/Wippersnapper_StatusLED.cpp
+++ b/src/components/statusLED/Wippersnapper_StatusLED.cpp
@@ -16,7 +16,6 @@
 #include "Wippersnapper_StatusLED.h"
 #include "wippersnapper.h"
 
-extern wippersnapper Ws;
 #ifdef USE_STATUS_NEOPIXEL
 Adafruit_NeoPixel *statusPixel = new Adafruit_NeoPixel(
     STATUS_NEOPIXEL_NUM, STATUS_NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);

--- a/src/components/uart/controller.h
+++ b/src/components/uart/controller.h
@@ -50,4 +50,4 @@ private:
   std::vector<drvUartBase *>
       _uart_drivers; ///< Vector of UART device drivers (eg: PM2.5, etc.)
 };
-#endif                   // WS_UART_CONTROLLER_H
+#endif // WS_UART_CONTROLLER_H

--- a/src/components/uart/controller.h
+++ b/src/components/uart/controller.h
@@ -50,5 +50,4 @@ private:
   std::vector<drvUartBase *>
       _uart_drivers; ///< Vector of UART device drivers (eg: PM2.5, etc.)
 };
-extern wippersnapper Ws; ///< Wippersnapper V2 instance
 #endif                   // WS_UART_CONTROLLER_H

--- a/src/platforms/airlift_wifi.h
+++ b/src/platforms/airlift_wifi.h
@@ -36,7 +36,8 @@
 
 #define SPIWIFI SPI /*!< Instance of SPI interface used by an AirLift. */
 
-extern wippersnapper Ws; ///< Wippersnapper client instance
+class airlift_wifi;
+extern airlift_wifi Ws; ///< Global Wippersnapper instance
 /*!
     @brief  Class for using the AirLift Co-Processor network iface.
 */

--- a/src/platforms/esp32_wifi.h
+++ b/src/platforms/esp32_wifi.h
@@ -27,7 +27,8 @@
 #include "WiFiMulti.h"
 #include <NetworkClient.h>
 #include <NetworkClientSecure.h>
-extern wippersnapper Ws; ///< Wippersnapper client instance
+class esp32_wifi;
+extern esp32_wifi Ws; ///< Wippersnapper client instance
 
 /*!
     @brief  Class for using the ESP32 network interface.

--- a/src/platforms/esp8266_wifi.h
+++ b/src/platforms/esp8266_wifi.h
@@ -36,8 +36,8 @@
  */
 // static const char *fingerprint PROGMEM =  "4E C1 52 73 24 A8 36 D6 7A 4C 67
 // C7 91 0C 0A 22 B9 2D 5B CA";
-
-extern wippersnapper Ws;
+class esp8266_wifi;
+extern esp8266_wifi Ws;
 
 /*!
     @brief  Class for interacting with the Espressif ESP8266's network

--- a/src/platforms/ninafw_wifi.h
+++ b/src/platforms/ninafw_wifi.h
@@ -27,11 +27,12 @@
 #define SPIWIFI                                                                \
   SPI /*!< Instance of SPI interface used by an external uBlox module. */
 
-extern Wippersnapper WS; ///< Global Wippersnapper instance
+class ninafw_wifi;
+extern ninafw_wifi WS; ///< Global Wippersnapper instance
 /*!
     @brief  Class for using the AirLift Co-Processor network iface.
 */
-class ninafw_wifi : public Wippersnapper {
+class ninafw_wifi : public wippersnapper {
 
 public:
   /*!

--- a/src/platforms/pico_offline.h
+++ b/src/platforms/pico_offline.h
@@ -27,7 +27,8 @@
 #include "Arduino.h"
 #include "wippersnapper.h"
 
-extern wippersnapper Ws;
+class pico_offline;
+extern pico_offline WS;
 
 /*!
     @brief  Class for using the Raspberry Pi Pico network interface.

--- a/src/platforms/pico_wifi.h
+++ b/src/platforms/pico_wifi.h
@@ -30,7 +30,8 @@
 #include "Arduino.h"
 #include <WiFiClient.h>
 #include <WiFiClientSecure.h>
-extern wippersnapper Ws;
+class pico_wifi;
+extern pico_wifi Ws;
 
 /*!
     @brief  Class for using the Raspberry Pi Pico network interface.

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.h
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.h
@@ -33,5 +33,4 @@ public:
               ws_led_status_t status_state = WS_LED_STATUS_ERROR_RUNTIME);
   void GetSDCSPin();
 };
-extern wippersnapper Ws;
 #endif // WIPPERSNAPPER_LITTLEFS_H

--- a/src/provisioning/sdcard/ws_sdcard.h
+++ b/src/provisioning/sdcard/ws_sdcard.h
@@ -138,5 +138,4 @@ private:
   bool _use_test_data;        ///< True if sample data is being used for testing
   bool _is_battery_low;       ///< True if battery < LOW_SD_WRITE_BATT_THRESH
 };
-extern wippersnapper Ws;
 #endif // WS_SDCARD_H

--- a/src/provisioning/tinyusb/Wippersnapper_FS.h
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.h
@@ -66,5 +66,4 @@ public:
 private:
   bool _is_secrets_file_empty = false;
 };
-extern wippersnapper Ws;
 #endif // Wippersnapper_FS_V2_V2_H

--- a/src/wippersnapper.cpp
+++ b/src/wippersnapper.cpp
@@ -34,11 +34,11 @@
 #include "wippersnapper.h"
 
 // Define the global WS instance as the platform-specific derived class
-// This ensures virtual methods like _connect() route to the correct implementation
-#if (defined(IS_OFFLINE_MODE) && (IS_OFFLINE_MODE == 1)) || \
-    defined(ARDUINO_RASPBERRY_PI_PICO_2) ||                 \
-    defined(ARDUINO_RASPBERRY_PI_PICO) ||                   \
-    defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_ADALOGGER) ||   \
+// Ensures virtual methods like _connect() route to the correct implementation
+#if (defined(IS_OFFLINE_MODE) && (IS_OFFLINE_MODE == 1)) ||                    \
+    defined(ARDUINO_RASPBERRY_PI_PICO_2) ||                                    \
+    defined(ARDUINO_RASPBERRY_PI_PICO) ||                                      \
+    defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_ADALOGGER) ||                      \
     defined(ARDUINO_ADAFRUIT_METRO_RP2350)
 ws_adapter_offline Ws;
 #else

--- a/src/wippersnapper.cpp
+++ b/src/wippersnapper.cpp
@@ -33,7 +33,17 @@
 
 #include "wippersnapper.h"
 
-wippersnapper Ws;
+// Define the global WS instance as the platform-specific derived class
+// This ensures virtual methods like _connect() route to the correct implementation
+#if (defined(IS_OFFLINE_MODE) && (IS_OFFLINE_MODE == 1)) || \
+    defined(ARDUINO_RASPBERRY_PI_PICO_2) ||                 \
+    defined(ARDUINO_RASPBERRY_PI_PICO) ||                   \
+    defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_ADALOGGER) ||   \
+    defined(ARDUINO_ADAFRUIT_METRO_RP2350)
+ws_adapter_offline Ws;
+#else
+ws_adapter_wifi Ws;
+#endif
 
 /*!
     @brief    wippersnapper constructor

--- a/src/wippersnapper.h
+++ b/src/wippersnapper.h
@@ -345,6 +345,7 @@ protected:
   char *_device_uidV2;     /*!< Unique device identifier  */
   char *_mqtt_client_id;   /*!< MQTT client ID with "io-wipper" prefix */
 };
-extern wippersnapper Ws; ///< Global member variable for callbacks
+
+#include "ws_platforms.h" // Include the platform-specific Wippersnapper_WiFi typedef
 
 #endif // WIPPERSNAPPER_H

--- a/src/ws_platforms.h
+++ b/src/ws_platforms.h
@@ -49,6 +49,7 @@ typedef ninafw_wifi ws_adapter_wifi;
     defined(ARDUINO_ADAFRUIT_METRO_RP2350)
 #include "platforms/pico_offline.h"
 typedef pico_offline ws_adapter_offline;
+#define IS_OFFLINE_MODE 1
 #else
 #warning "Platform not defined within ws_platforms.h!"
 #endif


### PR DESCRIPTION
Fixes the linking issue for v2 where the Ws global is pointing at the base class, causing failure to access the wifi adapter specific superclass methods.

Matches v1 #829 and fixes the RSSI returning 0 and logging network adapter not defined (https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/pull/946)