### PR TITLE
ci(v2): add workflow_dispatch trigger for nightly asset builds

### DIFF
--- a/.github/workflows/build-migrate-api-v2.yml
+++ b/.github/workflows/build-migrate-api-v2.yml
@@ -12,6 +12,11 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches:
       - migrate-api-v2
+  # Manual runs, and the target for the nightly cron dispatcher
+  # (nightly-migrate-api-v2.yml, which must live on the default branch --
+  # GitHub only fires `schedule` crons from there, so it dispatches this
+  # workflow on the migrate-api-v2 ref instead).
+  workflow_dispatch:
 
 jobs:
   # Mirrors `build-esp32sx-esptool` in the v1 workflow (build-clang-doxy.yml on


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to `build-migrate-api-v2.yml` alongside the existing push/PR triggers.

This is half of the nightly-asset-build setup: GitHub only fires `schedule` crons from the default branch, so a companion cron dispatcher workflow on `main` — adafruit/Adafruit_Wippersnapper_Arduino#980 — triggers this workflow on the `migrate-api-v2` ref at 06:00 UTC nightly. The dispatch API requires the target workflow to declare `workflow_dispatch` on the target ref — which this PR adds. It also enables manual full asset builds from the Actions tab.

This PR should merge before adafruit/Adafruit_Wippersnapper_Arduino#980's first cron firing, otherwise the dispatch call fails (noisy but harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)