### PR TITLE
ci: restore 6am UTC nightly cron after schedule test

### DIFF
--- a/.github/workflows/nightly-migrate-api-v2.yml
+++ b/.github/workflows/nightly-migrate-api-v2.yml
@@ -14,7 +14,7 @@ name: Nightly build (migrate-api-v2 branch)
 on:
   schedule:
     # 06:00 UTC nightly (06:00 UK in winter, 07:00 during BST)
-    - cron: "0 16 * * *"
+    - cron: "0 6 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Reverts the temporary `0 16 * * *` test schedule back to the intended `0 6 * * *` (06:00 UTC nightly). The test tick fired successfully at 16:06:31 UTC today (run 33776637318, `schedule` event dispatching the v2 asset build on `migrate-api-v2`), confirming the cron dispatcher from adafruit/Adafruit_Wippersnapper_Arduino#980 works end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)