### PR TITLE
ci: add nightly cron dispatcher for migrate-api-v2 asset builds

### DIFF
--- a/.github/workflows/nightly-migrate-api-v2.yml
+++ b/.github/workflows/nightly-migrate-api-v2.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Brent Rubell for Adafruit Industries, 2026
+#
+# SPDX-License-Identifier: MIT
+#
+# Nightly asset build for the migrate-api-v2 (API v2) branch.
+#
+# GitHub only fires `schedule` crons from the workflow copy on the default
+# branch, and a scheduled run checks out the default branch's code. This
+# file therefore has to live on the default branch, and instead of building
+# directly it dispatches build-migrate-api-v2.yml on the migrate-api-v2 ref
+# so the v2 code is what gets built.
+name: Nightly build (migrate-api-v2 branch)
+
+on:
+  schedule:
+    # 06:00 UTC nightly (06:00 UK in winter, 07:00 during BST)
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  dispatch:
+    name: Dispatch v2 asset build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger build-migrate-api-v2.yml on migrate-api-v2
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/actions/workflows/build-migrate-api-v2.yml/dispatches" \
+            -f ref=migrate-api-v2


### PR DESCRIPTION
Adds `nightly-migrate-api-v2.yml`: a cron (06:00 UTC nightly, plus manual `workflow_dispatch`) that dispatches `build-migrate-api-v2.yml` on the `migrate-api-v2` ref so v2 firmware assets get built every night.

Why a dispatcher on `main` instead of a `schedule` trigger in the v2 workflow itself: GitHub only fires `schedule` crons from the workflow copy on the default branch, and a scheduled run checks out the default branch's code — so a cron in `build-migrate-api-v2.yml` (which lives only on `migrate-api-v2`) would never fire, and from `main` it would build the wrong code. The dispatcher runs the v2 workflow on the v2 ref via the workflow-dispatch API using the built-in `GITHUB_TOKEN` (`permissions: actions: write`, everything else dropped to none).

Companion PR adding the required `workflow_dispatch` trigger to the v2 build workflow: adafruit/Adafruit_Wippersnapper_Arduino#979 — that one should merge before the first cron firing, otherwise the dispatch call fails (noisy but harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)